### PR TITLE
Remove unnecessary loop from SolverTest unit test.

### DIFF
--- a/unittests/Solver/SolverTest.cpp
+++ b/unittests/Solver/SolverTest.cpp
@@ -61,9 +61,7 @@ void testOperation(Solver &solver,
   // replaced value is appropriated constrained.
   for (unsigned kid = 0; kid < T::numKids; kid++) {
     std::vector<Expr::CreateArg> partiallyConstantArgs(symbolicArgs);
-    for (unsigned i = 0; i < T::numKids; i++)
-      if (i==kid)
-        partiallyConstantArgs[i] = getConstant(value, operandWidth);
+    partiallyConstantArgs[kid] = getConstant(value, operandWidth);
 
     ref<Expr> expr = 
       NotOptimizedExpr::create(EqExpr::create(partiallyConstantArgs[kid].expr,


### PR DESCRIPTION
I can't see a good reason for this loop to be here. The unit test still passes with this commit applied.
