### PR TITLE
get_sign.c missing include

### DIFF
--- a/examples/get_sign/get_sign.c
+++ b/examples/get_sign/get_sign.c
@@ -2,6 +2,7 @@
  * First KLEE tutorial: testing a small function
  */
 
+#include <klee/klee.h>
 
 int get_sign(int x) {
   if (x == 0)


### PR DESCRIPTION
The file `examples/get_sign/get_sign.c` is missing the

```
#include <klee/klee.h>
```

worst, it compiles, with the klee_make_symbolic implicitly declared:

```
get_sign.c:18:3: warning: implicit declaration of function 'klee_make_symbolic' is invalid in C99 [-Wimplicit-function-declaration]
  klee_make_symbolic(&a, sizeof(a), "a");
  ^
```
