### PR TITLE
Fix the get_sign tutorial

### DIFF
--- a/Tutorial-1.html
+++ b/Tutorial-1.html
@@ -67,7 +67,8 @@
   we run:
 
   <div class="instr">
-  llvm-gcc --emit-llvm -c -g get_sign.c
+  cd examples/get_sign.c
+  llvm-gcc -I ../../include --emit-llvm -c -g get_sign.c
   </div>
 
   to generate the LLVM bitcode file <tt>get_sign.o</tt>.


### PR DESCRIPTION
The tutorial was missing the `cd dir` and the `-I ../../include` path to llvm-gcc
