### PR TITLE
klee: option to print range for each symbolic value

### DIFF
--- a/include/klee/Interpreter.h
+++ b/include/klee/Interpreter.h
@@ -153,6 +153,8 @@ public:
 
   virtual void getCoveredLines(const ExecutionState &state,
                                std::map<const std::string*, std::set<unsigned> > &res) = 0;
+  virtual void getRanges(const ExecutionState &state,
+          std::string &res) = 0;
 };
 
 } // End klee namespace

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3476,6 +3476,27 @@ void Executor::getConstraintLog(const ExecutionState &state, std::string &res,
   }
 }
 
+void Executor::getRanges(const ExecutionState &state, std::string &res)
+{
+  llvm::raw_string_ostream info(res);
+  for (unsigned i = 0; i != state.symbolics.size(); ++i) {
+    const MemoryObject *mo = state.symbolics[i].first;
+    const ObjectState *os = state.addressSpace.findObject(mo);
+    std::string symb_name = state.symbolics[i].first->name;
+    ref<Expr> read_symb = os->read(0, 8 * mo->size);
+    Query q(state.constraints, read_symb);
+    std::pair< ref<Expr>, ref<Expr> > res =
+      solver->solver->getRange(q);
+    ConstantExpr *a = dyn_cast<ConstantExpr>(res.first);
+    ConstantExpr *b = dyn_cast<ConstantExpr>(res.second);
+
+    assert(a); assert(b);
+    info << '"' << symb_name.c_str() << "\" = [" <<
+      a->getZExtValue() << ' ' << b->getZExtValue() <<
+      "]\n";
+  }
+}
+
 bool Executor::getSymbolicSolution(const ExecutionState &state,
                                    std::vector< 
                                    std::pair<std::string,

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -457,6 +457,8 @@ public:
   virtual void getConstraintLog(const ExecutionState &state,
                                 std::string &res,
                                 Interpreter::LogType logFormat = Interpreter::STP);
+  virtual void getRanges(const ExecutionState &state,
+          std::string &res);
 
   virtual bool getSymbolicSolution(const ExecutionState &state, 
                                    std::vector< 

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -110,7 +110,11 @@ namespace {
   cl::opt<bool>
   WriteCov("write-cov", 
            cl::desc("Write coverage information for each test case"));
-  
+
+  cl::opt<bool>
+      WriteRange("write-range",
+              cl::desc("Write the range of values for symbolic value."));
+
   cl::opt<bool>
   WriteTestInfo("write-test-info", 
                 cl::desc("Write additional test case information"));
@@ -495,6 +499,14 @@ void KleeHandler::processTestCase(const ExecutionState &state,
         m_interpreter->getConstraintLog(state, constraints, Interpreter::SMTLIB2);
         llvm::raw_ostream *f = openTestFile("smt2", id);
         *f << constraints;
+        delete f;
+    }
+
+    if (WriteRange) {
+        std::string ranges;
+        m_interpreter->getRanges(state, ranges);
+        llvm::raw_ostream *f = openTestFile("range", id);
+        *f << ranges;
         delete f;
     }
 


### PR DESCRIPTION
Print the range of the integer values that a symbolic value can take.  If the range is not contiguous, the behavior is undefined. This patch is more of a RFC than a fully fledged patch (the are no tests for example).

Signed-off-by: Lucian Cojocar l.cojocar@vu.nl
