### PR TITLE
Fix testcase FD_Fail2.c

### DIFF
--- a/test/Runtime/POSIX/FD_Fail2.c
+++ b/test/Runtime/POSIX/FD_Fail2.c
@@ -10,7 +10,7 @@
 // RUN: test -f %t.klee-out/test000002.ktest
 // RUN: test -f %t.klee-out/test000003.ktest
 // RUN: test -f %t.klee-out/test000004.ktest
-// FAIL: test -f %t.klee-out/test000005.ktest
+// RUN: not test -f %t.klee-out/test000005.ktest
 
 #include <stdio.h>
 #include <assert.h>


### PR DESCRIPTION
Major issue was that puts was used for the succeed printf calls.
With newer gcc/clang versions, printf is always used.

The former took different code paths leading to much more possibilities
to trigger failed writes and therefore generating more test cases.

This patch avoids the generation of puts.
And checks for the 4 possible generated test cases for 2 possible errors.
