### PR TITLE
Fix compilation of unittests under Clang.

### DIFF
--- a/unittests/Makefile
+++ b/unittests/Makefile
@@ -14,5 +14,9 @@ DIRS = Expr Solver Ref
 
 include $(LEVEL)/Makefile.common
 
+# Remove -fno-rtti as this prevents typeid() being used
+# in gtest
+CXX.Flags := $(filter-out -fno-rtti,$(CPP.Flags))
+
 clean::
 	$(Verb) $(RM) -f *Tests


### PR DESCRIPTION
It seems the GTest header file in LLVM 3.3 (and possibly other versions)
makes use of typeid() but the build system passes -fno-rtti. These
are incompatible and if building with Clang then compilation will
fail. GCC doesn't seem to care!

The error you would see is something similiar too...

```
In file included from /home/dan/documents/projects/project/klee/src/unittests/TestMain.cpp:10:
In file included from /home/dan/documents/projects/llvm-upstream/src/utils/unittest/googletest/include/gtest/gtest.h:57:
In file included from /home/dan/documents/projects/llvm-upstream/src/utils/unittest/googletest/include/gtest/internal/gtest-internal.h:40:
/home/dan/documents/projects/llvm-upstream/src/utils/unittest/googletest/include/gtest/internal/gtest-port.h:1036:16: error: 
      cannot use typeid with -fno-rtti
  GTEST_CHECK_(typeid(*base) == typeid(Derived));
               ^
/home/dan/documents/projects/llvm-upstream/src/utils/unittest/googletest/include/gtest/internal/gtest-port.h:951:37: note: 
      expanded from macro 'GTEST_CHECK_'
    if (::testing::internal::IsTrue(condition)) \
                                    ^
/home/dan/documents/projects/llvm-upstream/src/utils/unittest/googletest/include/gtest/internal/gtest-port.h:1036:33: error: 
      cannot use typeid with -fno-rtti
  GTEST_CHECK_(typeid(*base) == typeid(Derived));
                                ^
/home/dan/documents/projects/llvm-upstream/src/utils/unittest/googletest/include/gtest/internal/gtest-port.h:951:37: note: 
      expanded from macro 'GTEST_CHECK_'
    if (::testing::internal::IsTrue(condition)) \
                                    ^
In file included from /home/dan/documents/projects/project/klee/src/unittests/TestMain.cpp:10:
In file included from /home/dan/documents/projects/llvm-upstream/src/utils/unittest/googletest/include/gtest/gtest.h:57:
In file included from /home/dan/documents/projects/llvm-upstream/src/utils/unittest/googletest/include/gtest/internal/gtest-internal.h:57:
/home/dan/documents/projects/llvm-upstream/src/utils/unittest/googletest/include/gtest/internal/gtest-type-util.h:68:28: error: 
      cannot use typeid with -fno-rtti
  const char* const name = typeid(T).name();
                           ^
3 errors generated.

```
