### PR TITLE
Fix runtime search path for STP library

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -33,7 +33,7 @@ C.Flags += -std=gnu89
 # This is filename that KLEE will look for when trying to load klee-uclibc
 KLEE_UCLIBC_BCA_NAME="klee-uclibc.bca"
 
-LD.Flags += -L$(STP_ROOT)/lib
+LD.Flags += -L$(STP_ROOT)/lib -Wl,-rpath,$(STP_ROOT)/lib
 CXX.Flags += -I$(STP_ROOT)/include
 CXX.Flags += -DKLEE_DIR=\"$(PROJ_OBJ_ROOT)\" -DKLEE_INSTALL_BIN_DIR=\"$(PROJ_bindir)\"
 CXX.Flags += -DKLEE_INSTALL_LIB_DIR=\"$(PROJ_libdir)\"


### PR DESCRIPTION
In our case, typically, STP library is not
installed in the systems library path.
Make sure we search for library path during
runtime of the application as well - not only during linktime.

Fixes #130