### PR TITLE
Added support for printing Expr to llvm::raw_ostream

### DIFF
--- a/include/klee/Expr.h
+++ b/include/klee/Expr.h
@@ -17,10 +17,12 @@
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <set>
 #include <vector>
 #include <iosfwd> // FIXME: Remove this!!!
+#include <sstream> // For llvm::raw_ostream hack
 
 namespace llvm {
   class Type;
@@ -297,6 +299,24 @@ inline std::ostream &operator<<(std::ostream &os, const Expr &e) {
 inline std::ostream &operator<<(std::ostream &os, const Expr::Kind kind) {
   Expr::printKind(os, kind);
   return os;
+}
+
+inline llvm::raw_ostream& operator<<(llvm::raw_ostream& ros, const Expr &e){
+    // This is a hack. I do not want to template Expr to support
+    // llvm::raw_ostream so this will have to do!
+    std::ostringstream ss;
+    ss << e;
+    ros << ss.str();
+    return ros;
+}
+
+inline llvm::raw_ostream& operator<<(llvm::raw_ostream& ros, const Expr::Kind kind){
+    // This is a hack. I do not want to template Expr to support
+    // llvm::raw_ostream so this will have to do!
+    std::ostringstream ss;
+    ss << kind;
+    ros << ss.str();
+    return ros;
 }
 
 // Terminal Exprs

--- a/include/klee/util/Ref.h
+++ b/include/klee/util/Ref.h
@@ -11,6 +11,7 @@
 #define KLEE_REF_H
 
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
 using llvm::isa;
 using llvm::cast;
 using llvm::cast_or_null;
@@ -108,6 +109,12 @@ public:
 
 template<class T>
 inline std::ostream &operator<<(std::ostream &os, const ref<T> &e) {
+  os << *e;
+  return os;
+}
+
+template<class T>
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const ref<T> &e) {
   os << *e;
   return os;
 }


### PR DESCRIPTION
The implementation is a little hacky but is far simpler than changing
all the code to use llvm::raw_ostream instead of std::ostream.

Now we can do things like:

```
    #include <llvm/Support/Debug.h>
    ...
    ref<Expr> e = /* Some expression */
    DEBUG_WITH_TYPE("klee_something", dbgs() << "Expression:" << e << "\n");
```

We should probably come up with a convention for writing debug information out in KLEE e.g.

For solver stuff use

```
 DEBUG_WITH_TYPE("klee_solver", dbgs() << "Expression:" << e << "\n");
// only shows output when use -debug=klee_solver command line argument and with Debug build.
```

For executor stuff use

```
 DEBUG_WITH_TYPE("klee_executor", dbgs() << "Expression:" << e << "\n");
// only shows output when use -debug=klee_executor command line argument and with Debug build.
```

The DEBUG macros is documented in the [LLVM programmer's manual](http://llvm.org/docs/ProgrammersManual.html#the-debug-macro-and-debug-option)
