### PR TITLE
Fixes support for passing arguments to klee in the ConcreteTests.

### DIFF
--- a/test/Concrete/BitwiseOps.ll
+++ b/test/Concrete/BitwiseOps.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/BoolReadWrite.ll
+++ b/test/Concrete/BoolReadWrite.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i1(i1)
 

--- a/test/Concrete/Casts.ll
+++ b/test/Concrete/Casts.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/CmpEq.ll
+++ b/test/Concrete/CmpEq.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/ConcreteTest.py
+++ b/test/Concrete/ConcreteTest.py
@@ -30,7 +30,7 @@ def testFile(name, klee_path, lli_path):
     klee_out_path = "Output/%s.klee-out" % (baseName,)
     if os.path.exists(klee_out_path):
         shutil.rmtree(klee_out_path)
-    klee_cmd = [klee_path, '--output-dir=' + klee_out_path,  '--no-output', exeFile]
+    klee_cmd = klee_path.split() + ['--output-dir=' + klee_out_path,  '--no-output', exeFile]
     print("EXECUTING: %s" % (klee_cmd,))
     sys.stdout.flush()
 

--- a/test/Concrete/ConstantExpr.ll
+++ b/test/Concrete/ConstantExpr.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 ; Most of the test below use the *address* of gInt as part of their computation,
 ; and then perform some operation (like x | ~x) which makes the result

--- a/test/Concrete/FloatingPointOps.ll
+++ b/test/Concrete/FloatingPointOps.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 ; casting error messages
 @.strTrunc     = internal constant [15 x i8] c"FPTrunc broken\00"

--- a/test/Concrete/GlobalInitializers.ll
+++ b/test/Concrete/GlobalInitializers.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/GlobalUndef.ll
+++ b/test/Concrete/GlobalUndef.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 target datalayout =
 "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"

--- a/test/Concrete/GlobalVariable.ll
+++ b/test/Concrete/GlobalVariable.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/ICmp.ll
+++ b/test/Concrete/ICmp.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/OneCall.ll
+++ b/test/Concrete/OneCall.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/OverlappingPhiNodes.ll
+++ b/test/Concrete/OverlappingPhiNodes.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/Select.ll
+++ b/test/Concrete/Select.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/Shifts.ll
+++ b/test/Concrete/Shifts.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/SimpleStoreAndLoad.ll
+++ b/test/Concrete/SimpleStoreAndLoad.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/UnconditionalBranch.ll
+++ b/test/Concrete/UnconditionalBranch.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/UnconditionalBranchWithSimplePhi.ll
+++ b/test/Concrete/UnconditionalBranchWithSimplePhi.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/UnorderedPhiNodes.ll
+++ b/test/Concrete/UnorderedPhiNodes.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
 

--- a/test/Concrete/ackermann.c
+++ b/test/Concrete/ackermann.c
@@ -1,4 +1,4 @@
-// RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+// RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 #include <stdio.h>
 

--- a/test/Concrete/arith_test.ll
+++ b/test/Concrete/arith_test.ll
@@ -1,4 +1,4 @@
-; RUN: %S/ConcreteTest.py --klee=%klee --lli=%lli %s
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 define void @"test_simple_arith"(i16 %i0, i16 %j0) {
   %t1 = add i16 %i0, %j0

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -98,7 +98,7 @@ if len(kleaver_extra_params) != 0:
 subs = [ ('%kleaver', 'kleaver', kleaver_extra_params), ('%klee','klee', klee_extra_params) ]
 for s,basename,extra_args in subs:
     config.substitutions.append( ( s,
-                                   "{0} {1}".format( os.path.join(klee_tools_dir, basename), extra_args )
+                                   "{0} {1}".format( os.path.join(klee_tools_dir, basename), extra_args ).strip()
                                  )
                                )
 


### PR DESCRIPTION
This is for use with llvm-lit --param=klee_opts=...

Fixes lit.cfg to not have an extraneous space behind the klee command.
Augments ConcreteTest to accept and pass arguments to klee.
Augments all the ConcreteTest cases to wrap %klee in quotes.

Without wrapping %klee the extra arguments will be seen as arguments
to ConcreteTest.py resulting in an unknown argument error.
