### PR TITLE
Fixing linking order if metaSMT is used: linking rt after z3 to avoid un...

### DIFF
--- a/tools/kleaver/Makefile
+++ b/tools/kleaver/Makefile
@@ -29,7 +29,7 @@ ifeq ($(ENABLE_METASMT),1)
               -L$(METASMT_ROOT)/../../deps/boost-1_52_0/lib 
   CXX.Flags += -DBOOST_HAS_GCC_TR1
   CXX.Flags := $(filter-out -fno-exceptions,$(CXX.Flags)) 
-  LIBS += -lrt -lgomp -lboost_iostreams -lboost_thread -lboost_system -lmetaSMT -lz3 -lboolector -lminisat_core
+  LIBS += -lgomp -lboost_iostreams -lboost_thread -lboost_system -lmetaSMT -lz3 -lrt -lboolector -lminisat_core
 endif
 
 ifeq ($(STP_NEEDS_BOOST),1)

--- a/tools/klee/Makefile
+++ b/tools/klee/Makefile
@@ -30,7 +30,7 @@ ifeq ($(ENABLE_METASMT),1)
               -L$(METASMT_ROOT)/../../deps/boost-1_52_0/lib 
   CXX.Flags += -DBOOST_HAS_GCC_TR1
   CXX.Flags := $(filter-out -fno-exceptions,$(CXX.Flags)) 
-  LIBS += -lrt -lgomp -lboost_iostreams -lboost_thread -lboost_system -lmetaSMT -lz3 -lboolector -lminisat_core
+  LIBS += -lgomp -lboost_iostreams -lboost_thread -lboost_system -lmetaSMT -lz3 -lrt -lboolector -lminisat_core
 endif
 
 ifeq ($(STP_NEEDS_BOOST),1)


### PR DESCRIPTION
...defined symbols in the z3 library.
