### PR TITLE
Fix typo.

### DIFF
--- a/KQuery.html
+++ b/KQuery.html
@@ -340,7 +340,7 @@
   <div class="example">
     array small_array[2] : w32 -> w8 = symbolic <font color="Red"># The array we will read from</font><br>
     <br>
-    (Read w8 0 thing) <font color="Red"># No Updates to small_array</font><br>
+    (Read w8 0 small_array) <font color="Red"># No Updates to small_array</font><br>
     (Read w8 1 [1=0xff] @ small_array) <font color="Red"># Read from small_array at byte offset 1 with update where byte 1 set to decimal 255</font><br>
   </div>
   <p>A version can be specified either by an identifier, which can refer to an


### PR DESCRIPTION
This fixes a typo in the KQuery documentation.
