### PR TITLE
stop after not covering new code in specified time

### DIFF
--- a/include/klee/Internal/Module/KInstruction.h
+++ b/include/klee/Internal/Module/KInstruction.h
@@ -23,12 +23,25 @@ namespace klee {
   struct InstructionInfo;
   class KModule;
 
+  /* Stores running status for a KInstruction */
+  struct InstructionStatus {
+    bool covered;
+
+  public:
+    InstructionStatus()
+      : covered(false) {}
+
+    bool isCovered() const { return covered; }
+    void setCovered() { covered = true; }
+  };
+
 
   /// KInstruction - Intermediate instruction representation used
   /// during execution.
   struct KInstruction {
     llvm::Instruction *inst;    
     const InstructionInfo *info;
+    InstructionStatus status;
 
     /// Value numbers for each operand. -1 is an invalid value,
     /// otherwise negative numbers are indices (negated and offset by

--- a/lib/Core/ExecutorTimers.cpp
+++ b/lib/Core/ExecutorTimers.cpp
@@ -43,6 +43,11 @@ MaxTime("max-time",
         cl::desc("Halt execution after the specified number of seconds (0=off)"),
         cl::init(0));
 
+cl::opt<double>
+StopAfterNoGainInTime("stop-after-no-gain-in-time",
+                      cl::desc("Halt execution after not covering new codes in the specified number of seconds (0=off)"),
+                      cl::init(0));
+
 ///
 
 class HaltTimer : public Executor::Timer {
@@ -62,6 +67,7 @@ public:
 
 static const double kSecondsPerTick = .1;
 static volatile unsigned timerTicks = 0;
+static volatile unsigned timerTicksSinceCoverNew = 0;
 
 // XXX hack
 extern "C" unsigned dumpStates, dumpPTree;
@@ -69,6 +75,7 @@ unsigned dumpStates = 0, dumpPTree = 0;
 
 static void onAlarm(int) {
   ++timerTicks;
+  ++timerTicksSinceCoverNew;
 }
 
 // oooogalay
@@ -116,6 +123,15 @@ void Executor::processTimers(ExecutionState *current,
   if (!ticks && ++callsWithoutCheck > 1000) {
     setupHandler();
     ticks = 1;
+  }
+
+  if (!current->pc->status.isCovered()) {
+    current->pc->status.setCovered();
+    timerTicksSinceCoverNew = 0;
+  } else {
+    if (StopAfterNoGainInTime &&
+        timerTicksSinceCoverNew * kSecondsPerTick >= StopAfterNoGainInTime)
+      haltExecution = true;
   }
 
   if (ticks || dumpPTree || dumpStates) {


### PR DESCRIPTION
This patch adds a new stop control criterion: stop after not covering new instructions in a certain amount of time.

I added a new `struct` to track the covered/uncovered information for each instruction. Not sure whether this is efficient or not. Please suggest if there are better ways to do this.