### PR TITLE
Add the ability to control whether the pretty printer uses line breaks

### DIFF
--- a/include/klee/util/ExprPPrinter.h
+++ b/include/klee/util/ExprPPrinter.h
@@ -25,6 +25,7 @@ namespace klee {
     virtual ~ExprPPrinter() {}
 
     virtual void setNewline(const std::string &newline) = 0;
+    virtual void setForceNoLineBreaks(bool forceNoLineBreaks) = 0;
     virtual void reset() = 0;
     virtual void scan(const ref<Expr> &e) = 0;
     virtual void print(const ref<Expr> &e, unsigned indent=0) = 0;

--- a/lib/Expr/ExprPPrinter.cpp
+++ b/lib/Expr/ExprPPrinter.cpp
@@ -51,6 +51,7 @@ private:
   unsigned counter;
   unsigned updateCounter;
   bool hasScan;
+  bool forceNoLineBreaks;
   std::string newline;
 
   /// shouldPrintWidth - Predicate for whether this expression should
@@ -307,10 +308,15 @@ public:
     newline = _newline;
   }
 
+  void setForceNoLineBreaks(bool _forceNoLineBreaks) {
+    forceNoLineBreaks = _forceNoLineBreaks;
+  }
+
   void reset() {
     counter = 0;
     updateCounter = 0;
     hasScan = false;
+    forceNoLineBreaks = false;
     bindings.clear();
     updateBindings.clear();
     couldPrint.clear();
@@ -412,7 +418,7 @@ public:
   /* Public utility functions */
 
   void printSeparator(PrintContext &PC, bool simple, unsigned indent) {
-    if (simple) {
+    if (simple || forceNoLineBreaks) {
       PC << ' ';
     } else {
       PC.breakLine(indent);


### PR DESCRIPTION
This change makes it possible to more reliably write unit tests which check
that an expression is equivalent to an expected pretty printed string.
