### PR TITLE
klee: let user override path to runtime library

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -575,6 +575,11 @@ void KleeHandler::getOutFiles(std::string path,
 }
 
 std::string KleeHandler::getRunTimeLibraryPath(const char *argv0) {
+  // allow specifying the path to the runtime library
+  const char *env = getenv("KLEE_RUNTIME_LIBRARY_PATH");
+  if (env)
+    return std::string(env);
+
   // Take any function from the execution binary but not main (as not allowed by
   // C++ standard)
   void *MainExecAddr = (void *)(intptr_t)getRunTimeLibraryPath;


### PR DESCRIPTION
Hi,

recently I've run into this very same problem:
http://lists.cs.uiuc.edu/pipermail/llvmdev/2013-June/062731.html

My use-case is that I'd like to run klee in parallel  on more computers, but I don't want to build it in place, but rather to rsync it there (just the binary and related libs). The hard-coded paths do a little bit mess in it.

I solved it by this patch for now. Do you think something like this could be accepted upstream?

Thanks,
Marek
