### PR TITLE
Fixed nondeterministic behaviour in test case ./test/Solver/LargeInteger...

### DIFF
--- a/test/Solver/LargeIntegers.pc
+++ b/test/Solver/LargeIntegers.pc
@@ -11,7 +11,7 @@ array a[64] : w32 -> w8 = symbolic
 (query [] false [(Extract w5 60 (Concat w128 (w64 1) (w64 2)))])
 
 # RUN: grep -A 1 \"Query 2\" %t > %t2
-# RUN: grep \"Array 0:\ta.16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0\" %t2
+# RUN: grep \"Array 0:\ta.16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1\" %t2
 (query [(Eq 0x0102030405060708090A0B0C0D0E0F10 (ReadLSB w128 0 a))] 
        false 
        [] [a])


### PR DESCRIPTION
...s.pc -- only 16 bytes of array a were initialised in Query 2, but values of 17 bytes were later required for comparison.
