### PR TITLE
Fix implementation for putchar

### DIFF
--- a/runtime/klee-libc/putchar.c
+++ b/runtime/klee-libc/putchar.c
@@ -15,6 +15,7 @@
 
 int putchar(int c) {
   char x = c;
-  write(1, &x, 1);
-  return 1;
+  if (1 == write(1, &x, 1))
+    return c;
+  return EOF;
 }


### PR DESCRIPTION
According to manual: putchar() return the character written as an
unsigned char cast to an int or EOF on error.

Use return value of write to return the correct value for putchar.
