### PR TITLE
Use monotonic clock for timestamps, and introduce optional higher-performance coarse clocks

### DIFF
--- a/include/klee/Internal/System/Time.h
+++ b/include/klee/Internal/System/Time.h
@@ -15,14 +15,22 @@
 namespace klee {
   namespace util {
 
-    /// Seconds spent by this process in user mode.
+    /// Seconds spent by this process in user mode (usually at least microsecond precision).
     double getUserTime();
 
-    /// Wall time in seconds.
+    /// Wall time in seconds (usually at least microsecond precision).
     double getWallTime();
 
-    /// Wall time as TimeValue object.
+    /// Wall time in seconds (usually millisecond precision).
+    /// If possible, uses cheaper, coarse and monotonic clock. Neither is guaranteed.
+    double getWallTimeCoarse();
+
+    /// Wall time as TimeValue object (usually at least microsecond precision).
     llvm::sys::TimeValue getWallTimeVal();
+
+    /// Wall time as TimeValue object (usually millisecond precision).
+    /// If possible, uses cheaper, coarse and monotonic clock. Neither is guaranteed.
+    llvm::sys::TimeValue getWallTimeValCoarse();
   }
 }
 

--- a/include/klee/Internal/System/Time.h
+++ b/include/klee/Internal/System/Time.h
@@ -10,10 +10,19 @@
 #ifndef KLEE_UTIL_TIME_H
 #define KLEE_UTIL_TIME_H
 
+#include <llvm/Support/TimeValue.h>
+
 namespace klee {
   namespace util {
+
+    /// Seconds spent by this process in user mode.
     double getUserTime();
+
+    /// Wall time in seconds.
     double getWallTime();
+
+    /// Wall time as TimeValue object.
+    llvm::sys::TimeValue getWallTimeVal();
   }
 }
 

--- a/lib/Core/ExecutorTimerInfo.h
+++ b/lib/Core/ExecutorTimerInfo.h
@@ -31,7 +31,7 @@ public:
   TimerInfo(Timer *_timer, double _rate)
     : timer(_timer),
       rate(_rate),
-      nextFireTime(util::getWallTime() + rate) {}
+      nextFireTime(util::getWallTimeCoarse() + rate) {}
   ~TimerInfo() { delete timer; }
 };
 

