### PR TITLE
Previous point and quick cache

### DIFF
--- a/include/klee/Constraints.h
+++ b/include/klee/Constraints.h
@@ -65,6 +65,10 @@ public:
     return constraints == other.constraints;
   }
   
+  ref<Expr> get(unsigned index) const{
+	  return constraints[index];
+  }
+
 private:
   std::vector< ref<Expr> > constraints;
 

--- a/include/klee/Expr.h
+++ b/include/klee/Expr.h
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <set>
 #include <vector>
+#include <map>
 
 namespace llvm {
   class Type;
@@ -600,55 +601,92 @@ private:
 
 class Array {
 public:
-  const std::string name;
-  // FIXME: Not 64-bit clean.
-  unsigned size;  
+	//Name of the array
+	const std::string name;
 
-  /// constantValues - The constant initial values for this array, or empty for
-  /// a symbolic array. If non-empty, this size of this array is equivalent to
-  /// the array size.
-  const std::vector< ref<ConstantExpr> > constantValues;
+	// FIXME: Not 64-bit clean.
+	const unsigned size;
 
-  Expr::Width domain, range;
+	//Domain is how many bits can be used to access the array [32 bits]
+	//Range is the size (in bits) of the number stored there (array of bytes -> 8)
+	const Expr::Width domain, range;
+
+	/// constantValues - The constant initial values for this array, or empty for
+	/// a symbolic array. If non-empty, this size of this array is equivalent to
+	/// the array size.
+	const std::vector<ref<ConstantExpr> > constantValues;
+
+	/// Array - Construct a new array object.
+	///
+	/// \param _name - The name for this array. Names should generally be unique
+	/// across an application, but this is not necessary for correctness, except
+	/// when printing expressions. When expressions are printed the output will
+	/// not parse correctly since two arrays with the same name cannot be
+	/// distinguished once printed.
+
+private:
+	unsigned hashValue;
+
+	/*
+	 * The symbolic array singleton map is necessary to prevent aliasing issues on arrays.
+	 * A lot of the Solvers use maps such as <const * Array, std::vector<unsigned>>.
+	 * This causes problems because stored answers can't be easily recovered.
+	 * Even worse, in read expressions, such as (read array 32), array is a pointer,
+	 * meaning actual solutions don't "work" because the two instances of array
+	 * aren't recognized as the same.
+	 */
+	static std::map<unsigned, const Array *> symbolicArraySingletonMap;
+
+	//This shouldn't be allowed since it's a singleton class
+	Array(const Array& array);
+
+	//This shouldn't be allowed since it's a singleton class
+	Array& operator =(const Array& array);
+
+	~Array();
+
+	Array(const std::string &_name, uint64_t _size,
+			const ref<ConstantExpr> *constantValuesBegin = 0,
+			const ref<ConstantExpr> *constantValuesEnd = 0,
+			Expr::Width _domain = Expr::Int32, Expr::Width _range = Expr::Int8)
+	: name(_name), size(_size), domain(_domain), range(_range),
+	  constantValues(constantValuesBegin, constantValuesEnd)
+	{
+		assert((isSymbolicArray() || constantValues.size() == size) &&
+				"Invalid size for constant array!");
+		computeHash();
+#ifndef NDEBUG
+		for (const ref<ConstantExpr> *it = constantValuesBegin;
+				it != constantValuesEnd; ++it)
+			assert((*it)->getWidth() == getRange() &&
+					"Invalid initial constant value!");
+#endif //NDEBUG
+	}
 
 public:
-  /// Array - Construct a new array object.
-  ///
-  /// \param _name - The name for this array. Names should generally be unique
-  /// across an application, but this is not necessary for correctness, except
-  /// when printing expressions. When expressions are printed the output will
-  /// not parse correctly since two arrays with the same name cannot be
-  /// distinguished once printed.
-  Array(const std::string &_name, uint64_t _size, 
-        const ref<ConstantExpr> *constantValuesBegin = 0,
-        const ref<ConstantExpr> *constantValuesEnd = 0,
-        Expr::Width _domain = Expr::Int32, Expr::Width _range = Expr::Int8)
-    : name(_name), size(_size), 
-      constantValues(constantValuesBegin, constantValuesEnd),
-      domain(_domain), range(_range) {
-    assert((isSymbolicArray() || constantValues.size() == size) &&
-           "Invalid size for constant array!");
-    computeHash();
-#ifndef NDEBUG
-    for (const ref<ConstantExpr> *it = constantValuesBegin;
-         it != constantValuesEnd; ++it)
-      assert((*it)->getWidth() == getRange() &&
-             "Invalid initial constant value!");
-#endif
-  }
-  ~Array();
+	bool isSymbolicArray() const { return constantValues.empty(); }
+	bool isConstantArray() const { return !isSymbolicArray(); }
 
-  bool isSymbolicArray() const { return constantValues.empty(); }
-  bool isConstantArray() const { return !isSymbolicArray(); }
+	const std::string getName() const { return name; }
+	unsigned getSize() const { return size; }
+	Expr::Width getDomain() const { return domain; }
+	Expr::Width getRange() const { return range; }
 
-  Expr::Width getDomain() const { return domain; }
-  Expr::Width getRange() const { return range; }
-  
-  unsigned computeHash();
-  unsigned hash() const { return hashValue; }
-   
-private:
-  unsigned hashValue;
+	unsigned computeHash();
+	unsigned hash() const { return hashValue; }
+
+	/*
+	 * Fairly simple idea.  Since by defn (see Array), symbolic arrays
+	 * have constant values of size 0.  Concrete Arrays have their respective
+	 * values stored in each element.  Therefore, each incoming call is tested.
+	 * An array is created and, if it's concrete, it's simply returned.  If
+	 * instead it is symbolic, then a map is checked to see if it was created
+	 * before, so there is only a single instance floating out there.
+	 */
+	static const Array * CreateArray(const std::string &_name, uint64_t _size,
+			const ref<ConstantExpr> *constantValuesBegin = 0,
+			const ref<ConstantExpr> *constantValuesEnd = 0,
+			Expr::Width _domain = Expr::Int32, Expr::Width _range = Expr::Int8);
 };
 
 /// Class representing a complete list of updates into an array.

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2924,7 +2924,7 @@ ref<Expr> Executor::replaceReadWithSymbolic(ExecutionState &state,
   // and return it.
   
   static unsigned id;
-  const Array *array = new Array("rrws_arr" + llvm::utostr(++id), 
+  const Array *array = Array::CreateArray("rrws_arr" + llvm::utostr(++id),
                                  Expr::getMinBytesForWidth(e->getWidth()));
   ref<Expr> res = Expr::createTempRead(array, e->getWidth());
   ref<Expr> eq = NotOptimizedExpr::create(EqExpr::create(e, res));
@@ -3263,7 +3263,7 @@ void Executor::executeMakeSymbolic(ExecutionState &state,
     while (!state.arrayNames.insert(uniqueName).second) {
       uniqueName = name + "_" + llvm::utostr(++id);
     }
-    const Array *array = new Array(uniqueName, mo->size);
+    const Array *array = Array::CreateArray(uniqueName, mo->size);
     bindObjectInState(state, mo, false, array);
     state.addSymbolic(mo, array);
     

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -113,7 +113,7 @@ ObjectState::ObjectState(const MemoryObject *mo)
   if (!UseConstantArrays) {
     // FIXME: Leaked.
     static unsigned id = 0;
-    const Array *array = new Array("tmp_arr" + llvm::utostr(++id), size);
+    const Array *array = Array::CreateArray("tmp_arr" + llvm::utostr(++id), size);
     updates = UpdateList(array, 0);
   }
   memset(concreteStore, 0, size);
@@ -222,7 +222,7 @@ const UpdateList &ObjectState::getUpdates() const {
     // Start a new update list.
     // FIXME: Leaked.
     static unsigned id = 0;
-    const Array *array = new Array("const_arr" + llvm::utostr(++id), size,
+    const Array *array = Array::CreateArray("const_arr" + llvm::utostr(++id), size,
                                    &Contents[0],
                                    &Contents[0] + Contents.size());
     updates = UpdateList(array, 0);

--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -494,6 +494,30 @@ unsigned Array::computeHash() {
   return hashValue; 
 }
 
+std::map<unsigned, const Array *> Array::symbolicArraySingletonMap;
+
+const Array * Array::CreateArray(const std::string &_name, uint64_t _size,
+		const ref<ConstantExpr> *constantValuesBegin,
+		const ref<ConstantExpr> *constantValuesEnd,
+		Expr::Width _domain, Expr::Width _range){
+
+	const Array * array = new Array(_name, _size, constantValuesBegin, constantValuesEnd, _domain,_range);
+	if(array->constantValues.size() == 0){
+		//means is a symbolic array and we should look up the values;
+		unsigned hash = array->hash();
+		if(Array::symbolicArraySingletonMap.count(hash)){
+			delete array;
+			return Array::symbolicArraySingletonMap[hash];
+		}else{
+			Array::symbolicArraySingletonMap[hash] = array;
+			return array;
+		}
+	}else{
+		return array;
+	}
+	return 0;
+}
+
 /***/
 
 ref<Expr> ReadExpr::create(const UpdateList &ul, ref<Expr> index) {

--- a/lib/Expr/Parser.cpp
+++ b/lib/Expr/Parser.cpp
@@ -519,12 +519,12 @@ DeclResult ParserImpl::ParseArrayDecl() {
 
   // FIXME: Array should take domain and range.
   const Identifier *Label = GetOrCreateIdentifier(Name);
-  Array *Root;
+  const Array *Root;
   if (!Values.empty())
-    Root = new Array(Label->Name, Size.get(),
+    Root = Array::CreateArray(Label->Name, Size.get(),
                      &Values[0], &Values[0] + Values.size());
   else
-    Root = new Array(Label->Name, Size.get());
+    Root = Array::CreateArray(Label->Name, Size.get());
   ArrayDecl *AD = new ArrayDecl(Label, Size.get(), 
                                 DomainType.get(), RangeType.get(), Root);
 
@@ -1306,7 +1306,7 @@ VersionResult ParserImpl::ParseVersionSpecifier() {
   VersionResult Res = ParseVersion();
   // Define update list to avoid use-of-undef errors.
   if (!Res.isValid()) {
-    Res = VersionResult(true, UpdateList(new Array("", 0), NULL));
+    Res = VersionResult(true, UpdateList(Array::CreateArray("", 0), NULL));
   }
   
   if (Label)

--- a/lib/SMT/SMTParser.cpp
+++ b/lib/SMT/SMTParser.cpp
@@ -165,7 +165,7 @@ void SMTParser::DeclareExpr(std::string name, Expr::Width w) {
   std::cout << "Declaring " << name << " of width " << w << "\n";
 #endif
   
-  Array *arr = new Array(name, w / 8);
+  const Array *arr = Array::CreateArray(name, w / 8);
   
   ref<Expr> *kids = new ref<Expr>[w/8];
   for (unsigned i=0; i < w/8; i++)

--- a/unittests/Expr/ExprTest.cpp
+++ b/unittests/Expr/ExprTest.cpp
@@ -29,9 +29,9 @@ TEST(ExprTest, BasicConstruction) {
 }
 
 TEST(ExprTest, ConcatExtract) {
-  Array *array = new Array("arr0", 256);
+  const Array *array = Array::CreateArray("arr0", 256);
   ref<Expr> read8 = Expr::createTempRead(array, 8);
-  Array *array2 = new Array("arr1", 256);
+  const Array *array2 = Array::CreateArray("arr1", 256);
   ref<Expr> read8_2 = Expr::createTempRead(array2, 8);
   ref<Expr> c100 = getConstant(100, 8);
 
@@ -81,10 +81,10 @@ TEST(ExprTest, ConcatExtract) {
 }
 
 TEST(ExprTest, ExtractConcat) {
-  Array *array = new Array("arr2", 256);
+  const Array *array = Array::CreateArray("arr2", 256);
   ref<Expr> read64 = Expr::createTempRead(array, 64);
 
-  Array *array2 = new Array("arr3", 256);
+  const Array *array2 = Array::CreateArray("arr3", 256);
   ref<Expr> read8_2 = Expr::createTempRead(array2, 8);
   
   ref<Expr> extract1 = ExtractExpr::create(read64, 36, 4);

--- a/unittests/Solver/SolverTest.cpp
+++ b/unittests/Solver/SolverTest.cpp
@@ -46,7 +46,7 @@ void testOperation(Solver &solver,
 
     unsigned size = Expr::getMinBytesForWidth(operandWidth);
     static uint64_t id = 0;
-    Array *array = new Array("arr" + llvm::utostr(++id), size);
+    const Array *array = Array::CreateArray("arr" + llvm::utostr(++id), size);
     symbolicArgs.push_back(Expr::CreateArg(Expr::createTempRead(array, 
                                                                 operandWidth)));
   }


### PR DESCRIPTION
This commit is conceptually orthogonal to the other pull request submitted on 2/16/15 called IndependentSolverGetIntialValues.  In actuality, however, they play off of each other for a combined effect superior to either one individually and involve a lot of the same files.

This particular commit targets the CexCachingSolver so that the UBTree is called less frequently. Specifically, the two optimizations are a "QuickCache" that determines when two constraints are identical. The cache stores solutions so that they can be used in the future. The second optimizations tests the parent state's solution on every newly created state. This will work, by defn, at least
50% of the time. It also prevents the UBTree's invocation, which can be costly.

When the improvements present in this in pull request are combined with the IndependentSolverGetInitalValues pull request, the overall time spent in the default search is on average, almost halved.

After completion, the changes:
1) Pass all provided tests (other than ones that were expected to fail)
2) Have been verified via -debug-validate-solver by a complete run through
of 9 members of the bin-utils for
--search=dfs with a halt being placed, and states dumped, after 500 forks
--search=default with a halt being placed, and the states dumped, after 1000 forks
3) Achieved significant speedup on test programs
--search=dfs
a. On average 93% improvement (for example, nm-new saw a decrease from 1200 seconds to 670 seconds)
b. Worst case 13% improvement (obj-copy when from 950 seconds to 835 seconds)
--search=default
a. On average 85% improvement (for example, addr2line saw a decrease from 1325 seconds to 717 seconds)
b. Worst case 29% improvement (ar went from 560 seconds to 435 seconds)

