### PR TITLE
Taught klee_warning(), klee_error() etc... to emit coloured text output.

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1529,7 +1529,18 @@ int main(int argc, char **argv, char **envp) {
         << handler->getNumPathsExplored() << "\n";
   stats << "KLEE: done: generated tests = " 
         << handler->getNumTestCases() << "\n";
+
+  bool useColors = llvm::errs().is_displayed();
+  if (useColors)
+    llvm::errs().changeColor(llvm::raw_ostream::GREEN,
+                             /*bold=*/true,
+                             /*bg=*/false);
+
   llvm::errs() << stats.str();
+
+  if (useColors)
+    llvm::errs().resetColor();
+
   handler->getInfoStream() << stats.str();
 
   BufferPtr.take();


### PR DESCRIPTION
Also use bold green text when KLEE finishes. This is done by taking
advantage of llvm::raw_ostream's nice API for controlling the console
text colour.

This looks like this...

![image](https://cloud.githubusercontent.com/assets/511795/3484043/46e8016c-039d-11e4-8b4d-6716a81c9a53.png)
