### PR TITLE
Fix va args passing for big types

### DIFF
--- a/test/Feature/VarArgLongDouble.c
+++ b/test/Feature/VarArgLongDouble.c
@@ -1,7 +1,6 @@
 // RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t.bc
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out %t.bc | FileCheck %s
-// XFAIL:
 
 #include <stdarg.h>
 #include <assert.h>


### PR DESCRIPTION
Fixed Executor to (more) correctly handle the alignment of types larger than 64bit (such as long double) when those are passed in var_args on x86_64.
Added test/Feature/VarArgLongDouble.c to test for the problem.

Specifically:
From http://www.x86-64.org/documentation/abi.pdf
AMD64-ABI 3.5.7p5: Step 7.
Align l->overflow_arg_area upwards to a 16 byte boundary if alignment needed by type exceeds 8 byte boundary.
