### PR TITLE
Allow passing arbitrary command line flags to klee and kleaver when running llvm-lit

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -53,10 +53,23 @@ for name in subs:
         lit.fatal('{0} is not set'.format(name))
     config.substitutions.append( ('%' + name, value))
 
-# Set absolute paths for KLEE's tools
-subs = [ ('%kleaver', 'kleaver'), ('%klee','klee') ]
-for s,basename in subs:
-    config.substitutions.append( (s, os.path.join(klee_tools_dir, basename) ) )
+# Get KLEE and Kleaver specific parameters passed on llvm-lit cmd line
+# e.g. llvm-lit --param klee_opts=--help
+klee_extra_params = lit.params.get('klee_opts',"")
+kleaver_extra_params = lit.params.get('kleaver_opts',"")
+
+if len(klee_extra_params) != 0:
+    print("Passing extra KLEE command line args: {0}".format(klee_extra_params))
+if len(kleaver_extra_params) != 0:
+    print("Passing extra Kleaver command line args: {0}".format(kleaver_extra_params))
+
+# Set absolute paths and extra cmdline args for KLEE's tools
+subs = [ ('%kleaver', 'kleaver', kleaver_extra_params), ('%klee','klee', klee_extra_params) ]
+for s,basename,extra_args in subs:
+    config.substitutions.append( ( s,
+                                   "{0} {1}".format( os.path.join(klee_tools_dir, basename), extra_args )
+                                 )
+                               )
 
 
 # LLVM < 3.0 doesn't Support %T directive


### PR DESCRIPTION
This is done by doing something like

```
$ cd test/
$ llvm-lit --param klee_opts=--xxx --param kleaver_opts=--yyy .
```

This would pass `--xxx` as an extra option to `klee` when running
tests and would pass `--yyy` as an extra option to `kleaver` when
running tests.

This feature has been added to make it easy to pass extra flags to
KLEE or Kleaver without needing to modify tests or recompile KLEE with
different defaults (yuck!).
