### PR TITLE
Bugfix: Remove llvm.trap declaration after cleaning all uses.

### DIFF
--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -61,6 +61,8 @@ bool IntrinsicCleanerPass::runOnModule(Module &M) {
   for (Module::iterator f = M.begin(), fe = M.end(); f != fe; ++f)
     for (Function::iterator b = f->begin(), be = f->end(); b != be; ++b)
       dirty |= runOnBasicBlock(*b, M);
+    if (Function *Declare = M.getFunction("llvm.trap"))
+      Declare->eraseFromParent();
   return dirty;
 }
 
@@ -209,9 +211,6 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         new UnreachableInst(getGlobalContext(), ii);
 
         ii->eraseFromParent();
-
-        if (Function *Declare = M.getFunction("llvm.trap"))
-          Declare->eraseFromParent();
 
         dirty = true;
         break;


### PR DESCRIPTION
Sorry about this bug I introduced. :( The def should be removed after all use are removed.
