### PR TITLE
libstdcxx's c++11 support for unordered sets and maps confined only to t...

### DIFF
--- a/include/klee/util/ArrayExprHash.h
+++ b/include/klee/util/ArrayExprHash.h
@@ -140,4 +140,7 @@ void ArrayExprHash<T>::hashUpdateNodeExpr(const UpdateNode* un, T& exp)
 
 }
 
+#undef unordered_map
+#undef unordered_set
+
 #endif

--- a/include/klee/util/ExprHashMap.h
+++ b/include/klee/util/ExprHashMap.h
@@ -56,4 +56,7 @@ namespace klee {
 
 }
 
+#undef unordered_map
+#undef unordered_set
+
 #endif


### PR DESCRIPTION
...he scope of KLEE (metaSMT's boost implementation does not support that)
