### PR TITLE
Added a max-forks-terminate option to the commandline to allow for

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -265,6 +265,11 @@ namespace {
   MaxMemoryInhibit("max-memory-inhibit",
             cl::desc("Inhibit forking at memory cap (vs. random terminate) (default=on)"),
             cl::init(true));
+
+  cl::opt<unsigned>
+  MaxForksTerminate("max-forks-terminate",
+            cl::desc("Only fork this many times and then dump states (default=0 (off))"),
+            cl::init(0));
 }
 
 
@@ -796,6 +801,10 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
         }
       }
     }
+  }
+
+  if(MaxForksTerminate && stats::forks >= MaxForksTerminate){
+	  haltExecution = true;
   }
 
   // Fix branch in only-replay-seed mode, if we don't have both true


### PR DESCRIPTION
fair, head to head comparison of different Klee implementations.

The max-forks-terminate option kills exploration after reaching a
certain number of forks.  Klee then begins to dump states and wrap up
execution.  This metric is included so we can time how long it takes a
particular implementation to reach a certain depth of exploration.