### PR TITLE
Fix Runtime/POSIX/Isatty.c test under LLVM3.3.

### DIFF
--- a/test/Runtime/POSIX/Isatty.c
+++ b/test/Runtime/POSIX/Isatty.c
@@ -1,5 +1,5 @@
 // RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t.bc
-// RUN: %klee --libc=uclibc --posix-runtime %t.bc --sym-files 0 10 --sym-stdout 2>%t.log
+// RUN: %klee --libc=uclibc --posix-runtime %t.bc --sym-files 0 10 --sym-stdout > %t.log 2>&1
 // RUN: test -f %T/klee-last/test000001.ktest
 // RUN: test -f %T/klee-last/test000002.ktest
 // RUN: test -f %T/klee-last/test000003.ktest
@@ -10,7 +10,7 @@
 // RUN: grep -q "stdout is NOT a tty" %t.log
 
 // Depending on how uClibc is compiled (i.e. without -DKLEE_SYM_PRINTF)
-// fprintf prints out on stdout even stderr is provided.
+// fprintf prints out on stdout even if stderr is provided.
 #include <unistd.h>
 #include <stdio.h>
 #include <assert.h>


### PR DESCRIPTION
The program makes a call fprintf(stderr,...). llvm-gcc transforms this to a call to
fwrite() however clang does not so klee-uclibc's fprintf will be
called instead and if klee-uclibc is compiled with KLEE_SYM_PRINTF
then output will always go stdout if the FILE is stdout or stderr.

The end result of this is that when we build with Clang under LLVM3.3
is that the fprintf(stderr,...) print outs go to standard output instead
and so the test would fail because it expects the fprintf(stderr,...)
to be on stderr.

This test sort of fixes this by having the test check stdout for
the fprintf(stderr,...) statements too.
