### PR TITLE
Commit of improved IndependentSolver::getInitalValues().

### DIFF
--- a/include/klee/Constraints.h
+++ b/include/klee/Constraints.h
@@ -65,6 +65,11 @@ public:
     return constraints == other.constraints;
   }
   
+  ref<Expr> get(unsigned index) const{
+    return constraints[index];
+  }
+
+
 private:
   std::vector< ref<Expr> > constraints;
 

--- a/include/klee/Constraints.h
+++ b/include/klee/Constraints.h
@@ -66,9 +66,8 @@ public:
   }
   
   ref<Expr> get(unsigned index) const{
-    return constraints[index];
+	  return constraints[index];
   }
-
 
 private:
   std::vector< ref<Expr> > constraints;

--- a/include/klee/Expr.h
+++ b/include/klee/Expr.h
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <set>
 #include <vector>
+#include <map>
 
 namespace llvm {
   class Type;

--- a/include/klee/util/Assignment.h
+++ b/include/klee/util/Assignment.h
@@ -29,13 +29,13 @@ namespace klee {
   public:
     Assignment(bool _allowFreeValues=false) 
       : allowFreeValues(_allowFreeValues) {}
-    Assignment(std::vector<const Array*> &objects, 
+    Assignment(const std::vector<const Array*> &objects,
                std::vector< std::vector<unsigned char> > &values,
                bool _allowFreeValues=false) 
       : allowFreeValues(_allowFreeValues){
       std::vector< std::vector<unsigned char> >::iterator valIt = 
         values.begin();
-      for (std::vector<const Array*>::iterator it = objects.begin(),
+      for (std::vector<const Array*>::const_iterator it = objects.begin(),
              ie = objects.end(); it != ie; ++it) {
         const Array *os = *it;
         std::vector<unsigned char> &arr = *valIt;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -265,6 +265,11 @@ namespace {
   MaxMemoryInhibit("max-memory-inhibit",
             cl::desc("Inhibit forking at memory cap (vs. random terminate) (default=on)"),
             cl::init(true));
+
+  cl::opt<unsigned>
+  MaxForksTerminate("max-forks-terminate",
+		  cl::desc("Only fork this many times and then dump states (default=-1 (off))"),
+          cl::init(~0u));
 }
 
 
@@ -796,6 +801,10 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
         }
       }
     }
+  }
+
+  if(stats::forks >= MaxForksTerminate){
+	  haltExecution = true;
   }
 
   // Fix branch in only-replay-seed mode, if we don't have both true

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -268,8 +268,8 @@ namespace {
 
   cl::opt<unsigned>
   MaxForksTerminate("max-forks-terminate",
-		  cl::desc("Only fork this many times and then dump states (default=-1 (off))"),
-          cl::init(~0u));
+  		cl::desc("Only fork this many times and then dump states (default=-1 (off))"),
+  		cl::init(~0u));
 }
 
 
@@ -2933,7 +2933,7 @@ ref<Expr> Executor::replaceReadWithSymbolic(ExecutionState &state,
   // and return it.
   
   static unsigned id;
-  const Array *array = new Array("rrws_arr" + llvm::utostr(++id), 
+  const Array *array = Array::CreateArray("rrws_arr" + llvm::utostr(++id),
                                  Expr::getMinBytesForWidth(e->getWidth()));
   ref<Expr> res = Expr::createTempRead(array, e->getWidth());
   ref<Expr> eq = NotOptimizedExpr::create(EqExpr::create(e, res));
@@ -3272,7 +3272,7 @@ void Executor::executeMakeSymbolic(ExecutionState &state,
     while (!state.arrayNames.insert(uniqueName).second) {
       uniqueName = name + "_" + llvm::utostr(++id);
     }
-    const Array *array = new Array(uniqueName, mo->size);
+    const Array *array = Array::CreateArray(uniqueName, mo->size);
     bindObjectInState(state, mo, false, array);
     state.addSymbolic(mo, array);
     

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -113,7 +113,7 @@ ObjectState::ObjectState(const MemoryObject *mo)
   if (!UseConstantArrays) {
     // FIXME: Leaked.
     static unsigned id = 0;
-    const Array *array = new Array("tmp_arr" + llvm::utostr(++id), size);
+    const Array *array = Array::CreateArray("tmp_arr" + llvm::utostr(++id), size);
     updates = UpdateList(array, 0);
   }
   memset(concreteStore, 0, size);
@@ -222,7 +222,7 @@ const UpdateList &ObjectState::getUpdates() const {
     // Start a new update list.
     // FIXME: Leaked.
     static unsigned id = 0;
-    const Array *array = new Array("const_arr" + llvm::utostr(++id), size,
+    const Array *array = Array::CreateArray("const_arr" + llvm::utostr(++id), size,
                                    &Contents[0],
                                    &Contents[0] + Contents.size());
     updates = UpdateList(array, 0);

--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -494,6 +494,30 @@ unsigned Array::computeHash() {
   return hashValue; 
 }
 
+std::map<unsigned, const Array *> Array::symbolicArraySingletonMap;
+
+const Array * Array::CreateArray(const std::string &_name, uint64_t _size,
+		const ref<ConstantExpr> *constantValuesBegin,
+		const ref<ConstantExpr> *constantValuesEnd,
+		Expr::Width _domain, Expr::Width _range){
+
+	const Array * array = new Array(_name, _size, constantValuesBegin, constantValuesEnd, _domain,_range);
+	if(array->constantValues.size() == 0){
+		//means is a symbolic array and we should look up the values;
+		unsigned hash = array->hash();
+		if(Array::symbolicArraySingletonMap.count(hash)){
+			delete array;
+			return Array::symbolicArraySingletonMap[hash];
+		}else{
+			Array::symbolicArraySingletonMap[hash] = array;
+			return array;
+		}
+	}else{
+		return array;
+	}
+	return 0;
+}
+
 /***/
 
 ref<Expr> ReadExpr::create(const UpdateList &ul, ref<Expr> index) {

--- a/lib/Expr/Parser.cpp
+++ b/lib/Expr/Parser.cpp
@@ -519,12 +519,12 @@ DeclResult ParserImpl::ParseArrayDecl() {
 
   // FIXME: Array should take domain and range.
   const Identifier *Label = GetOrCreateIdentifier(Name);
-  Array *Root;
+  const Array *Root;
   if (!Values.empty())
-    Root = new Array(Label->Name, Size.get(),
+    Root = Array::CreateArray(Label->Name, Size.get(),
                      &Values[0], &Values[0] + Values.size());
   else
-    Root = new Array(Label->Name, Size.get());
+    Root = Array::CreateArray(Label->Name, Size.get());
   ArrayDecl *AD = new ArrayDecl(Label, Size.get(), 
                                 DomainType.get(), RangeType.get(), Root);
 
@@ -1306,7 +1306,7 @@ VersionResult ParserImpl::ParseVersionSpecifier() {
   VersionResult Res = ParseVersion();
   // Define update list to avoid use-of-undef errors.
   if (!Res.isValid()) {
-    Res = VersionResult(true, UpdateList(new Array("", 0), NULL));
+    Res = VersionResult(true, UpdateList(Array::CreateArray("", 0), NULL));
   }
   
   if (Label)

--- a/lib/SMT/SMTParser.cpp
+++ b/lib/SMT/SMTParser.cpp
@@ -165,7 +165,7 @@ void SMTParser::DeclareExpr(std::string name, Expr::Width w) {
   std::cout << "Declaring " << name << " of width " << w << "\n";
 #endif
   
-  Array *arr = new Array(name, w / 8);
+  Array *arr = Array::CreateArray(name, w / 8);
   
   ref<Expr> *kids = new ref<Expr>[w/8];
   for (unsigned i=0; i < w/8; i++)

--- a/lib/Solver/CexCachingSolver.cpp
+++ b/lib/Solver/CexCachingSolver.cpp
@@ -49,12 +49,80 @@ struct AssignmentLessThan {
   }
 };
 
+/*
+ * Contains a list of pairs of expressions and their answers that happen
+ * to map to the same hash value.  Prevents a hash collision.
+ */
+class AssignmentBundle{
+	typedef std::pair<std::set<unsigned>, Assignment *> answer;
+
+private:
+	//The list of possible answers to iterate through should a collision occur
+	std::vector<answer> possibleAnswers;
+
+public :
+	AssignmentBundle(){}
+
+	bool match(const KeyType &key, answer &possible){
+		if(key.size() != possible.first.size()){
+			return false;
+		}
+
+		for(std::set<ref<Expr> >::const_iterator it = key.begin(); it != key.end(); it ++){
+			if(possible.first.count(it->get()->hash()) == 0){
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool get(const KeyType &key, Assignment * &assignment){
+		for(std::vector<answer>::const_iterator it = possibleAnswers.begin(); it != possibleAnswers.end(); it++){
+			answer a = * it;
+			if(match(key, a)){
+				assignment = it->second;
+				return true;
+			}
+		}
+		assignment = 0;
+		return false;
+	}
+
+	bool get(const std::vector<ref<Expr> > & key, Assignment * &result){
+		KeyType pass;
+		for(std::vector<ref<Expr> >::const_iterator it = key.begin(); it != key.end(); it++){
+			ref<Expr> e = * it;
+			pass.insert(e);
+		}
+		return get(pass, result);
+	}
+
+	void put(const KeyType & key, Assignment * &result){
+		for(std::vector<answer>::const_iterator it = possibleAnswers.begin(); it != possibleAnswers.end(); it++){
+			answer a = * it;
+			if(match(key, a)){
+				return;
+			}
+		}
+		std::set<unsigned> add;
+		for(KeyType::const_iterator it = key.begin(); it != key.end(); it ++){
+			ref<Expr> expr = *it;
+			add.insert(expr.get()->hash());
+		}
+
+		answer a(add, result);
+		possibleAnswers.push_back(a);
+	}
+};
 
 class CexCachingSolver : public SolverImpl {
   typedef std::set<Assignment*, AssignmentLessThan> assignmentsTable_ty;
 
   Solver *solver;
   
+  std::map<long, AssignmentBundle *> quickCache;
+
   MapOfSets<ref<Expr>, Assignment*> cache;
   // memo table
   assignmentsTable_ty assignmentsTable;
@@ -68,6 +136,16 @@ class CexCachingSolver : public SolverImpl {
     KeyType key;
     return lookupAssignment(query, key, result);
   }
+
+  //Caching operations
+  bool getFromQuickCache(const KeyType & key, Assignment * &assignment);
+  void insertInQuickCache(const KeyType & key, Assignment * &binding);
+  void insertInCaches(const KeyType & key, Assignment * &binding);
+
+  bool quickMatch(const Query &query, const KeyType &key, Assignment *&result);
+
+  bool checkPreviousSolutionHelper(const ref<Expr>, const std::set<ref<Expr> > &key, Assignment * &result);
+  bool checkPreviousSolution(const Query &query, Assignment *&result);
 
   bool getAssignment(const Query& query, Assignment *&result);
   
@@ -171,6 +249,131 @@ bool CexCachingSolver::searchForAssignment(KeyType &key, Assignment *&result) {
   return false;
 }
 
+bool
+CexCachingSolver::getFromQuickCache(const KeyType &key, Assignment * &result){
+	long comboHash = 0;
+	for(KeyType::const_iterator it = key.begin(); it != key.end(); it++){
+		comboHash += (*it).get()->hash();
+	}
+
+	if(quickCache.count(comboHash)){
+		AssignmentBundle * bundle = quickCache[comboHash];
+		return bundle->get(key, result);
+	}
+	result = 0;
+	return false;
+}
+
+void
+CexCachingSolver::insertInQuickCache(const KeyType &key, Assignment * &binding){
+	long comboHash = 0;
+	for(KeyType::iterator it = key.begin(); it != key.end(); it++){
+		comboHash += (*it).get()->hash();
+	}
+
+	AssignmentBundle * b = quickCache[comboHash];
+	if(! b){
+		b = new AssignmentBundle();
+		quickCache[comboHash] = b;
+	}
+
+	b->put(key, binding);
+}
+
+void
+CexCachingSolver::insertInCaches(const KeyType &key, Assignment * &binding){
+	insertInQuickCache(key, binding);
+	cache.insert(key, binding);
+}
+
+bool CexCachingSolver::quickMatch(const Query &query,
+								  const KeyType &key,
+								  Assignment *&result) {
+	if(getFromQuickCache(key, result)){
+		return true;
+	}
+	result = 0;
+	return false;
+}
+
+bool CexCachingSolver::checkPreviousSolutionHelper(const ref<Expr> queryExpr,	//If anything other than query.expr, then negated.
+										   const std::set<ref<Expr> > &key,
+										   Assignment * &result){
+	Assignment * parentSolution;
+	if(getFromQuickCache(key, parentSolution)){
+		if(!parentSolution){
+			//means that the the previous state was UNSAT and therefore the
+			//new answer will also be necessarily UNSAT
+			assert(!result);
+			return true;
+		}else{
+			/*
+			 * Means that there is in fact a parent solution.  In this case,
+			 * we can now check whether this parent solution satisfies the
+			 * child state.  There's a pretty good chance... at least 50/50
+			 */
+			ref<Expr> neg = Expr::createIsZero(queryExpr);
+			ref<Expr> q = parentSolution->evaluate(neg);
+
+			assert(isa<ConstantExpr>(q) && "assignment evaluation did not result in constant");
+			if(cast<ConstantExpr>(q)->isTrue()){
+				result = parentSolution;
+				return true;
+			}else{
+				/*
+				 * If goes false, that means that the point that had gotten us to our parent
+				 * went along the opposing branch and it won't help us at this stage.  The
+				 * value stored in oldAnswer could help someone though.
+				 */
+				assert(!result);
+				return false;
+			}
+		}
+	}
+	assert(!parentSolution);
+	assert(!result);
+	return false;
+}
+
+bool CexCachingSolver::checkPreviousSolution(const Query &query,
+										  Assignment *&result){
+	if(query.constraints.size() == 0){
+		return false;
+	}
+
+	std::set<ref<Expr> > parentKey;
+	ref<Expr> queryExpr;
+	if(isa<ConstantExpr>(query.expr)){
+		assert(cast<ConstantExpr>(query.expr)->isFalse() && "query.expr == true should'd happen");
+		for(unsigned i = 0; i < query.constraints.size() - 1; i ++){
+			ref<Expr> ref = query.constraints.get(i);
+			parentKey.insert(ref);
+		}
+
+        ref<Expr> toNeg = query.constraints.get(query.constraints.size() - 1);
+        queryExpr = Expr::createIsZero(toNeg);
+	}else{
+		for(unsigned i = 0; i < query.constraints.size(); i ++){
+			ref<Expr> ref = query.constraints.get(i);
+			parentKey.insert(ref);
+		}
+		queryExpr = query.expr;
+	}
+
+	if(checkPreviousSolutionHelper(queryExpr, parentKey, result)){
+		/*
+		 * result may contain one of two things
+		 * 	- A 0, meaning that the previous piece of the was UNSAT and therefore new is too
+		 *	  (I put an assertion in checkPrevHelper to discount this case, but being careful)
+		 * 	- An actual result which we should verify is correct.
+		 */
+		return true;
+	}else{
+		return false;
+	}
+}
+
+
 /// lookupAssignment - Lookup a cached result for the given \arg query.
 ///
 /// \param query - The query to lookup.
@@ -194,10 +397,27 @@ bool CexCachingSolver::lookupAssignment(const Query &query,
     key.insert(neg);
   }
 
-  bool found = searchForAssignment(key, result);
-  if (found)
+  bool found = quickMatch(query, key, result);
+
+  if(!found){
+  		found = checkPreviousSolution(query, result);
+  		if(found){
+  			insertInQuickCache(key, result);
+  		}
+  }
+
+  if(!found){
+	  found = searchForAssignment(key, result);
+	  if(found){
+		  insertInQuickCache(key, result);
+	  }
+  }
+
+  if (found){
     ++stats::queryCexCacheHits;
-  else ++stats::queryCexCacheMisses;
+  }else{
+	  ++stats::queryCexCacheMisses;
+  }
     
   return found;
 }
@@ -235,7 +455,7 @@ bool CexCachingSolver::getAssignment(const Query& query, Assignment *&result) {
   }
   
   result = binding;
-  cache.insert(key, binding);
+  insertInCaches(key, binding);
 
   return true;
 }
@@ -317,10 +537,8 @@ bool CexCachingSolver::computeValue(const Query& query,
 
 bool 
 CexCachingSolver::computeInitialValues(const Query& query,
-                                       const std::vector<const Array*> 
-                                         &objects,
-                                       std::vector< std::vector<unsigned char> >
-                                         &values,
+                                       const std::vector<const Array*>  &objects,
+									   std::vector< std::vector<unsigned char> > &values,
                                        bool &hasSolution) {
   TimerStatIncrementer t(stats::cexCacheTime);
   Assignment *a;

--- a/lib/Solver/IndependenceAnalysis.cpp
+++ b/lib/Solver/IndependenceAnalysis.cpp
@@ -1,0 +1,303 @@
+/*
+ * IndependenceAnalysis.cpp
+ *
+ *  Created on: Jan 29, 2015
+ *      Author: ericrizzi
+ */
+
+#include "IndependenceAnalysis.h"
+
+/*
+ * Keeps track of all reads in a single Constraint.  Maintains
+ * a list of indices that are accessed in a concrete way.  This
+ * can be superseded, however, by a set of arrays (wholeObjects)
+ * that have been symbolically accessed.
+ */
+IndependentElementSet::IndependentElementSet() {}
+
+IndependentElementSet::IndependentElementSet(ref<Expr> e) {
+	// Track all reads in the program.  Determines whether reads are
+	//concrete or symbolic.  If they are symbolic, "collapses" array
+	//by adding it to wholeObjects.  Otherwise, creates a mapping of
+	//the form Map<array, set<index>> which tracks which parts of the
+	//array are being accessed
+	exprs.push_back(e);
+	std::vector< ref<ReadExpr> > reads;
+	findReads(e, /* visitUpdates= */ true, reads);
+	for (unsigned i = 0; i != reads.size(); ++i) {
+		ReadExpr *re = reads[i].get();
+		const Array *array = re->updates.root;
+
+		// Reads of a constant array don't alias.
+		if (re->updates.root->isConstantArray() &&
+				!re->updates.head)
+			continue;
+
+		if (!wholeObjects.count(array)) { //if haven't been scrambled yet
+			if (ConstantExpr *CE = dyn_cast<ConstantExpr>(re->index)) {
+				//if index constant, then add to set of constraints operating
+				//on that array (actually, don't add constraint, just set index)
+				::DenseSet<unsigned> &dis = elements[array];
+				dis.add((unsigned) CE->getZExtValue(32));
+			} else {
+				//means symbolic access
+				elements_ty::iterator it2 = elements.find(array);
+				if (it2!=elements.end())
+					//if first time seen, erase set
+					elements.erase(it2);
+				wholeObjects.insert(array);
+			}
+		}
+	}
+}
+
+IndependentElementSet::IndependentElementSet(const IndependentElementSet &ies) :
+	elements(ies.elements),
+	wholeObjects(ies.wholeObjects),
+	exprs(ies.exprs){}
+
+void IndependentElementSet::print(llvm::raw_ostream &os) const {
+	os << "{";
+	bool first = true;
+	for (std::set<const Array*>::iterator it = wholeObjects.begin(),
+			ie = wholeObjects.end(); it != ie; ++it) {
+		const Array *array = *it;
+
+		if (first) {
+			first = false;
+		} else {
+			os << ", ";
+		}
+
+		os << "MO" << array->name;
+	}
+	for (elements_ty::const_iterator it = elements.begin(), ie = elements.end();
+			it != ie; ++it) {
+		const Array *array = it->first;
+		const ::DenseSet<unsigned> &dis = it->second;
+
+		if (first) {
+			first = false;
+		} else {
+			os << ", ";
+		}
+
+		os << "MO" << array->name << " : " << dis;
+	}
+	os << "}";
+}
+
+// more efficient when this is the smaller set
+bool IndependentElementSet::intersects(const IndependentElementSet &b) {
+	//If there are any symbolic arrays in our query that b accesses
+	for (std::set<const Array*>::iterator it = wholeObjects.begin(),
+			ie = wholeObjects.end(); it != ie; ++it) {
+		const Array *array = *it;
+		if (b.wholeObjects.count(array) ||
+				b.elements.find(array) != b.elements.end())
+			return true;
+	}
+
+	for (elements_ty::iterator it = elements.begin(), ie = elements.end();
+			it != ie; ++it) {
+		const Array *array = it->first;
+		//if any of the elements we access are symbolic in b
+		if (b.wholeObjects.count(array))
+			return true;
+		elements_ty::const_iterator it2 = b.elements.find(array);
+		//Or if we access the same index as b
+		if (it2 != b.elements.end()) {
+			if (it->second.intersects(it2->second))
+				return true;
+		}
+	}
+	return false;
+}
+
+// returns true iff set is changed by addition
+bool IndependentElementSet::add(const IndependentElementSet &b) {
+
+	for(unsigned i = 0; i < b.exprs.size(); i ++){
+		ref<Expr> expr = b.exprs[i];
+		exprs.push_back(expr);
+	}
+	std::set<const Array*> seen;
+	bool modified = false;
+	for (std::set<const Array*>::const_iterator it = b.wholeObjects.begin(),
+			ie = b.wholeObjects.end(); it != ie; ++it) {
+		const Array *array = *it;
+		elements_ty::iterator it2 = elements.find(array);
+		if (it2!=elements.end()) {
+			modified = true;
+			elements.erase(it2);
+			wholeObjects.insert(array);
+		} else {
+			if (!wholeObjects.count(array)) {
+				modified = true;
+				wholeObjects.insert(array);
+			}
+		}
+	}
+	for (elements_ty::const_iterator it = b.elements.begin(),
+			ie = b.elements.end(); it != ie; ++it) {
+		const Array *array = it->first;
+		if (!wholeObjects.count(array)) {
+			elements_ty::iterator it2 = elements.find(array);
+			if (it2==elements.end()) {
+				modified = true;
+				elements.insert(*it);
+			} else {
+				if (it2->second.add(it->second))
+					modified = true;
+			}
+		}
+	}
+	return modified;
+}
+
+/*
+ * Breaks down a constraint into all of it's individual pieces, returning a
+ * list of IndependentElementSets or the independent factors.
+ */
+void getAllFactors(const Query& query, std::list<IndependentElementSet> * &factors ){
+	assert(factors && "should not pass in a null vector");
+	ConstantExpr *CE = dyn_cast<ConstantExpr>(query.expr);
+
+	/*
+	 * If the query.expr is false, we can simply ignore it.  Otherwise, we need to
+	 * negate it and add it to the list of factors.
+	 */
+	if(CE){
+		assert(CE && CE->isFalse() && "the expr should always be false and therefore not included in factors");
+	}else{
+		ref<Expr> neg = Expr::createIsZero(query.expr);
+		factors->push_back(IndependentElementSet(neg));
+	}
+
+	for (ConstraintManager::const_iterator it = query.constraints.begin(),
+			ie = query.constraints.end(); it != ie; ++it)
+		//iterate through all the previously separated constraints.  Until we
+		//actually return, factors is treated as a queue of expressions to be
+		//evaluated.  If the queue property isn't maintained, then the exprs
+		//could be returned in an order different from how they came it, negatively
+		//affecting later stages.
+		factors->push_back(IndependentElementSet(*it));
+
+	bool doneLoop = false;
+	do {
+		doneLoop = true;
+		std::list<IndependentElementSet> * done = new std::list<IndependentElementSet>;
+		while(factors->size() > 0){
+			IndependentElementSet current = factors->front();
+			factors->pop_front();
+			std::set<const Array*> seen;
+
+			//This list represents the set of factors that are separate from current.
+			//Those that are not inserted into this list (queue) intersect with current.
+			std::list<IndependentElementSet> *keep = new std::list<IndependentElementSet>;
+			while(factors->size() > 0){
+				IndependentElementSet compare = factors->front();
+				factors->pop_front();
+				if(current.intersects(compare)){
+					if (current.add(compare)){
+						/*
+						 * Means that we have added (z=y)added to (x=y)
+						 * Now need to see if there are any (z=?)'s
+						 */
+						doneLoop = false;
+					}
+				}else{
+					keep->push_back(compare);
+				}
+			}
+			done->push_back(current);
+			delete factors;
+			factors = keep;
+
+		}
+		delete factors;
+		factors = done;
+	}while(!doneLoop);
+}
+
+/*
+ * Extracts which arrays are referenced from a particular independent set.  Examines both
+ * the actual known array accesses arr[1] plus the undetermined accesses arr[x].
+ */
+void calculateArrays(const IndependentElementSet & ie, std::vector<const Array *> &returnVector){
+	//Now need to some how extract the arrays from these pieces...
+	std::set<const Array*> thisSeen;
+	for(std::map<const Array*, ::DenseSet<unsigned> >::const_iterator it = ie.elements.begin(); it != ie.elements.end(); it ++){
+		const Array* arr = it->first;
+		thisSeen.insert(arr);
+	}
+
+	for(std::set<const Array *>::iterator it = ie.wholeObjects.begin(); it != ie.wholeObjects.end(); it ++){
+		const Array* arr = * it;
+		thisSeen.insert(arr);
+	}
+
+	for(std::set<const Array *>::iterator it = thisSeen.begin(); it != thisSeen.end(); it ++){
+		const Array * arr = * it;
+		returnVector.push_back(arr);
+	}
+}
+
+/*
+ * Returns a pair.
+ * 	First: Contains the elements related to the new part of the query ("fresh" in Green terms)
+ * 	Second: Contains a set of all of the independent factors in the entire query.
+ *
+ * 	The reason we need to add this second part (the set) is for getInitialValues
+ *
+ * 	Note: This could be improved with caching, but since it's C++,
+ * 	it's still pretty damn fast.
+ */
+IndependentElementSet getFreshFactor(const Query& query,
+		std::vector< ref<Expr> > &result) {
+	IndependentElementSet eltsClosure(query.expr); //The new thing we're testing
+	std::vector< std::pair<ref<Expr>, IndependentElementSet> > worklist;
+
+	for (ConstraintManager::const_iterator it = query.constraints.begin(),
+			ie = query.constraints.end(); it != ie; ++it)
+		//iterate through all the previously separated constraints
+		worklist.push_back(std::make_pair(*it, IndependentElementSet(*it)));
+
+	// XXX This should be more efficient (in terms of low level copy stuff).
+	bool done = false;
+	do {
+		done = true;
+		//The pair below keeps track of <Expr, Set<Variables in Expression>>
+		std::vector< std::pair<ref<Expr>, IndependentElementSet> > newWorklist;
+		for (std::vector< std::pair<ref<Expr>, IndependentElementSet> >::iterator
+				it = worklist.begin(), ie = worklist.end(); it != ie; ++it) {
+			if (it->second.intersects(eltsClosure)) {
+				if (eltsClosure.add(it->second))
+					done = false;	//Means that we have added (z=y)added to (x=y)
+				//Now need to see if there are any (z=?)'s
+				result.push_back(it->first);
+			} else {
+				newWorklist.push_back(*it);
+			}
+		}
+		worklist.swap(newWorklist);
+	} while (!done);
+
+	KLEE_DEBUG(
+			std::set< ref<Expr> > reqset(result.begin(), result.end());
+	errs() << "--\n";
+	errs() << "Q: " << query.expr << "\n";
+	errs() << "\telts: " << IndependentElementSet(query.expr) << "\n";
+	int i = 0;
+	for (ConstraintManager::const_iterator it = query.constraints.begin(),
+			ie = query.constraints.end(); it != ie; ++it) {
+		errs() << "C" << i++ << ": " << *it;
+		errs() << " " << (reqset.count(*it) ? "(required)" : "(independent)") << "\n";
+		errs() << "\telts: " << IndependentElementSet(*it) << "\n";
+	}
+	errs() << "elts closure: " << eltsClosure << "\n";
+	);
+
+
+	return eltsClosure;
+}

--- a/lib/Solver/IndependenceAnalysis.h
+++ b/lib/Solver/IndependenceAnalysis.h
@@ -1,0 +1,152 @@
+/*
+ * IndependenceAnalysis.h
+ *
+ *  Created on: Jan 29, 2015
+ *      Author: ericrizzi
+ */
+
+#ifndef KLEE_UTIL_INDEPENDENCEANALYSIS_H_
+#define KLEE_UTIL_INDEPENDENCEANALYSIS_H_
+
+#include "klee/Solver.h"
+
+#include "klee/Expr.h"
+#include "klee/Constraints.h"
+#include "klee/SolverImpl.h"
+#include "klee/Internal/Support/Debug.h"
+#include "klee/Common.h"
+
+#include "klee/util/ExprUtil.h"
+
+#include "llvm/Support/raw_ostream.h"
+#include <map>
+#include <vector>
+#include <ostream>
+#include <list>
+
+using namespace klee;
+using namespace llvm;
+
+
+template<class T>
+class DenseSet {
+	typedef std::set<T> set_ty;
+
+public:
+	set_ty s;
+
+	DenseSet(){}
+
+	void add(T x){
+		s.insert(x);
+	}
+
+	void add(T start, T end) {
+		for (; start<end; start++)
+			s.insert(start);
+	}
+
+	// returns true iff set is changed by addition
+	bool add(const DenseSet &b){
+		bool modified = false;
+		for (typename set_ty::const_iterator it = b.s.begin(), ie = b.s.end();
+				it != ie; ++it) {
+			if (modified || !s.count(*it)) {
+				modified = true;
+				s.insert(*it);
+			}
+		}
+		return modified;
+	}
+
+	bool intersects(const DenseSet &b){
+		for (typename set_ty::iterator it = s.begin(), ie = s.end();
+				it != ie; ++it)
+			if (b.s.count(*it))
+				return true;
+		return false;
+	}
+
+	std::set<unsigned>::iterator begin(){
+	    return s.begin();
+	}
+
+	std::set<unsigned>::iterator end(){
+		return s.end();
+	}
+
+	void print(llvm::raw_ostream &os) const{
+		bool first = true;
+		os << "{";
+		for (typename set_ty::iterator it = s.begin(), ie = s.end();
+				it != ie; ++it) {
+			if (first) {
+				first = false;
+			} else {
+				os << ",";
+			}
+			os << *it;
+		}
+		os << "}";
+	}
+};
+
+template <class T>
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const ::DenseSet<T> &dis) {
+	dis.print(os);
+	return os;
+}
+
+/*
+ * Keeps track of all reads in a single Constraint.  Maintains
+ * a list of indices that are accessed in a concrete way.  This
+ * can be superseded, however, by a set of arrays (wholeObjects)
+ * that have been symbolically accessed.
+ */
+class IndependentElementSet {
+
+
+public:
+	typedef std::map<const Array*, ::DenseSet<unsigned> > elements_ty;
+
+	elements_ty elements;
+	std::set<const Array*> wholeObjects;	//Pretty sure represents symbolic accessed arrays
+	std::vector<ref<Expr> > exprs;
+
+	IndependentElementSet();
+	IndependentElementSet(ref<Expr> e);
+	IndependentElementSet(const IndependentElementSet &ies);
+
+	void print(llvm::raw_ostream &os) const;
+
+	// more efficient when this is the smaller set
+	bool intersects(const IndependentElementSet &b);
+
+	// returns true iff set is changed by addition
+	bool add(const IndependentElementSet &b);
+
+	IndependentElementSet &operator=(const IndependentElementSet &ies) {
+		elements = ies.elements;
+		wholeObjects = ies.wholeObjects;
+
+		for(unsigned i = 0; i < ies.exprs.size(); i ++){
+			ref<Expr> expr = ies.exprs[i];
+			exprs.push_back(expr);
+		}
+
+		return *this;
+	}
+};
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const IndependentElementSet &ies) {
+	ies.print(os);
+	return os;
+}
+
+void getAllFactors(const Query& query, std::list<IndependentElementSet> * &factors );
+
+void calculateArrays(const IndependentElementSet & ie, std::vector<const Array *> &returnVector);
+
+IndependentElementSet getFreshFactor(const Query& query, std::vector<ref<Expr> > &result);
+
+#endif /* KLEE_UTIL_INDEPENDENCEANALYSIS_H_ */

--- a/lib/Solver/IndependentSolver.cpp
+++ b/lib/Solver/IndependentSolver.cpp
@@ -14,387 +14,18 @@
 #include "klee/Constraints.h"
 #include "klee/SolverImpl.h"
 #include "klee/Internal/Support/Debug.h"
+#include "klee/util/Assignment.h"
+#include "IndependenceAnalysis.h"
 
 #include "klee/util/ExprUtil.h"
-#include "klee/util/Assignment.h"
 
 #include "llvm/Support/raw_ostream.h"
 #include <map>
 #include <vector>
 #include <ostream>
-#include <list>
 
 using namespace klee;
 using namespace llvm;
-
-template<class T>
-class DenseSet {
-  typedef std::set<T> set_ty;
-  set_ty s;
-
-public:
-  DenseSet() {}
-
-  void add(T x) {
-    s.insert(x);
-  }
-  void add(T start, T end) {
-    for (; start<end; start++)
-      s.insert(start);
-  }
-
-  // returns true iff set is changed by addition
-  bool add(const DenseSet &b) {
-    bool modified = false;
-    for (typename set_ty::const_iterator it = b.s.begin(), ie = b.s.end(); 
-         it != ie; ++it) {
-      if (modified || !s.count(*it)) {
-        modified = true;
-        s.insert(*it);
-      }
-    }
-    return modified;
-  }
-
-  bool intersects(const DenseSet &b) {
-    for (typename set_ty::iterator it = s.begin(), ie = s.end(); 
-         it != ie; ++it)
-      if (b.s.count(*it))
-        return true;
-    return false;
-  }
-
-  std::set<unsigned>::iterator begin(){
-	  return s.begin();
-  }
-
-  std::set<unsigned>::iterator end(){
-  	  return s.end();
-  }
-
-  void print(llvm::raw_ostream &os) const {
-    bool first = true;
-    os << "{";
-    for (typename set_ty::iterator it = s.begin(), ie = s.end(); 
-         it != ie; ++it) {
-      if (first) {
-        first = false;
-      } else {
-        os << ",";
-      }
-      os << *it;
-    }
-    os << "}";
-  }
-};
-
-template <class T>
-inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                     const ::DenseSet<T> &dis) {
-  dis.print(os);
-  return os;
-}
-
-class IndependentElementSet {
-public:
-  typedef std::map<const Array*, ::DenseSet<unsigned> > elements_ty;
-  elements_ty elements;					//Represents individual elements of array accesses (arr[1])
-  std::set<const Array*> wholeObjects;	//Represents symbolically accessed arrays (arr[x])
-  std::vector<ref<Expr> > exprs;		//All expressions that are associated with this factor
-
-  IndependentElementSet() {}
-  IndependentElementSet(ref<Expr> e) {
-    exprs.push_back(e);
-    // Track all reads in the program.  Determines whether reads are
-    //concrete or symbolic.  If they are symbolic, "collapses" array
-    //by adding it to wholeObjects.  Otherwise, creates a mapping of
-    //the form Map<array, set<index>> which tracks which parts of the
-    //array are being accessed
-    std::vector< ref<ReadExpr> > reads;
-    findReads(e, /* visitUpdates= */ true, reads);
-    for (unsigned i = 0; i != reads.size(); ++i) {
-      ReadExpr *re = reads[i].get();
-      const Array *array = re->updates.root;
-      
-      // Reads of a constant array don't alias.
-      if (re->updates.root->isConstantArray() &&
-          !re->updates.head)
-        continue;
-
-      if (!wholeObjects.count(array)) {
-        if (ConstantExpr *CE = dyn_cast<ConstantExpr>(re->index)) {
-          //if index constant, then add to set of constraints operating
-          //on that array (actually, don't add constraint, just set index)
-          ::DenseSet<unsigned> &dis = elements[array];
-          dis.add((unsigned) CE->getZExtValue(32));
-        } else {
-          elements_ty::iterator it2 = elements.find(array);
-          if (it2!=elements.end())
-            elements.erase(it2);
-          wholeObjects.insert(array);
-        }
-      }
-    }
-  }
-  IndependentElementSet(const IndependentElementSet &ies) : 
-    elements(ies.elements),
-    wholeObjects(ies.wholeObjects),
-	exprs(ies.exprs){}
-
-  IndependentElementSet &operator=(const IndependentElementSet &ies) {
-    elements = ies.elements;
-    wholeObjects = ies.wholeObjects;
-
-    for(unsigned i = 0; i < ies.exprs.size(); i ++){
-    	ref<Expr> expr = ies.exprs[i];
-    	exprs.push_back(expr);
-    }
-
-    return *this;
-  }
-
-  void print(llvm::raw_ostream &os) const {
-    os << "{";
-    bool first = true;
-    for (std::set<const Array*>::iterator it = wholeObjects.begin(), 
-           ie = wholeObjects.end(); it != ie; ++it) {
-      const Array *array = *it;
-
-      if (first) {
-        first = false;
-      } else {
-        os << ", ";
-      }
-
-      os << "MO" << array->name;
-    }
-    for (elements_ty::const_iterator it = elements.begin(), ie = elements.end();
-         it != ie; ++it) {
-      const Array *array = it->first;
-      const ::DenseSet<unsigned> &dis = it->second;
-
-      if (first) {
-        first = false;
-      } else {
-        os << ", ";
-      }
-
-      os << "MO" << array->name << " : " << dis;
-    }
-    os << "}";
-  }
-
-  // more efficient when this is the smaller set
-  bool intersects(const IndependentElementSet &b) {
-	 //If there are any symbolic arrays in our query that b accesses
-    for (std::set<const Array*>::iterator it = wholeObjects.begin(), 
-           ie = wholeObjects.end(); it != ie; ++it) {
-      const Array *array = *it;
-      if (b.wholeObjects.count(array) || 
-          b.elements.find(array) != b.elements.end())
-        return true;
-    }
-    for (elements_ty::iterator it = elements.begin(), ie = elements.end();
-         it != ie; ++it) {
-      const Array *array = it->first;
-      //if any of the elements we access are symbolic in b
-      if (b.wholeObjects.count(array))
-        return true;
-      elements_ty::const_iterator it2 = b.elements.find(array);
-      //if any of the elements we access are symbolic in b
-      if (it2 != b.elements.end()) {
-        if (it->second.intersects(it2->second))
-          return true;
-      }
-    }
-    return false;
-  }
-
-  // returns true iff set is changed by addition
-  bool add(const IndependentElementSet &b) {
-	for(unsigned i = 0; i < b.exprs.size(); i ++){
-			ref<Expr> expr = b.exprs[i];
-	  	  exprs.push_back(expr);
-	}
-	std::set<const Array*> seen;
-    bool modified = false;
-    for (std::set<const Array*>::const_iterator it = b.wholeObjects.begin(), 
-           ie = b.wholeObjects.end(); it != ie; ++it) {
-      const Array *array = *it;
-      elements_ty::iterator it2 = elements.find(array);
-      if (it2!=elements.end()) {
-        modified = true;
-        elements.erase(it2);
-        wholeObjects.insert(array);
-      } else {
-        if (!wholeObjects.count(array)) {
-          modified = true;
-          wholeObjects.insert(array);
-        }
-      }
-    }
-    for (elements_ty::const_iterator it = b.elements.begin(), 
-           ie = b.elements.end(); it != ie; ++it) {
-      const Array *array = it->first;
-      if (!wholeObjects.count(array)) {
-        elements_ty::iterator it2 = elements.find(array);
-        if (it2==elements.end()) {
-          modified = true;
-          elements.insert(*it);
-        } else {//Now need to see if there are any (z=?)'s
-
-          if (it2->second.add(it->second))
-            modified = true;
-        }
-      }
-    }
-    return modified;
-  }
-};
-
-inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                     const IndependentElementSet &ies) {
-  ies.print(os);
-  return os;
-}
-
-/*
- * Breaks down a constraint into all of it's individual pieces, returning a
- * list of IndependentElementSets or the independent factors.
- */
-void getAllFactors(const Query& query, std::list<IndependentElementSet> * &factors ){
-	assert(factors && "should not pass in a null vector");
-	ConstantExpr *CE = dyn_cast<ConstantExpr>(query.expr);
-
-	/*
-	 * If the query.expr is false, we can simply ignore it.  Otherwise, we need to
-	 * negate it and add it to the list of factors.
-	 */
-	if(CE){
-		assert(CE && CE->isFalse() && "the expr should always be false and therefore not included in factors");
-	}else{
-		ref<Expr> neg = Expr::createIsZero(query.expr);
-		factors->push_back(IndependentElementSet(neg));
-	}
-
-	for (ConstraintManager::const_iterator it = query.constraints.begin(),
-			ie = query.constraints.end(); it != ie; ++it)
-		//iterate through all the previously separated constraints.  Until we
-		//actually return, factors is treated as a queue of expressions to be
-		//evaluated.  If the queue property isn't maintained, then the exprs
-		//could be returned in an order different from how they came it, negatively
-		//affecting later stages.
-		factors->push_back(IndependentElementSet(*it));
-
-	bool doneLoop = false;
-	do {
-		doneLoop = true;
-		std::list<IndependentElementSet> * done = new std::list<IndependentElementSet>;
-		while(factors->size() > 0){
-			IndependentElementSet current = factors->front();
-			factors->pop_front();
-			std::set<const Array*> seen;
-
-			//This list represents the set of factors that are separate from current.
-			//Those that are not inserted into this list (queue) intersect with current.
-			std::list<IndependentElementSet> *keep = new std::list<IndependentElementSet>;
-			while(factors->size() > 0){
-				IndependentElementSet compare = factors->front();
-				factors->pop_front();
-				if(current.intersects(compare)){
-					if (current.add(compare)){
-						/*
-						 * Means that we have added (z=y)added to (x=y)
-						 * Now need to see if there are any (z=?)'s
-						 */
-						 doneLoop = false;
-					}
-				}else{
-					keep->push_back(compare);
-				}
-			}
-			done->push_back(current);
-			delete factors;
-			factors = keep;
-
-		}
-		delete factors;
-		factors = done;
-	}while(!doneLoop);
-}
-
-static 
-IndependentElementSet getFreshFactor(const Query& query,
-                                                std::vector< ref<Expr> > &result) {
-  IndependentElementSet eltsClosure(query.expr);
-  std::vector< std::pair<ref<Expr>, IndependentElementSet> > worklist;
-
-  for (ConstraintManager::const_iterator it = query.constraints.begin(), 
-         ie = query.constraints.end(); it != ie; ++it)
-    worklist.push_back(std::make_pair(*it, IndependentElementSet(*it)));
-
-  // XXX This should be more efficient (in terms of low level copy stuff).
-  bool done = false;
-  do {
-    done = true;
-    std::vector< std::pair<ref<Expr>, IndependentElementSet> > newWorklist;
-    for (std::vector< std::pair<ref<Expr>, IndependentElementSet> >::iterator
-           it = worklist.begin(), ie = worklist.end(); it != ie; ++it) {
-      if (it->second.intersects(eltsClosure)) {
-        if (eltsClosure.add(it->second))
-          done = false; //Means that we have added (z=y)added to (x=y)
-        //Now need to see if there are any (z=?)'s
-        result.push_back(it->first);
-      } else {
-        newWorklist.push_back(*it);
-      }
-    }
-    worklist.swap(newWorklist);
-  } while (!done);
-
-  KLEE_DEBUG(
-    std::set< ref<Expr> > reqset(result.begin(), result.end());
-    errs() << "--\n";
-    errs() << "Q: " << query.expr << "\n";
-    errs() << "\telts: " << IndependentElementSet(query.expr) << "\n";
-    int i = 0;
-    for (ConstraintManager::const_iterator it = query.constraints.begin(),
-        ie = query.constraints.end(); it != ie; ++it) {
-      errs() << "C" << i++ << ": " << *it;
-      errs() << " " << (reqset.count(*it) ? "(required)" : "(independent)") << "\n";
-      errs() << "\telts: " << IndependentElementSet(*it) << "\n";
-    }
-    errs() << "elts closure: " << eltsClosure << "\n";
- );
-
-
-  return eltsClosure;
-}
-
-/*
- * Extracts which arrays are referenced from a particular independent set.  Examines both
- * the actual known array accesses arr[1] plus the undetermined accesses arr[x].
- */
-static
-void calculateArrays(const IndependentElementSet & ie, std::vector<const Array *> &returnVector){
-	//Now need to some how extract the arrays from these pieces...
-	std::set<const Array*> thisSeen;
-	for(std::map<const Array*, ::DenseSet<unsigned> >::const_iterator it = ie.elements.begin(); it != ie.elements.end(); it ++){
-		const Array* arr = it->first;
-		thisSeen.insert(arr);
-	}
-
-	for(std::set<const Array *>::iterator it = ie.wholeObjects.begin(); it != ie.wholeObjects.end(); it ++){
-		const Array* arr = * it;
-		thisSeen.insert(arr);
-	}
-
-	for(std::set<const Array *>::iterator it = thisSeen.begin(); it != thisSeen.end(); it ++){
-		const Array * arr = * it;
-		returnVector.push_back(arr);
-	}
-}
-
 
 class IndependentSolver : public SolverImpl {
 private:
@@ -430,7 +61,7 @@ bool IndependentSolver::computeValidity(const Query& query,
 bool IndependentSolver::computeTruth(const Query& query, bool &isValid) {
   std::vector< ref<Expr> > required;
   IndependentElementSet eltsClosure = 
-    getFreshFactor(query, required);
+	getFreshFactor(query, required);
   ConstraintManager tmp(required);
   return solver->impl->computeTruth(Query(tmp, query.expr), 
                                     isValid);
@@ -439,7 +70,7 @@ bool IndependentSolver::computeTruth(const Query& query, bool &isValid) {
 bool IndependentSolver::computeValue(const Query& query, ref<Expr> &result) {
   std::vector< ref<Expr> > required;
   IndependentElementSet eltsClosure = 
-    getFreshFactor(query, required);
+	getFreshFactor(query, required);
   ConstraintManager tmp(required);
   return solver->impl->computeValue(Query(tmp, query.expr), result);
 }
@@ -449,24 +80,24 @@ bool IndependentSolver::computeValue(const Query& query, ref<Expr> &result) {
  * is in fact correct.
  */
 bool createdPointEvaluatesToTrue(const Query &query,
-               const std::vector<const Array*> &objects,
-               std::vector< std::vector<unsigned char> > &values){
+		const std::vector<const Array*> &objects,
+		std::vector< std::vector<unsigned char> > &values){
 
-       Assignment assign = Assignment(objects, values);
+	Assignment assign = Assignment(objects, values);
 
-       for(ConstraintManager::constraint_iterator it = query.constraints.begin();
-                       it != query.constraints.end(); ++it){
-               ref<Expr> ret = assign.evaluate(*it);
-               if(! isa<ConstantExpr>(ret) || ! cast<ConstantExpr>(ret)->isTrue()){
-                       return false;
-               }
-       }
+	for(ConstraintManager::constraint_iterator it = query.constraints.begin();
+			it != query.constraints.end(); ++it){
+		ref<Expr> ret = assign.evaluate(*it);
+		if(! isa<ConstantExpr>(ret) || ! cast<ConstantExpr>(ret)->isTrue()){
+			return false;
+		}
+	}
 
-       ref<Expr> neg = Expr::createIsZero(query.expr);
-       ref<Expr> q = assign.evaluate(neg);
+	ref<Expr> neg = Expr::createIsZero(query.expr);
+	ref<Expr> q = assign.evaluate(neg);
 
-       assert(isa<ConstantExpr>(q) && "assignment evaluation did not result in constant");
-       return cast<ConstantExpr>(q)->isTrue();
+	assert(isa<ConstantExpr>(q) && "assignment evaluation did not result in constant");
+	return cast<ConstantExpr>(q)->isTrue();
 }
 
 bool IndependentSolver::computeInitialValues(const Query& query,
@@ -494,7 +125,7 @@ bool IndependentSolver::computeInitialValues(const Query& query,
 		ConstraintManager tmp(it->exprs);
 		std::vector<std::vector<unsigned char> > tempValues;
 		if(!solver->impl->computeInitialValues(Query(tmp, ConstantExpr::alloc(0, Expr::Bool)), arraysInFactor, tempValues, hasSolution)){
-			values.clear(); //The above assertion is to make sure we are returning values in correct state
+			values.clear();	//The above assertion is to make sure we are returning values in correct state
 			return false;
 		}else if(!hasSolution){
 			values.clear();//The above assertion is to make sure we are returning values in correct state

--- a/lib/Solver/IndependentSolver.cpp
+++ b/lib/Solver/IndependentSolver.cpp
@@ -16,11 +16,13 @@
 #include "klee/Internal/Support/Debug.h"
 
 #include "klee/util/ExprUtil.h"
+#include "klee/util/Assignment.h"
 
 #include "llvm/Support/raw_ostream.h"
 #include <map>
 #include <vector>
 #include <ostream>
+#include <list>
 
 using namespace klee;
 using namespace llvm;
@@ -62,6 +64,14 @@ public:
     return false;
   }
 
+  std::set<unsigned>::iterator begin(){
+	  return s.begin();
+  }
+
+  std::set<unsigned>::iterator end(){
+  	  return s.end();
+  }
+
   void print(llvm::raw_ostream &os) const {
     bool first = true;
     os << "{";
@@ -86,13 +96,20 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 }
 
 class IndependentElementSet {
-  typedef std::map<const Array*, ::DenseSet<unsigned> > elements_ty;
-  elements_ty elements;
-  std::set<const Array*> wholeObjects;
-
 public:
+  typedef std::map<const Array*, ::DenseSet<unsigned> > elements_ty;
+  elements_ty elements;					//Represents individual elements of array accesses (arr[1])
+  std::set<const Array*> wholeObjects;	//Represents symbolically accessed arrays (arr[x])
+  std::vector<ref<Expr> > exprs;		//All expressions that are associated with this factor
+
   IndependentElementSet() {}
   IndependentElementSet(ref<Expr> e) {
+    exprs.push_back(e);
+    // Track all reads in the program.  Determines whether reads are
+    //concrete or symbolic.  If they are symbolic, "collapses" array
+    //by adding it to wholeObjects.  Otherwise, creates a mapping of
+    //the form Map<array, set<index>> which tracks which parts of the
+    //array are being accessed
     std::vector< ref<ReadExpr> > reads;
     findReads(e, /* visitUpdates= */ true, reads);
     for (unsigned i = 0; i != reads.size(); ++i) {
@@ -106,6 +123,8 @@ public:
 
       if (!wholeObjects.count(array)) {
         if (ConstantExpr *CE = dyn_cast<ConstantExpr>(re->index)) {
+          //if index constant, then add to set of constraints operating
+          //on that array (actually, don't add constraint, just set index)
           ::DenseSet<unsigned> &dis = elements[array];
           dis.add((unsigned) CE->getZExtValue(32));
         } else {
@@ -119,11 +138,18 @@ public:
   }
   IndependentElementSet(const IndependentElementSet &ies) : 
     elements(ies.elements),
-    wholeObjects(ies.wholeObjects) {}    
+    wholeObjects(ies.wholeObjects),
+	exprs(ies.exprs){}
 
   IndependentElementSet &operator=(const IndependentElementSet &ies) {
     elements = ies.elements;
     wholeObjects = ies.wholeObjects;
+
+    for(unsigned i = 0; i < ies.exprs.size(); i ++){
+    	ref<Expr> expr = ies.exprs[i];
+    	exprs.push_back(expr);
+    }
+
     return *this;
   }
 
@@ -160,6 +186,7 @@ public:
 
   // more efficient when this is the smaller set
   bool intersects(const IndependentElementSet &b) {
+	 //If there are any symbolic arrays in our query that b accesses
     for (std::set<const Array*>::iterator it = wholeObjects.begin(), 
            ie = wholeObjects.end(); it != ie; ++it) {
       const Array *array = *it;
@@ -170,9 +197,11 @@ public:
     for (elements_ty::iterator it = elements.begin(), ie = elements.end();
          it != ie; ++it) {
       const Array *array = it->first;
+      //if any of the elements we access are symbolic in b
       if (b.wholeObjects.count(array))
         return true;
       elements_ty::const_iterator it2 = b.elements.find(array);
+      //if any of the elements we access are symbolic in b
       if (it2 != b.elements.end()) {
         if (it->second.intersects(it2->second))
           return true;
@@ -183,6 +212,11 @@ public:
 
   // returns true iff set is changed by addition
   bool add(const IndependentElementSet &b) {
+	for(unsigned i = 0; i < b.exprs.size(); i ++){
+			ref<Expr> expr = b.exprs[i];
+	  	  exprs.push_back(expr);
+	}
+	std::set<const Array*> seen;
     bool modified = false;
     for (std::set<const Array*>::const_iterator it = b.wholeObjects.begin(), 
            ie = b.wholeObjects.end(); it != ie; ++it) {
@@ -207,7 +241,8 @@ public:
         if (it2==elements.end()) {
           modified = true;
           elements.insert(*it);
-        } else {
+        } else {//Now need to see if there are any (z=?)'s
+
           if (it2->second.add(it->second))
             modified = true;
         }
@@ -223,8 +258,73 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   return os;
 }
 
+/*
+ * Breaks down a constraint into all of it's individual pieces, returning a
+ * list of IndependentElementSets or the independent factors.
+ */
+void getAllFactors(const Query& query, std::list<IndependentElementSet> * &factors ){
+	assert(factors && "should not pass in a null vector");
+	ConstantExpr *CE = dyn_cast<ConstantExpr>(query.expr);
+
+	/*
+	 * If the query.expr is false, we can simply ignore it.  Otherwise, we need to
+	 * negate it and add it to the list of factors.
+	 */
+	if(CE){
+		assert(CE && CE->isFalse() && "the expr should always be false and therefore not included in factors");
+	}else{
+		ref<Expr> neg = Expr::createIsZero(query.expr);
+		factors->push_back(IndependentElementSet(neg));
+	}
+
+	for (ConstraintManager::const_iterator it = query.constraints.begin(),
+			ie = query.constraints.end(); it != ie; ++it)
+		//iterate through all the previously separated constraints.  Until we
+		//actually return, factors is treated as a queue of expressions to be
+		//evaluated.  If the queue property isn't maintained, then the exprs
+		//could be returned in an order different from how they came it, negatively
+		//affecting later stages.
+		factors->push_back(IndependentElementSet(*it));
+
+	bool doneLoop = false;
+	do {
+		doneLoop = true;
+		std::list<IndependentElementSet> * done = new std::list<IndependentElementSet>;
+		while(factors->size() > 0){
+			IndependentElementSet current = factors->front();
+			factors->pop_front();
+			std::set<const Array*> seen;
+
+			//This list represents the set of factors that are separate from current.
+			//Those that are not inserted into this list (queue) intersect with current.
+			std::list<IndependentElementSet> *keep = new std::list<IndependentElementSet>;
+			while(factors->size() > 0){
+				IndependentElementSet compare = factors->front();
+				factors->pop_front();
+				if(current.intersects(compare)){
+					if (current.add(compare)){
+						/*
+						 * Means that we have added (z=y)added to (x=y)
+						 * Now need to see if there are any (z=?)'s
+						 */
+						 doneLoop = false;
+					}
+				}else{
+					keep->push_back(compare);
+				}
+			}
+			done->push_back(current);
+			delete factors;
+			factors = keep;
+
+		}
+		delete factors;
+		factors = done;
+	}while(!doneLoop);
+}
+
 static 
-IndependentElementSet getIndependentConstraints(const Query& query,
+IndependentElementSet getFreshFactor(const Query& query,
                                                 std::vector< ref<Expr> > &result) {
   IndependentElementSet eltsClosure(query.expr);
   std::vector< std::pair<ref<Expr>, IndependentElementSet> > worklist;
@@ -242,7 +342,8 @@ IndependentElementSet getIndependentConstraints(const Query& query,
            it = worklist.begin(), ie = worklist.end(); it != ie; ++it) {
       if (it->second.intersects(eltsClosure)) {
         if (eltsClosure.add(it->second))
-          done = false;
+          done = false; //Means that we have added (z=y)added to (x=y)
+        //Now need to see if there are any (z=?)'s
         result.push_back(it->first);
       } else {
         newWorklist.push_back(*it);
@@ -270,6 +371,31 @@ IndependentElementSet getIndependentConstraints(const Query& query,
   return eltsClosure;
 }
 
+/*
+ * Extracts which arrays are referenced from a particular independent set.  Examines both
+ * the actual known array accesses arr[1] plus the undetermined accesses arr[x].
+ */
+static
+void calculateArrays(const IndependentElementSet & ie, std::vector<const Array *> &returnVector){
+	//Now need to some how extract the arrays from these pieces...
+	std::set<const Array*> thisSeen;
+	for(std::map<const Array*, ::DenseSet<unsigned> >::const_iterator it = ie.elements.begin(); it != ie.elements.end(); it ++){
+		const Array* arr = it->first;
+		thisSeen.insert(arr);
+	}
+
+	for(std::set<const Array *>::iterator it = ie.wholeObjects.begin(); it != ie.wholeObjects.end(); it ++){
+		const Array* arr = * it;
+		thisSeen.insert(arr);
+	}
+
+	for(std::set<const Array *>::iterator it = thisSeen.begin(); it != thisSeen.end(); it ++){
+		const Array * arr = * it;
+		returnVector.push_back(arr);
+	}
+}
+
+
 class IndependentSolver : public SolverImpl {
 private:
   Solver *solver;
@@ -285,10 +411,7 @@ public:
   bool computeInitialValues(const Query& query,
                             const std::vector<const Array*> &objects,
                             std::vector< std::vector<unsigned char> > &values,
-                            bool &hasSolution) {
-    return solver->impl->computeInitialValues(query, objects, values,
-                                              hasSolution);
-  }
+                            bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query&);
   void setCoreSolverTimeout(double timeout);
@@ -298,7 +421,7 @@ bool IndependentSolver::computeValidity(const Query& query,
                                         Solver::Validity &result) {
   std::vector< ref<Expr> > required;
   IndependentElementSet eltsClosure =
-    getIndependentConstraints(query, required);
+    getFreshFactor(query, required);
   ConstraintManager tmp(required);
   return solver->impl->computeValidity(Query(tmp, query.expr), 
                                        result);
@@ -307,7 +430,7 @@ bool IndependentSolver::computeValidity(const Query& query,
 bool IndependentSolver::computeTruth(const Query& query, bool &isValid) {
   std::vector< ref<Expr> > required;
   IndependentElementSet eltsClosure = 
-    getIndependentConstraints(query, required);
+    getFreshFactor(query, required);
   ConstraintManager tmp(required);
   return solver->impl->computeTruth(Query(tmp, query.expr), 
                                     isValid);
@@ -316,9 +439,106 @@ bool IndependentSolver::computeTruth(const Query& query, bool &isValid) {
 bool IndependentSolver::computeValue(const Query& query, ref<Expr> &result) {
   std::vector< ref<Expr> > required;
   IndependentElementSet eltsClosure = 
-    getIndependentConstraints(query, required);
+    getFreshFactor(query, required);
   ConstraintManager tmp(required);
   return solver->impl->computeValue(Query(tmp, query.expr), result);
+}
+
+/*
+ * Used only for assertions to make sure point created during computeInitialValues
+ * is in fact correct.
+ */
+bool createdPointEvaluatesToTrue(const Query &query,
+               const std::vector<const Array*> &objects,
+               std::vector< std::vector<unsigned char> > &values){
+
+       Assignment assign = Assignment(objects, values);
+
+       for(ConstraintManager::constraint_iterator it = query.constraints.begin();
+                       it != query.constraints.end(); ++it){
+               ref<Expr> ret = assign.evaluate(*it);
+               if(! isa<ConstantExpr>(ret) || ! cast<ConstantExpr>(ret)->isTrue()){
+                       return false;
+               }
+       }
+
+       ref<Expr> neg = Expr::createIsZero(query.expr);
+       ref<Expr> q = assign.evaluate(neg);
+
+       assert(isa<ConstantExpr>(q) && "assignment evaluation did not result in constant");
+       return cast<ConstantExpr>(q)->isTrue();
+}
+
+bool IndependentSolver::computeInitialValues(const Query& query,
+		const std::vector<const Array*> &objects,
+		std::vector< std::vector<unsigned char> > &values,
+		bool &hasSolution){
+
+	std::list<IndependentElementSet> * factors = new std::list<IndependentElementSet>;
+	getAllFactors(query, factors);
+
+	//Used to rearrange all of the answers into the correct order
+	std::map<const Array*, std::vector<unsigned char> > retMap;
+
+	for (std::list<IndependentElementSet>::iterator it = factors->begin(); it != factors->end(); ++it) {
+
+		std::vector<const Array*> arraysInFactor;
+		calculateArrays(*it, arraysInFactor);
+
+		//Going to use this as the "fresh" expression for the Query() invocation below
+		assert(it->exprs.size() >= 1 && "No null/empty factors");
+		if(arraysInFactor.size() == 0){
+			continue;
+		}
+
+		ConstraintManager tmp(it->exprs);
+		std::vector<std::vector<unsigned char> > tempValues;
+		if(!solver->impl->computeInitialValues(Query(tmp, ConstantExpr::alloc(0, Expr::Bool)), arraysInFactor, tempValues, hasSolution)){
+			values.clear(); //The above assertion is to make sure we are returning values in correct state
+			return false;
+		}else if(!hasSolution){
+			values.clear();//The above assertion is to make sure we are returning values in correct state
+			return true;
+		}else{
+			assert(tempValues.size() == arraysInFactor.size() && "Should be equal number arrays and answers");
+			for(unsigned i = 0; i < tempValues.size(); i++){
+				if(retMap.count(arraysInFactor[i])){
+					//We already have an array with some partially correct answers,
+					//so we need to place the answers to the new query into the right
+					//spot while avoiding the undetermined values also in the array
+					std::vector<unsigned char> * tempPtr = &retMap[arraysInFactor[i]];
+					assert(tempPtr->size() == tempValues[i].size() && "we're talking about the same array here");
+					::DenseSet<unsigned> * ds = &(it->elements[arraysInFactor[i]]);
+					for(std::set<unsigned>::iterator it2 = ds->begin(); it2 != ds->end(); it2++){
+						unsigned index = * it2;
+						(* tempPtr)[index] = tempValues[i][index];
+					}
+				}else{
+					//Dump all the new values into the array
+					retMap[arraysInFactor[i]] = tempValues[i];
+				}
+			}
+		}
+	}
+
+	for(std::vector<const Array *>::const_iterator it = objects.begin(); it != objects.end(); it++){
+		const Array * arr = * it;
+		if(!retMap.count(arr)){
+			//this means we have an array that is somehow related to the
+			//constraint, but whose values aren't actually required to
+			//satisfy the query.
+			std::vector<unsigned char> ret(arr->size);
+			values.push_back(ret);
+		}else{
+			values.push_back(retMap[arr]);
+		}
+	}
+
+	assert(createdPointEvaluatesToTrue(query, objects, values) && "should satisfy the equation");
+
+	delete factors;
+	return true;
+
 }
 
 SolverImpl::SolverRunStatus IndependentSolver::getOperationStatusCode() {

--- a/unittests/Expr/ExprTest.cpp
+++ b/unittests/Expr/ExprTest.cpp
@@ -29,9 +29,9 @@ TEST(ExprTest, BasicConstruction) {
 }
 
 TEST(ExprTest, ConcatExtract) {
-  Array *array = new Array("arr0", 256);
+  Array *array = Array::CreateArray("arr0", 256);
   ref<Expr> read8 = Expr::createTempRead(array, 8);
-  Array *array2 = new Array("arr1", 256);
+  Array *array2 = Array::CreateArray("arr1", 256);
   ref<Expr> read8_2 = Expr::createTempRead(array2, 8);
   ref<Expr> c100 = getConstant(100, 8);
 
@@ -81,10 +81,10 @@ TEST(ExprTest, ConcatExtract) {
 }
 
 TEST(ExprTest, ExtractConcat) {
-  Array *array = new Array("arr2", 256);
+  Array *array = Array::CreateArray("arr2", 256);
   ref<Expr> read64 = Expr::createTempRead(array, 64);
 
-  Array *array2 = new Array("arr3", 256);
+  Array *array2 = Array::CreateArray("arr3", 256);
   ref<Expr> read8_2 = Expr::createTempRead(array2, 8);
   
   ref<Expr> extract1 = ExtractExpr::create(read64, 36, 4);

--- a/unittests/Solver/SolverTest.cpp
+++ b/unittests/Solver/SolverTest.cpp
@@ -46,7 +46,7 @@ void testOperation(Solver &solver,
 
     unsigned size = Expr::getMinBytesForWidth(operandWidth);
     static uint64_t id = 0;
-    Array *array = new Array("arr" + llvm::utostr(++id), size);
+    Array *array = Array::CreateArray("arr" + llvm::utostr(++id), size);
     symbolicArgs.push_back(Expr::CreateArg(Expr::createTempRead(array, 
                                                                 operandWidth)));
   }


### PR DESCRIPTION
The previous implementation simply passes the entire constraint forward
without any factoring of the constraint at all.  This is a problem
since it is highly likely that there are cached solutions to pieces
of the constraint.  The new implementation breaks the entire
constraint down into its requisite factors and passes each piece
forward, one by one, down the solver chain.  After an answer is
returned, it is integrated into a larger solution.  Since, by
definition, no factor can affect another, we can safely create a
solution to the larger constraint from the answers of its smaller
pieces.

In addition, the command line option -max-forks-terminate, was added to
provide a fair test of the optimization.  The command line option works
by terminating the exploration, and dumping the explored states upon
forking a certain number of times.  This allows for a fair, head to head
comparison of the improved getInitialValues relative to the old 
implementation.

After completion, the changes:
1) Pass all provided tests (other than ones that were expected to fail)
2) Have been verified via -debug-validate-solver by a complete run through of 9 members of the bin-utils for
     --search=dfs with a halt being placed, and states dumped, after 500 forks
     --search=default with a halt being placed, and the states dumped, after 1000 forks
3) Achieved significant speedup on test programs
     --search=dfs
            a. On average 10% improvement (for example strings saw a decrease from 252 seconds to 162 seconds)
            b. Worst case (objcopy) saw decrease in performance of 27% (950 seconds to 1287 seconds)
     --search=default
            a. On average 48% improvement (for example regElf saw a decrease from 1078 seconds to 884 seconds)
            b. Worse case (objcopy) saw decrease in performance of 15% (862 seconds to 1022 seconds)