### PR TITLE
[Core] Always warn if states get deleted due to memory limits

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2592,9 +2592,7 @@ void Executor::run(ExecutionState &initialState) {
             unsigned numStates = states.size();
             unsigned toKill = std::max(1U, numStates - numStates*MaxMemory/mbs);
 
-            if (MaxMemoryInhibit)
-              klee_warning("killing %d states (over memory cap)",
-                           toKill);
+            klee_warning("killing %d states (over memory cap)", toKill);
 
             std::vector<ExecutionState*> arr(states.begin(), states.end());
             for (unsigned i=0,N=arr.size(); N && i<toKill; ++i,--N) {


### PR DESCRIPTION
Previously, KLEE was only warning about killing states if MaxMemoryInhibit was set to true.
Still, states were silently killed if memory limit was provided.

This patch changes the behavior to always warn in case states are killed