--- a/lib/Core/ExecutorTimers.cpp
+++ b/lib/Core/ExecutorTimers.cpp
@@ -189,7 +189,7 @@ void Executor::processTimers(ExecutionState *current,
     }
 
     if (!timers.empty()) {
-      double time = util::getWallTime();
+      double time = util::getWallTimeCoarse();
 
       for (std::vector<TimerInfo*>::iterator it = timers.begin(), 
              ie = timers.end(); it != ie; ++it) {

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -186,7 +186,7 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
     objectFilename(_objectFilename),
     statsFile(0),
     istatsFile(0),
-    startWallTime(util::getWallTime()),
+    startWallTime(util::getWallTimeCoarse()),
     numBranches(0),
     fullBranches(0),
     partialBranches(0),
@@ -402,7 +402,7 @@ void StatsTracker::writeStatsHeader() {
 }
 
 double StatsTracker::elapsed() {
-  return util::getWallTime() - startWallTime;
+  return util::getWallTimeCoarse() - startWallTime;
 }
 
 void StatsTracker::writeStatsLine() {

--- a/lib/Core/TimingSolver.cpp
+++ b/lib/Core/TimingSolver.cpp
@@ -13,10 +13,11 @@
 #include "klee/ExecutionState.h"
 #include "klee/Solver.h"
 #include "klee/Statistics.h"
+#include "klee/Internal/System/Time.h"
 
 #include "CoreStats.h"
 
-#include "llvm/Support/Process.h"
+#include "llvm/Support/TimeValue.h"
 
 using namespace klee;
 using namespace llvm;
@@ -31,15 +32,14 @@ bool TimingSolver::evaluate(const ExecutionState& state, ref<Expr> expr,
     return true;
   }
 
-  sys::TimeValue now(0,0),user(0,0),delta(0,0),sys(0,0);
-  sys::Process::GetTimeUsage(now,user,sys);
+  sys::TimeValue now = util::getWallTimeVal();
 
   if (simplifyExprs)
     expr = state.constraints.simplifyExpr(expr);
 
   bool success = solver->evaluate(Query(state.constraints, expr), result);
 
-  sys::Process::GetTimeUsage(delta,user,sys);
+  sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
   stats::solverTime += delta.usec();
   state.queryCost += delta.usec()/1000000.;
@@ -55,15 +55,14 @@ bool TimingSolver::mustBeTrue(const ExecutionState& state, ref<Expr> expr,
     return true;
   }
 
-  sys::TimeValue now(0,0),user(0,0),delta(0,0),sys(0,0);
-  sys::Process::GetTimeUsage(now,user,sys);
+  sys::TimeValue now = util::getWallTimeVal();
 
   if (simplifyExprs)
     expr = state.constraints.simplifyExpr(expr);
 
   bool success = solver->mustBeTrue(Query(state.constraints, expr), result);
 
-  sys::Process::GetTimeUsage(delta,user,sys);
+  sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
   stats::solverTime += delta.usec();
   state.queryCost += delta.usec()/1000000.;
@@ -102,15 +101,14 @@ bool TimingSolver::getValue(const ExecutionState& state, ref<Expr> expr,
     return true;
   }
   
-  sys::TimeValue now(0,0),user(0,0),delta(0,0),sys(0,0);
-  sys::Process::GetTimeUsage(now,user,sys);
+  sys::TimeValue now = util::getWallTimeVal();
 
   if (simplifyExprs)
     expr = state.constraints.simplifyExpr(expr);
 
   bool success = solver->getValue(Query(state.constraints, expr), result);
 
-  sys::Process::GetTimeUsage(delta,user,sys);
+  sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
   stats::solverTime += delta.usec();
   state.queryCost += delta.usec()/1000000.;
@@ -127,14 +125,13 @@ TimingSolver::getInitialValues(const ExecutionState& state,
   if (objects.empty())
     return true;
 
-  sys::TimeValue now(0,0),user(0,0),delta(0,0),sys(0,0);
-  sys::Process::GetTimeUsage(now,user,sys);
+  sys::TimeValue now = util::getWallTimeVal();
 
   bool success = solver->getInitialValues(Query(state.constraints,
                                                 ConstantExpr::alloc(0, Expr::Bool)), 
                                           objects, result);
   
-  sys::Process::GetTimeUsage(delta,user,sys);
+  sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
   stats::solverTime += delta.usec();
   state.queryCost += delta.usec()/1000000.;

--- a/lib/Support/Time.cpp
+++ b/lib/Support/Time.cpp
@@ -13,6 +13,9 @@
 #include "llvm/Support/TimeValue.h"
 #include "llvm/Support/Process.h"
 
+#include <sys/time.h>
+#include <time.h>
+
 using namespace llvm;
 using namespace klee;
 
@@ -27,6 +30,29 @@ double util::getWallTime() {
   return (now.seconds() + ((double) now.nanoseconds() * 1e-9));
 }
 
+double util::getWallTimeCoarse() {
+  sys::TimeValue now = getWallTimeValCoarse();
+  return (now.seconds() + ((double) now.nanoseconds() * 1e-9));
+}
+
 sys::TimeValue util::getWallTimeVal() {
+  // prefer clock_gettime(CLOCK_MONOTONIC) to gettimeofday()
+#if defined(CLOCK_MONOTONIC)
+  timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return sys::TimeValue(ts.tv_sec, ts.tv_nsec);
+#else
   return sys::TimeValue::now();
+#endif
+}
+
+sys::TimeValue util::getWallTimeValCoarse() {
+  //TODO check support for other platforms
+#if defined(CLOCK_MONOTONIC_COARSE)
+  timespec ts;
+  clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
+  return sys::TimeValue(ts.tv_sec, ts.tv_nsec);
+#else
+  return getWallTimeVal();
+#endif
 }

--- a/lib/Support/Time.cpp
+++ b/lib/Support/Time.cpp
@@ -10,6 +10,7 @@
 #include "klee/Config/Version.h"
 #include "klee/Internal/System/Time.h"
 
+#include "llvm/Support/TimeValue.h"
 #include "llvm/Support/Process.h"
 
 using namespace llvm;
@@ -22,7 +23,10 @@ double util::getUserTime() {
 }
 
 double util::getWallTime() {
-  sys::TimeValue now(0,0),user(0,0),sys(0,0);
-  sys::Process::GetTimeUsage(now,user,sys);
-  return (now.seconds() + (double) now.nanoseconds() * 1e-9);
+  sys::TimeValue now = getWallTimeVal();
+  return (now.seconds() + ((double) now.nanoseconds() * 1e-9));
+}
+
+sys::TimeValue util::getWallTimeVal() {
+  return sys::TimeValue::now();
 }

--- a/lib/Support/Timer.cpp
+++ b/lib/Support/Timer.cpp
@@ -10,19 +10,15 @@
 #include "klee/Config/Version.h"
 #include "klee/Internal/Support/Timer.h"
 
-#include "llvm/Support/Process.h"
+#include "klee/Internal/System/Time.h"
 
 using namespace klee;
 using namespace llvm;
 
 WallTimer::WallTimer() {
-  sys::TimeValue now(0,0),user(0,0),sys(0,0);
-  sys::Process::GetTimeUsage(now,user,sys);
-  startMicroseconds = now.usec();
+  startMicroseconds = util::getWallTimeVal().usec();
 }
 
 uint64_t WallTimer::check() {
-  sys::TimeValue now(0,0),user(0,0),sys(0,0);
-  sys::Process::GetTimeUsage(now,user,sys);
-  return now.usec() - startMicroseconds;
+  return util::getWallTimeVal().usec() - startMicroseconds;
 }

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -424,7 +424,7 @@ void KleeHandler::processTestCase(const ExecutionState &state,
     if (!success)
       klee_warning("unable to get symbolic solution, losing test case");
 
-    double start_time = util::getWallTime();
+    double start_time = util::getWallTimeCoarse();
 
     unsigned id = ++m_testIndex;
 
@@ -528,7 +528,7 @@ void KleeHandler::processTestCase(const ExecutionState &state,
       m_interpreter->setHaltExecution(true);
 
     if (WriteTestInfo) {
-      double elapsed_time = util::getWallTime() - start_time;
+      double elapsed_time = util::getWallTimeCoarse() - start_time;
       llvm::raw_ostream *f = openTestFile("info", id);
       *f << "Time to generate test case: " 
          << elapsed_time << "s\n";
@@ -1168,7 +1168,7 @@ int main(int argc, char **argv, char **envp) {
       fflush(stderr);
       sys::SetInterruptFunction(interrupt_handle_watchdog);
 
-      double nextStep = util::getWallTime() + MaxTime*1.1;
+      double nextStep = util::getWallTimeCoarse() + MaxTime*1.1;
       int level = 0;
 
       // Simple stupid code...
@@ -1190,7 +1190,7 @@ int main(int argc, char **argv, char **envp) {
         } else if (res==pid && WIFEXITED(status)) {
           return WEXITSTATUS(status);
         } else {
-          double time = util::getWallTime();
+          double time = util::getWallTimeCoarse();
 
           if (time > nextStep) {
             ++level;
@@ -1209,7 +1209,7 @@ int main(int argc, char **argv, char **envp) {
 
             // Ideally this triggers a dump, which may take a while,
             // so try and give the process extra time to clean up.
-            nextStep = util::getWallTime() + std::max(15., MaxTime*.1);
+            nextStep = util::getWallTimeCoarse() + std::max(15., MaxTime*.1);
           }
         }
       }


### PR DESCRIPTION
Related to #207 

KLEE uses LLVM's methods to get timestamps, which internally use the non-monotonic gettimeofday(). For calculating elapsed time, monotonic clocks are better.

With those changes, KLEE uses clock_gettime(CLOCK_MONOTONIC) where possible. Otherwise, it falls back to LLVM.

Added -Coarse() methods to get lower-precision timestamps using clock_gettime(CLOCK_MONOTONIC_COARSE). This clock is updated only on every tick and the calls are less expensive. Even on a fast TSC clock source, it is 3x cheaper than CLOCK_MONOTONIC. On a VM, it was measured to be 240x cheaper.
If the coarse clock is not available on the given system, this method falls back to regular timestamps.
Updated code to use those methods where sub-millisecond precision is not required. 

By default, this is not likely to make a difference for KLEE, but it can be useful, if millisecond-precision timestamps are needed per query or instruction.
