### PR TITLE
[Core] Fix: Do not randomly swap states returned by Executor::fork()

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -117,11 +117,6 @@ namespace {
 		   cl::desc("Dump test cases for all active states on exit (default=on)"));
  
   cl::opt<bool>
-  RandomizeFork("randomize-fork",
-                cl::init(false),
-		cl::desc("Randomly swap the true and false states on a fork (default=off)"));
- 
-  cl::opt<bool>
   AllowExternalSymCalls("allow-external-sym-calls",
                         cl::init(false),
 			cl::desc("Allow calls with symbolic arguments to external functions.  This concretizes the symbolic arguments.  (default=off)"));
@@ -861,9 +856,6 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
 
     falseState = trueState->branch();
     addedStates.insert(falseState);
-
-    if (RandomizeFork && theRNG.getBool())
-      std::swap(trueState, falseState);
 
     if (it != seedMap.end()) {
       std::vector<SeedInfo> seeds = it->second;


### PR DESCRIPTION
Several internal checks (e.g. out-of-bounds) depend on the order the states are returned.
If KLEE is executed with --randomize-fork=true, states should not be returned randomized.

This patch, fixes the behavior. 
