### PR TITLE
Fix build of POSIX file descriptor functions

### DIFF
--- a/runtime/POSIX/fd_32.c
+++ b/runtime/POSIX/fd_32.c
@@ -18,7 +18,6 @@
 #endif
 
 #include "klee/Config/Version.h"
-#if defined(ENV32) || (LLVM_VERSION_CODE < LLVM_VERSION(3, 2))
 #define _LARGEFILE64_SOURCE
 #include "fd.h"
 
@@ -205,21 +204,3 @@ __attribute__((weak)) int open64(const char *pathname, int flags, ...) {
 
   return __fd_open(pathname, flags, mode);
 }
-
-__attribute__((weak)) off64_t lseek64(int fd, off64_t off, int whence) {
-  return __fd_lseek(fd, off, whence);
-}
-
-__attribute__((weak)) int stat64(const char *path, struct stat64 *buf) {
-  return __fd_stat(path, buf);
-}
-
-__attribute__((weak)) int lstat64(const char *path, struct stat64 *buf) {
-  return __fd_lstat(path, buf);
-}
-
-__attribute__((weak)) int fstat64(int fd, struct stat64 *buf) {
-  return __fd_fstat(fd, buf);
-}
-
-#endif

--- a/runtime/POSIX/fd_64.c
+++ b/runtime/POSIX/fd_64.c
@@ -17,7 +17,6 @@
 
 
 #include "klee/Config/Version.h"
-#if defined(ENV64) || (LLVM_VERSION_CODE < LLVM_VERSION(3, 2))
 #define _LARGEFILE64_SOURCE
 #define _FILE_OFFSET_BITS 64
 #include "fd.h"
@@ -113,5 +112,3 @@ int getdents64(unsigned int fd, struct dirent *dirp, unsigned int count) {
 }
 int __getdents64(unsigned int fd, struct dirent *dirp, unsigned int count)
      __attribute__((alias("getdents64")));
-
-#endif


### PR DESCRIPTION
Build Large File System functions for 32bit and 64bit correctly.

Fix the previous build fix.
Solves a couple of failing tests.
