### PR TITLE
tools: prepend DESTDIR when installing

### DIFF
--- a/tools/klee-stats/Makefile
+++ b/tools/klee-stats/Makefile
@@ -36,11 +36,11 @@ install-local::
 uninstall-local::
 	$(Echo) Uninstall circumvented with NO_INSTALL
 else
-DestTool = $(PROJ_bindir)/$(TOOLSCRIPTNAME)
+DestTool = $(DESTDIR)$(PROJ_bindir)/$(TOOLSCRIPTNAME)
 
 install-local:: $(DestTool)
 
-$(DestTool): $(ToolBuildPath) $(PROJ_bindir)
+$(DestTool): $(ToolBuildPath) $(DESTDIR)$(PROJ_bindir)
 	$(Echo) Installing $(BuildMode) $(DestTool)
 	$(Verb) $(ProgInstall) $(ToolBuildPath) $(DestTool)
 

--- a/tools/ktest-tool/Makefile
+++ b/tools/ktest-tool/Makefile
@@ -36,11 +36,11 @@ install-local::
 uninstall-local::
 	$(Echo) Uninstall circumvented with NO_INSTALL
 else
-DestTool = $(PROJ_bindir)/$(TOOLSCRIPTNAME)
+DestTool = $(DESTDIR)$(PROJ_bindir)/$(TOOLSCRIPTNAME)
 
 install-local:: $(DestTool)
 
-$(DestTool): $(ToolBuildPath) $(PROJ_bindir)
+$(DestTool): $(ToolBuildPath) $(DESTDIR)$(PROJ_bindir)
 	$(Echo) Installing $(BuildMode) $(DestTool)
 	$(Verb) $(ProgInstall) $(ToolBuildPath) $(DestTool)
 


### PR DESCRIPTION
Some tools prepend DESTDIR properly, some not. ktest-tool and
klee-stats do not, so 'make install' chokes with an error:
llvm[2]: Installing Release+Asserts /usr/bin/ktest-tool
/usr/bin/install: cannot create regular file '/usr/bin/ktest-tool': Permission denied
