### PR TITLE
Fix queries not being logged correctly if an assertion failure is hit.

### DIFF
--- a/lib/Solver/QueryLoggingSolver.cpp
+++ b/lib/Solver/QueryLoggingSolver.cpp
@@ -74,6 +74,7 @@ void QueryLoggingSolver::flushBuffer() {
               // we do additional check here to log only timeouts in case
               // user specified negative value for minQueryTimeToLog param
               os << logBuffer.str();              
+              os.flush();
           }                    
       }
       


### PR DESCRIPTION
In QueryLoggingSolver call flush() on std::ofstream so that queries get correctly logged if an assertion failure is hit later on.
