### PR TITLE
Add Travis build status icon/link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Klee Symbolic Virtual Machine
 =============================
 
+[![Build Status](https://travis-ci.org/klee/klee.svg?branch=master)](https://travis-ci.org/klee/klee)
+
 `klee` is a symbolic virtual machine built on top of the LLVM compiler
 infrastructure. Currently, there are two primary components:
 


### PR DESCRIPTION
This just adds a nice icon that shows the build status. It is also a link so if you're on the GitHub homepage you can click on it and go to the Travis dashboard for KLEE.
