### PR TITLE
Exit if using --libc=uclibc and KLEE was not configured with uclibc

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -30,6 +30,7 @@
 #include "llvm/Instructions.h"
 #if LLVM_VERSION_CODE >= LLVM_VERSION(2, 7)
 #include "llvm/LLVMContext.h"
+#include "llvm/Support/FileSystem.h"
 #endif
 #endif
 #if LLVM_VERSION_CODE < LLVM_VERSION(2, 7)
@@ -1013,6 +1014,12 @@ static void replaceOrRenameFunction(llvm::Module *module,
 }
 
 static llvm::Module *linkWithUclibc(llvm::Module *mainModule) {
+  // Ensure that KLEE_UCLIBC exists
+  bool uclibcRootExists=false;
+  llvm::sys::fs::is_directory(KLEE_UCLIBC, uclibcRootExists);
+  if (!uclibcRootExists)
+    klee_error("Cannot link with uclibc. KLEE_UCLIBC (\"" KLEE_UCLIBC "\") is not a directory.");
+
   Function *f;
   // force import of __uClibc_main
   mainModule->getOrInsertFunction("__uClibc_main",


### PR DESCRIPTION
or if the configured path does not exist.

Previously if KLEE was configured and compiled without uclibc linking
would still succeed because KLEE_UCLIBC was blank so LLVM was
effectively asked to link with "<blank>/lib/libc.a" i.e. the system's native
C library!
