### PR TITLE
Replaced the current way to get KLEE's total memory usage with a new one...

### DIFF
--- a/include/klee/Internal/System/MemoryUsage.h
+++ b/include/klee/Internal/System/MemoryUsage.h
@@ -14,6 +14,7 @@
 
 namespace klee {
   namespace util {
+  	/** \brief returns KLEE's total malloc usage in mb */
     size_t GetTotalMallocUsage();
   }
 }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2591,7 +2591,7 @@ void Executor::run(ExecutionState &initialState) {
         // We need to avoid calling GetMallocUsage() often because it
         // is O(elts on freelist). This is really bad since we start
         // to pummel the freelist once we hit the memory cap.
-        unsigned mbs = util::GetTotalMallocUsage() >> 20;
+        unsigned mbs = util::GetTotalMallocUsage();
         if (mbs > MaxMemory) {
           if (mbs > MaxMemory + 100) {
             // just guess at how many to kill

--- a/lib/Support/MemoryUsage.cpp
+++ b/lib/Support/MemoryUsage.cpp
@@ -18,17 +18,15 @@
 using namespace klee;
 
 size_t util::GetTotalMallocUsage() {
-    double residentSet = 0.0;
-
-    long rss;
     std::string ignore;
     std::ifstream ifs("/proc/self/stat", std::ios_base::in);
-    ifs >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore 
-        >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore 
-        >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore 
-        >> ignore >> ignore >> rss;
-
-    long pageSizeKb = sysconf(_SC_PAGE_SIZE) / 1024; // in case x86-64 is configured to use 2MB pages
-    residentSet = rss * pageSizeKb / 1024.0;
-    return residentSet;
+    for(int i = 1; i <= 22; i++) // we're not interested in the first 22 fields
+    	ifs >> ignore;
+    
+    unsigned long vsize; // swap + ram usage in mb
+    ifs >> vsize;
+    vsize /= 1048576.0;
+		
+		ifs.close();
+    return vsize;
 }

--- a/lib/Support/MemoryUsage.cpp
+++ b/lib/Support/MemoryUsage.cpp
@@ -9,17 +9,26 @@
 
 #include "klee/Internal/System/MemoryUsage.h"
 #include <malloc.h>
+#include <iostream>
+#include <fstream>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string>
 
 using namespace klee;
 
 size_t util::GetTotalMallocUsage() {
-  struct mallinfo mi = ::mallinfo();
-  // The malloc implementation in glibc (pmalloc2)
-  // does not include mmap()'ed memory in mi.uordblks
-  // but other implementations (e.g. tcmalloc) do.
-#if defined(__GLIBC__)
-  return mi.uordblks + mi.hblkhd;
-#else
-  return mi.uordblks;
-#endif
+    double residentSet = 0.0;
+
+    long rss;
+    std::string ignore;
+    std::ifstream ifs("/proc/self/stat", std::ios_base::in);
+    ifs >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore 
+        >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore 
+        >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore 
+        >> ignore >> ignore >> rss;
+
+    long pageSizeKb = sysconf(_SC_PAGE_SIZE) / 1024; // in case x86-64 is configured to use 2MB pages
+    residentSet = rss * pageSizeKb / 1024.0;
+    return residentSet;
 }


### PR DESCRIPTION
... allowing KLEE's memory cap to be set to values greater than 2000 mb