### PR TITLE
Fix use include files from used LLVM to build KLEE

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -31,7 +31,7 @@ endif
 C.Flags += -std=gnu89
 
 LD.Flags += -L$(STP_ROOT)/lib
-CXX.Flags += -I$(STP_ROOT)/include
+CXX.Flags += -I$(STP_ROOT)/include -I$(shell $(LLVM_CONFIG) --includedir)
 CXX.Flags += -DKLEE_DIR=\"$(PROJ_OBJ_ROOT)\" -DKLEE_LIB_DIR=\"$(PROJ_libdir)\"
 
 # For STP.


### PR DESCRIPTION
Tested with LLVM 2.9 and 3.3.
