### PR TITLE
Multithread support v2

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -71,4 +71,4 @@ licenses, and/or restrictions:
 Program             Directory
 -------             ---------
 klee-libc           runtime/klee-libc
-
+multithread-support lib/Core runtime/POSIX

--- a/TODO.txt
+++ b/TODO.txt
@@ -48,7 +48,7 @@ KLEE Internal
    3. Since calling external functions will be totally invalid in this
       environment, we will have to invent replacements for the useful
       ones (printf). 
- 
+
  o Extend klee-replay to support specific thread schedulings.
 
 Kleaver Internal

--- a/TODO.txt
+++ b/TODO.txt
@@ -48,7 +48,8 @@ KLEE Internal
    3. Since calling external functions will be totally invalid in this
       environment, we will have to invent replacements for the useful
       ones (printf). 
-
+ 
+ o Extend klee-replay to support specific thread schedulings.
 
 Kleaver Internal
 --

--- a/examples/barrier/barrier1.c
+++ b/examples/barrier/barrier1.c
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <time.h>
+#include <klee/klee.h>
+
+pthread_barrier_t barrier;
+
+void * work0 (void *arg)
+{
+  printf("work0: wait at barrier\n");
+  pthread_barrier_wait (&barrier);
+  printf("work0: pass the barrier\n");
+  return 0;
+}
+
+
+void * work1 (void *arg)
+{
+  printf("work1: wait at barrier\n");
+  pthread_barrier_wait (&barrier);
+  printf("work1: pass the barrier\n");
+  return 0;
+}
+
+
+
+int main (int argc, char *argv[])
+{
+  pthread_t t0, t1;
+
+  int rc;
+  int nr;
+  
+  srand(time(0));
+  
+  if(argc != 1)
+    return 1;
+
+  klee_make_symbolic(&nr, sizeof(nr), "input");
+  
+  pthread_barrier_init (&barrier, 0, nr);
+  
+  printf("t0 = %u \n", (unsigned int) t0);
+
+  rc = pthread_create (&t0, 0, work0, 0);
+  rc = pthread_create (&t1, 0, work1, 0);
+
+  pthread_join(t0, 0);
+  
+  pthread_join(t1, 0);
+
+  pthread_barrier_destroy (&barrier);    
+  
+  printf ("STOP\n");
+  
+  return 0;
+}
+

--- a/examples/condvar/cond_var1.c
+++ b/examples/condvar/cond_var1.c
@@ -1,0 +1,70 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+
+#define NUM_THREADS  2
+
+
+
+volatile int count = 0;
+int thread_ids[2] = { 0, 1};
+pthread_mutex_t count_mutex;
+pthread_cond_t count_threshold_cv;
+
+void *
+inc_count (void* arg)
+{
+  pthread_mutex_lock (&count_mutex);
+  printf("signaling\n");
+  pthread_cond_signal (&count_threshold_cv);
+  printf("signaled\n");
+  
+  pthread_mutex_unlock (&count_mutex);
+  return 0;
+}
+
+void *
+watch_count (void *idp)
+{
+  pthread_mutex_lock (&count_mutex);
+  
+  printf("sleeping\n");
+  pthread_cond_wait (&count_threshold_cv, &count_mutex);
+  printf ("woke up\n");
+  
+  pthread_mutex_unlock (&count_mutex);
+  
+  return 0;
+}
+
+int
+main (int argc, char *argv[])
+{
+  int i;
+  pthread_t threads[2];
+  
+
+  /* Initialize mutex and condition variable objects */
+  pthread_mutex_init (&count_mutex, NULL);
+  
+  pthread_cond_init (&count_threshold_cv, NULL);
+
+  
+  pthread_create (&threads[1], 0, watch_count, 0);
+  pthread_create (&threads[0], 0, inc_count, 0);
+  
+
+  /* Wait for all threads to complete */
+  for (i = 0; i < NUM_THREADS; i++)
+    {
+      pthread_join (threads[i], NULL);
+    }
+  printf("main exited\n");
+  
+    
+  pthread_mutex_destroy (&count_mutex);
+  
+  return 0;
+}

--- a/examples/condvar/cond_var2.c
+++ b/examples/condvar/cond_var2.c
@@ -1,0 +1,87 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+
+#define NUM_THREADS  2
+
+volatile int count = 0;
+int thread_ids[2] = { 0, 1};
+pthread_mutex_t count_mutex;
+pthread_cond_t count_threshold_cv;
+
+pthread_mutex_t lock;
+
+volatile int x  = 0;
+
+void *
+inc_count (void* arg)
+{
+  pthread_mutex_lock (&count_mutex);
+
+  pthread_mutex_lock(&lock);
+
+  x++;
+
+  printf("signaling\n");
+  
+  pthread_cond_signal (&count_threshold_cv);
+  printf("signaled\n");
+  
+  pthread_mutex_unlock(&lock);
+  
+  pthread_mutex_unlock (&count_mutex);
+  return 0;
+}
+
+void *
+watch_count (void *idp)
+{
+  pthread_mutex_lock (&count_mutex);
+
+  pthread_mutex_lock(&lock);
+
+  x++;
+  
+  printf("sleeping\n");
+  pthread_cond_wait (&count_threshold_cv, &count_mutex);
+  
+  pthread_mutex_unlock(&lock);
+  
+  printf ("woke up\n");
+  
+  pthread_mutex_unlock (&count_mutex);
+  return 0;
+}
+
+int
+main (int argc, char *argv[])
+{
+  int i;
+  pthread_t threads[2];
+  
+  /* Initialize mutex and condition variable objects */
+  pthread_mutex_init (&count_mutex, NULL);
+  
+  pthread_mutex_init(&lock, NULL);
+  
+  
+  pthread_cond_init (&count_threshold_cv, NULL);
+
+  pthread_create (&threads[0], 0, watch_count, 0);
+  pthread_create (&threads[1], 0, inc_count, 0);
+  
+
+  /* Wait for all threads to complete */
+  for (i = 0; i < NUM_THREADS; i++)
+    {
+      pthread_join (threads[i], NULL);
+    }
+  printf("main exited\n");
+  
+    
+  pthread_mutex_destroy (&count_mutex);
+  
+  return 0;
+}

--- a/examples/deadlock/deadlock1.c
+++ b/examples/deadlock/deadlock1.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <time.h>
+
+pthread_mutex_t cs0;
+
+int globalX = 0;
+
+
+void
+print_safe()
+{
+  printf("-------- safe\n");
+}
+
+void
+print_deadlock()
+{
+  printf("------------- could deadlock\n");
+}
+
+void * work0 (void *arg)
+{
+  pthread_mutex_lock (&cs0);
+  printf("work0: got lock 0\n");
+  globalX++;
+  pthread_mutex_unlock (&cs0);
+  printf("work0: released lock 0\n");
+  return 0;
+}
+
+
+void * work1 (void *arg)
+{
+  pthread_mutex_lock (&cs0);
+  printf("work1: got lock 0\n");
+  globalX++;
+  print_safe();
+  pthread_mutex_unlock (&cs0);
+  return 0;
+}
+
+
+
+int main (int argc, char *argv[])
+{
+  //pthread_t h[2];
+
+  pthread_t t0, t1;
+
+  int rc;
+  
+  srand(time(0));
+  
+  if(argc != 1)
+    return 1;
+  
+  pthread_mutex_init (&cs0, 0);
+  
+  
+  printf("t0 = %u \n", (unsigned int) t0);
+
+  rc = pthread_create (&t0, 0, work0, 0);
+  rc = pthread_create (&t1, 0, work1, 0);
+
+  pthread_join(t0, 0);
+  
+  pthread_join(t1, 0);
+
+    
+  //pthread_mutex_destroy (&cs0);
+  //pthread_mutex_destroy (&cs1);
+  
+  printf ("STOP\n");
+  
+  return 0;
+}
+

--- a/examples/deadlock/deadlock2.c
+++ b/examples/deadlock/deadlock2.c
@@ -1,0 +1,133 @@
+/*
+ * This code can deadlock 
+ */
+
+
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <time.h>
+
+pthread_mutex_t cs0, cs1;
+
+int globalX = 0;
+int globalY = 0;
+
+
+void
+print_safe()
+{
+  printf("-------- safe\n");
+}
+
+void
+print_deadlock()
+{
+  printf("------------- could deadlock\n");
+}
+
+void * work0 (void *arg)
+{
+  pthread_mutex_lock (&cs0);
+  printf("work0: got lock 0\n");
+  globalX++;
+  pthread_mutex_lock (&cs1);
+  printf("work0: got lock 1\n");
+  globalY++;
+  pthread_mutex_unlock (&cs1);
+  printf("work0: released lock 1\n");
+  pthread_mutex_unlock (&cs0);
+  printf("work0: released lock 0\n");
+  return 0;
+}
+
+
+void * work1 (void *arg)
+{
+  int r = 0;
+  
+  if(r)
+    {
+      pthread_mutex_lock (&cs0);
+      printf("work1: got lock 0\n");
+      globalX++;
+      pthread_mutex_lock (&cs1);
+      printf("work1: got lock 1\n");
+      print_safe();
+      globalY++;
+    }
+  else
+    {
+      pthread_mutex_lock (&cs1);
+      printf("work1: got lock 1\n");
+      globalX++;
+      pthread_mutex_lock (&cs0);
+      printf("work1: got lock 0\n");
+      print_deadlock();
+      globalY++;
+    }
+
+
+  if(r)
+    {
+      pthread_mutex_unlock (&cs1);
+      print_safe();
+      pthread_mutex_unlock (&cs0);
+    }
+  else
+    {
+      pthread_mutex_unlock (&cs0);
+      printf("work1: released lock 0\n");
+      print_deadlock();
+      pthread_mutex_unlock (&cs1);
+      printf("work1: released lock 1\n");
+    }
+  return 0;
+}
+
+
+
+int main (int argc, char *argv[])
+{
+  //pthread_t h[2];
+
+  pthread_t t0, t1;
+
+  int rc;
+  
+  srand(time(0));
+  
+  if(argc != 1)
+    return 1;
+  
+  pthread_mutex_init (&cs0, 0);
+  pthread_mutex_init (&cs1, 0);
+  
+  printf ("START\n");
+  
+  printf("t0 = %u \n", (unsigned int) t0);
+
+  rc = pthread_create (&t0, 0, work0, 0);
+  rc = pthread_create (&t1, 0, work1, 0);
+
+
+  //rc = pthread_create (&h[0], 0, work0, 0);
+  //rc = pthread_create (&h[1], 0, work1, 0);
+    
+  //rc = pthread_join (h[0], 0);
+  //rc = pthread_join (h[1], 0);
+
+  pthread_join(t0, 0);
+  pthread_join(t1, 0);
+
+    
+  //pthread_mutex_destroy (&cs0);
+  //pthread_mutex_destroy (&cs1);
+  
+  printf ("TOTAL = (%d,%d)\n", globalX, globalY);
+  printf ("STOP\n");
+  
+  return 0;
+}
+

--- a/examples/deadlock/deadlock3.c
+++ b/examples/deadlock/deadlock3.c
@@ -1,0 +1,127 @@
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <time.h>
+
+pthread_mutex_t cs0, cs1;
+
+int globalX = 0;
+int globalY = 0;
+
+void
+print_safe()
+{
+  printf("-------- safe\n");
+}
+
+void
+print_deadlock()
+{
+  printf("------------- could deadlock\n");
+}
+
+void * work0 (void *arg)
+{
+  pthread_mutex_lock (&cs0);
+  printf("work0: got lock 0\n");
+  globalX++;
+  pthread_mutex_lock (&cs1);
+  printf("work0: got lock 1\n");
+  globalY++;
+  pthread_mutex_unlock (&cs1);
+  printf("work0: released lock 1\n");
+  pthread_mutex_unlock (&cs0);
+  printf("work0: released lock 0\n");
+  return 0;
+}
+
+
+void * work1 (void *arg)
+{
+  int r = 0;
+  
+  if(r)
+    {
+      pthread_mutex_lock (&cs0);
+      printf("work1: got lock 0\n");
+      globalX++;
+      pthread_mutex_lock (&cs1);
+      printf("work1: got lock 1\n");
+      print_safe();
+      globalY++;
+    }
+  else
+    {
+      pthread_mutex_lock (&cs1);
+      printf("work1: got lock 1\n");
+      globalX++;
+      pthread_mutex_lock (&cs0);
+      printf("work1: got lock 0\n");
+      print_deadlock();
+      globalY++;
+    }
+
+
+  if(r)
+    {
+      pthread_mutex_unlock (&cs1);
+      print_safe();
+      pthread_mutex_unlock (&cs0);
+    }
+  else
+    {
+      pthread_mutex_unlock (&cs0);
+      printf("work1: released lock 0\n");
+      print_deadlock();
+      pthread_mutex_unlock (&cs1);
+      printf("work1: released lock 1\n");
+    }
+  return 0;
+}
+
+
+
+int main (int argc, char *argv[])
+{
+  //pthread_t h[2];
+
+  pthread_t t0, t1;
+
+  int rc;
+  
+  srand(time(0));
+  
+  if(argc != 1)
+    return 1;
+  
+  pthread_mutex_init (&cs0, 0);
+  pthread_mutex_init (&cs1, 0);
+  
+  printf ("START\n");
+  
+  printf("t0 = %u \n", (unsigned int) t0);
+
+  rc = pthread_create (&t0, 0, work0, 0);
+  rc = pthread_create (&t1, 0, work1, 0);
+
+
+  //rc = pthread_create (&h[0], 0, work0, 0);
+  //rc = pthread_create (&h[1], 0, work1, 0);
+    
+  //rc = pthread_join (h[0], 0);
+  //rc = pthread_join (h[1], 0);
+
+  pthread_join(t0, 0);
+  pthread_join(t1, 0);
+
+    
+  //pthread_mutex_destroy (&cs0);
+  //pthread_mutex_destroy (&cs1);
+  
+  printf ("TOTAL = (%d,%d)\n", globalX, globalY);
+  printf ("STOP\n");
+  
+  return 0;
+}
+

--- a/examples/deadlock/deadlock4.c
+++ b/examples/deadlock/deadlock4.c
@@ -1,0 +1,133 @@
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <klee/klee.h>
+
+pthread_mutex_t cs0, cs1;
+
+int globalX = 0;
+int globalY = 0;
+
+void
+print_safe()
+{
+  printf("-------- safe\n");
+}
+
+void
+print_deadlock()
+{
+  printf("------------- could deadlock\n");
+}
+
+void * work0 (void *arg)
+{
+  pthread_mutex_lock (&cs0);
+  printf("work0: got lock 0\n");
+  globalX++;
+  pthread_mutex_lock (&cs1);
+  printf("work0: got lock 1\n");
+  globalY++;
+  pthread_mutex_unlock (&cs1);
+  printf("work0: released lock 1\n");
+  pthread_mutex_unlock (&cs0);
+  printf("work0: released lock 0\n");
+  return 0;
+}
+
+
+void * work1 (void *arg)
+{
+  int r;
+  klee_make_symbolic(&r, sizeof(r), "r");
+  
+  printf("r is now symbolic\n");
+  
+  
+  if(r)
+    {
+      pthread_mutex_lock (&cs0);
+      globalX++;
+      pthread_mutex_lock (&cs1);
+      print_safe();
+      globalY++;
+    }
+  else
+    {
+      pthread_mutex_lock (&cs1);
+      printf("work1: got lock 1\n");
+      print_deadlock();
+      globalX++;
+      pthread_mutex_lock (&cs0);
+      printf("work1: got lock 0\n");
+
+      globalY++;
+    }
+
+
+  if(r)
+    {
+      pthread_mutex_unlock (&cs1);
+      print_safe();
+      pthread_mutex_unlock (&cs0);
+    }
+  else
+    {
+      pthread_mutex_unlock (&cs0);
+      printf("work1: released lock 0\n");
+      print_deadlock();
+      pthread_mutex_unlock (&cs1);
+      printf("work1: released lock 1\n");
+    }
+  return 0;
+}
+
+
+
+int main (int argc, char *argv[])
+{
+  //pthread_t h[2];
+
+  pthread_t t0, t1;
+
+  int rc;
+  
+  srand(time(0));
+  
+  if(argc != 1)
+    return 1;
+  
+  pthread_mutex_init (&cs0, 0);
+  pthread_mutex_init (&cs1, 0);
+  
+  printf ("START\n");
+  
+  printf("t0 = %u \n", (unsigned int) t0);
+
+  rc = pthread_create (&t0, 0, work0, 0);
+  printf("t0 = %u \n", (unsigned int) t0);
+  rc = pthread_create (&t1, 0, work1, 0);
+
+
+  //rc = pthread_create (&h[0], 0, work0, 0);
+  //rc = pthread_create (&h[1], 0, work1, 0);
+    
+  //rc = pthread_join (h[0], 0);
+  //rc = pthread_join (h[1], 0);
+
+  pthread_join(t0, 0);
+  pthread_join(t1, 0);
+
+    
+  //pthread_mutex_destroy (&cs0);
+  //pthread_mutex_destroy (&cs1);
+  
+  printf ("TOTAL = (%d,%d)\n", globalX, globalY);
+  printf ("STOP\n");
+  
+  return 0;
+}
+

--- a/examples/rwlock/rwlock1.c
+++ b/examples/rwlock/rwlock1.c
@@ -1,0 +1,123 @@
+/*
+ * This code can deadlock 
+ */
+
+
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <time.h>
+#include <klee/klee.h>
+
+pthread_rwlock_t cs0, cs1;
+
+int globalX = 0;
+int globalY = 0;
+
+
+void
+print_safe()
+{
+  printf("-------- safe\n");
+}
+
+void
+print_deadlock()
+{
+  printf("------------- could deadlock\n");
+}
+
+void * work0 (void *arg)
+{
+  pthread_rwlock_wrlock (&cs0);
+  printf("work0: got write lock 0\n");
+  globalX++;
+  pthread_rwlock_wrlock (&cs1);
+  printf("work0: got write lock 1\n");
+  globalY++;
+  pthread_rwlock_unlock (&cs1);
+  printf("work0: released write lock 1\n");
+  pthread_rwlock_unlock (&cs0);
+  printf("work0: released write lock 0\n");
+  return 0;
+}
+
+
+void * work1 (void *arg)
+{
+  int r;
+
+  klee_make_symbolic(&r, sizeof(r), "input");
+  
+  if(r)
+    {
+      pthread_rwlock_wrlock (&cs0);
+      printf("work1: got write lock 0\n");
+      globalX++;
+      pthread_rwlock_wrlock (&cs1);
+      printf("work1: got write lock 1\n");
+      print_safe();
+      globalY++;
+    }
+  else
+    {
+      pthread_rwlock_wrlock (&cs1);
+      printf("work1: got write lock 1\n");
+      globalX++;
+      pthread_rwlock_wrlock (&cs0);
+      printf("work1: got write lock 0\n");
+      print_deadlock();
+      globalY++;
+    }
+
+
+  if(r)
+    {
+      pthread_rwlock_unlock (&cs1);
+      printf("work1: released write lock 1\n");
+      print_safe();
+      pthread_rwlock_unlock (&cs0);
+      printf("work1: released write lock 0\n");
+    }
+  else
+    {
+      pthread_rwlock_unlock (&cs0);
+      printf("work1: released write lock 0\n");
+      print_deadlock();
+      pthread_rwlock_unlock (&cs1);
+      printf("work1: released write lock 1\n");
+    }
+  return 0;
+}
+
+int main (int argc, char *argv[])
+{
+  pthread_t t0, t1;
+
+  int rc;
+  
+  srand(time(0));
+  
+  if(argc != 1)
+    return 1;
+  
+  pthread_rwlock_init (&cs0, 0);
+  pthread_rwlock_init (&cs1, 0);
+  
+  printf ("START\n");
+  
+  printf("t0 = %u \n", (unsigned int) t0);
+
+  rc = pthread_create (&t0, 0, work0, 0);
+  rc = pthread_create (&t1, 0, work1, 0);
+
+  pthread_join(t0, 0);
+  pthread_join(t1, 0);
+
+  printf ("TOTAL = (%d,%d)\n", globalX, globalY);
+  printf ("STOP\n");
+  
+  return 0;
+}
+

--- a/examples/rwlock/rwlock2.c
+++ b/examples/rwlock/rwlock2.c
@@ -1,0 +1,106 @@
+/*
+ * This code can deadlock 
+ */
+
+
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <time.h>
+#include <klee/klee.h>
+
+pthread_rwlock_t cs0, cs1;
+
+int globalX = 0;
+int globalY = 0;
+
+void * work0 (void *arg)
+{
+  pthread_rwlock_wrlock (&cs0);
+  printf("work0: got write lock 0\n");
+  globalX++;
+  pthread_rwlock_wrlock (&cs1);
+  printf("work0: got write lock 1\n");
+  globalY++;
+  pthread_rwlock_unlock (&cs1);
+  printf("work0: released write lock 1\n");
+  pthread_rwlock_unlock (&cs0);
+  printf("work0: released write lock 0\n");
+  return 0;
+}
+
+
+void * work1 (void *arg)
+{
+  int r;
+
+  klee_make_symbolic(&r, sizeof(r), "input");
+  
+  if(r)
+    {
+      pthread_rwlock_wrlock (&cs0);
+      printf("work1: got write lock 0\n");
+      globalX++;
+      pthread_rwlock_rdlock (&cs0);
+      printf("work1: got read lock 0\n");
+      globalY++;
+    }
+  else
+    {
+      pthread_rwlock_rdlock (&cs0);
+      printf("work1: got read lock 0\n");
+      globalX++;
+      pthread_rwlock_wrlock (&cs0);
+      printf("work1: got write lock 0\n");
+      globalY++;
+    }
+
+
+  if(r)
+    {
+      pthread_rwlock_unlock (&cs0);
+      printf("work1: released lock 0\n");
+      pthread_rwlock_unlock (&cs0);
+      printf("work1: released lock 0\n");
+    }
+  else
+    {
+      pthread_rwlock_unlock (&cs0);
+      printf("work1: released lock 1\n");
+      pthread_rwlock_unlock (&cs0);
+      printf("work1: released lock 1\n");
+    }
+  return 0;
+}
+
+int main (int argc, char *argv[])
+{
+  pthread_t t0, t1;
+
+  int rc;
+  
+  srand(time(0));
+  
+  if(argc != 1)
+    return 1;
+  
+  pthread_rwlock_init (&cs0, 0);
+  pthread_rwlock_init (&cs1, 0);
+  
+  printf ("START\n");
+  
+  printf("t0 = %u \n", (unsigned int) t0);
+
+  rc = pthread_create (&t0, 0, work0, 0);
+  rc = pthread_create (&t1, 0, work1, 0);
+
+  pthread_join(t0, 0);
+  pthread_join(t1, 0);
+
+  printf ("TOTAL = (%d,%d)\n", globalX, globalY);
+  printf ("STOP\n");
+  
+  return 0;
+}
+

--- a/examples/rwlock/rwlock3.c
+++ b/examples/rwlock/rwlock3.c
@@ -1,0 +1,111 @@
+/*
+ * This code can deadlock 
+ */
+
+
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <time.h>
+#include <errno.h>
+#include <klee/klee.h>
+
+pthread_rwlock_t cs0, cs1;
+
+int globalX = 0;
+int globalY = 0;
+
+void * work0 (void *arg)
+{
+  do {
+    pthread_rwlock_trywrlock (&cs0);
+  }while(errno == EBUSY);
+  printf("work0: got write lock 0\n");
+  globalX++;
+  do {
+    pthread_rwlock_trywrlock (&cs0);
+  }while(errno == EBUSY);
+  printf("work0: got write lock 0\n");
+  globalY++;
+  pthread_rwlock_unlock (&cs0);
+  printf("work0: released write lock 0\n");
+  pthread_rwlock_unlock (&cs0);
+  printf("work0: released write lock 0\n");
+  return 0;
+}
+
+
+void * work1 (void *arg)
+{
+  int r;
+
+  klee_make_symbolic(&r, sizeof(r), "input");
+  
+  if(r)
+    {
+      pthread_rwlock_wrlock (&cs0);
+      printf("work1: got write lock 0\n");
+      globalX++;
+      pthread_rwlock_wrlock (&cs1);
+      printf("work1: got write lock 1\n");
+      globalY++;
+    }
+  else
+    {
+      pthread_rwlock_wrlock (&cs1);
+      printf("work1: got write lock 1\n");
+      globalX++;
+      pthread_rwlock_wrlock (&cs0);
+      printf("work1: got write lock 0\n");
+      globalY++;
+    }
+
+
+  if(r)
+    {
+      pthread_rwlock_unlock (&cs1);
+      printf("work1: released write lock 1\n");
+      pthread_rwlock_unlock (&cs0);
+      printf("work1: released write lock 0\n");
+    }
+  else
+    {
+      pthread_rwlock_unlock (&cs0);
+      printf("work1: released write lock 0\n");
+      pthread_rwlock_unlock (&cs1);
+      printf("work1: released write lock 1\n");
+    }
+  return 0;
+}
+
+int main (int argc, char *argv[])
+{
+  pthread_t t0, t1;
+
+  int rc;
+  
+  srand(time(0));
+  
+  if(argc != 1)
+    return 1;
+  
+  pthread_rwlock_init (&cs0, 0);
+  pthread_rwlock_init (&cs1, 0);
+  
+  printf ("START\n");
+  
+  printf("t0 = %u \n", (unsigned int) t0);
+
+  rc = pthread_create (&t0, 0, work0, 0);
+  rc = pthread_create (&t1, 0, work1, 0);
+
+  pthread_join(t0, 0);
+  pthread_join(t1, 0);
+
+  printf ("TOTAL = (%d,%d)\n", globalX, globalY);
+  printf ("STOP\n");
+  
+  return 0;
+}
+

--- a/examples/rwlock/rwlock4.c
+++ b/examples/rwlock/rwlock4.c
@@ -1,0 +1,115 @@
+/*
+ * This code can deadlock 
+ */
+
+
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <time.h>
+#include <errno.h>
+#include <klee/klee.h>
+
+pthread_rwlock_t cs0, cs1;
+
+int globalX = 0;
+int globalY = 0;
+
+void * work0 (void *arg)
+{
+  pthread_rwlock_rdlock (&cs0);
+  printf("work0: got read lock 0\n");
+  globalX++;
+  pthread_rwlock_wrlock (&cs1);
+  printf("work0: got write lock 1\n");
+  globalY++;
+  pthread_rwlock_unlock (&cs1);
+  printf("work0: released write lock 1\n");
+  pthread_rwlock_unlock (&cs0);
+  printf("work0: released read lock 0\n");
+  return 0;
+}
+
+
+void * work1 (void *arg)
+{
+  int r;
+
+  klee_make_symbolic(&r, sizeof(r), "input");
+  
+  if(r)
+    {
+      do {
+        pthread_rwlock_trywrlock (&cs0);
+      }while(errno != EBUSY);
+      printf("work1: got write lock 0\n");
+      globalX++;
+      do {
+        pthread_rwlock_tryrdlock (&cs1);
+      }while(errno != EBUSY);
+      printf("work1: got read lock 1\n");
+      globalY++;
+    }
+  else
+    {
+      do {
+        pthread_rwlock_trywrlock (&cs1);
+      }while(errno != EBUSY);
+      printf("work1: got write lock 1\n");
+      globalX++;
+      do {
+        pthread_rwlock_tryrdlock (&cs0);
+      }while(errno != EBUSY);
+      printf("work1: got read lock 0\n");
+      globalY++;
+    }
+
+
+  if(r)
+    {
+      pthread_rwlock_unlock (&cs1);
+      printf("work1: released write lock 1\n");
+      pthread_rwlock_unlock (&cs0);
+      printf("work1: released read lock 0\n");
+    }
+  else
+    {
+      pthread_rwlock_unlock (&cs0);
+      printf("work1: released write lock 0\n");
+      pthread_rwlock_unlock (&cs1);
+      printf("work1: released read lock 1\n");
+    }
+  return 0;
+}
+
+int main (int argc, char *argv[])
+{
+  pthread_t t0, t1;
+
+  int rc;
+  
+  srand(time(0));
+  
+  if(argc != 1)
+    return 1;
+  
+  pthread_rwlock_init (&cs0, 0);
+  pthread_rwlock_init (&cs1, 0);
+  
+  printf ("START\n");
+  
+  printf("t0 = %u \n", (unsigned int) t0);
+
+  rc = pthread_create (&t0, 0, work0, 0);
+  rc = pthread_create (&t1, 0, work1, 0);
+
+  pthread_join(t0, 0);
+  pthread_join(t1, 0);
+
+  printf ("TOTAL = (%d,%d)\n", globalX, globalY);
+  printf ("STOP\n");
+  
+  return 0;
+}
+

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -16,6 +16,7 @@
 
 // FIXME: We do not want to be exposing these? :(
 #include "../../lib/Core/AddressSpace.h"
+#include "../../lib/Core/Thread.h"
 #include "klee/Internal/Module/KInstIterator.h"
 
 #include <map>
@@ -34,37 +35,11 @@ struct InstructionInfo;
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const MemoryMap &mm);
 
-struct StackFrame {
-  KInstIterator caller;
-  KFunction *kf;
-  CallPathNode *callPathNode;
-
-  std::vector<const MemoryObject *> allocas;
-  Cell *locals;
-
-  /// Minimum distance to an uncovered instruction once the function
-  /// returns. This is not a good place for this but is used to
-  /// quickly compute the context sensitive minimum distance to an
-  /// uncovered instruction. This value is updated by the StatsTracker
-  /// periodically.
-  unsigned minDistToUncoveredOnReturn;
-
-  // For vararg functions: arguments not passed via parameter are
-  // stored (packed tightly) in a local (alloca) memory object. This
-  // is setup to match the way the front-end generates vaarg code (it
-  // does not pass vaarg through as expected). VACopy is lowered inside
-  // of intrinsic lowering.
-  MemoryObject *varargs;
-
-  StackFrame(KInstIterator caller, KFunction *kf);
-  StackFrame(const StackFrame &s);
-  ~StackFrame();
-};
-
 /// @brief ExecutionState representing a path under exploration
 class ExecutionState {
 public:
-  typedef std::vector<StackFrame> stack_ty;
+  typedef std::map<Thread::thread_id_t, Thread> threads_ty;
+  typedef std::map<Thread::wlist_id_t, std::set<Thread::thread_id_t> > wlists_ty;
 
 private:
   // unsupported, use copy constructor
@@ -77,17 +52,22 @@ public:
 
   /// @brief Pointer to instruction to be executed after the current
   /// instruction
-  KInstIterator pc;
+  KInstIterator& pc() { return crtThread().pc; }
+  const KInstIterator& pc() const { return crtThread().pc; }
 
   /// @brief Pointer to instruction which is currently executed
-  KInstIterator prevPC;
+  KInstIterator& prevPC() { return crtThread().prevPC; }
+  const KInstIterator& prevPC() const { return crtThread().prevPC; }
+
 
   /// @brief Stack representing the current instruction stream
-  stack_ty stack;
+  Thread::stack_ty& stack() { return crtThread().stack; }
+  const Thread::stack_ty& stack() const { return crtThread().stack; }
 
   /// @brief Remember from which Basic Block control flow arrived
   /// (i.e. to select the right phi values)
-  unsigned incomingBBIndex;
+  unsigned incomingBBIndex() { return crtThread().incomingBBIndex; };
+  void incomingBBIndex(unsigned ibbi) { crtThread().incomingBBIndex = ibbi; }
 
   // Overall state of the state - Data specific
 
@@ -145,9 +125,61 @@ public:
   void addFnAlias(std::string old_fn, std::string new_fn);
   void removeFnAlias(std::string fn);
 
+  // @brief Threads in current state
+  threads_ty threads;
+
+  // @brief Pointer to current thread
+  threads_ty::iterator crtThreadIt;
+  Thread &crtThread() { return crtThreadIt->second; }
+  const Thread &crtThread() const { return crtThreadIt->second; }
+
+  // @brief Waiting lists to block threads
+  wlists_ty waitingLists;
+  Thread::wlist_id_t wlistCounter;
+
+  // @brief Accumulated preemptions
+  unsigned int preemptions;
+
+  // @brief List of context switches performed
+  std::vector<Thread::thread_id_t> schedulingHistory;
+
+  // @brief Create a new thread in the state
+  Thread& createThread(Thread::thread_id_t tid, KFunction *kf);
+
+  // @brief Terminate the specified thread
+  void terminateThread(threads_ty::iterator it);
+
+  // @brief Get next thread to be scheduled (round robin)
+  threads_ty::iterator nextThread(threads_ty::iterator it) {
+    if (it == threads.end())
+      it = threads.begin();
+    else {
+      it++;
+      if (it == threads.end())
+        it = threads.begin();
+    }
+    return it;
+  }
+
+  // @brief Set thread as active thread
+  void scheduleNext(threads_ty::iterator it) {
+    assert(it != threads.end());
+    crtThreadIt = it;
+    schedulingHistory.push_back(crtThread().tid);
+  }
+
+  // @brief Generate a new waiting list
+  Thread::wlist_id_t getWaitingList() { return wlistCounter++; }
+
+
+  void sleepThread(Thread::wlist_id_t wlist);
+  void notifyOne(Thread::wlist_id_t wlist, Thread::thread_id_t tid);
+  void notifyAll(Thread::wlist_id_t wlist);
+
 private:
   ExecutionState() : ptreeNode(0) {}
 
+  void setupMain(KFunction *kf);
 public:
   ExecutionState(KFunction *kf);
 
@@ -162,6 +194,7 @@ public:
   ExecutionState *branch();
 
   void pushFrame(KInstIterator caller, KFunction *kf);
+  void popFrame(Thread &t);
   void popFrame();
 
   void addSymbolic(const MemoryObject *mo, const Array *array);

--- a/include/klee/Internal/ADT/KTest.h
+++ b/include/klee/Internal/ADT/KTest.h
@@ -35,6 +35,9 @@ extern "C" {
 
     unsigned numObjects;
     KTestObject *objects;
+
+    unsigned numSchedSteps;
+    unsigned long *schedSteps;
   };
 
   

--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -153,6 +153,28 @@ extern "C" {
 
   /* Merge current states together if possible */
   void klee_merge();
+
+  /* Create a new thread */
+  void klee_thread_create(uint64_t tid, void *(*start_routine)(void*), void *arg);
+
+  /* Terminate current thread */
+  void klee_thread_terminate() __attribute__ ((__noreturn__));
+
+  /* Retrieve thread id of current thread */
+  void klee_get_context(uint64_t *tid);
+
+  /* Obtain waiting list id, where current thread is blocked */
+  uint64_t klee_get_wlist(void);
+
+  /* Preempt current thread. If yield is true, the current thread is not rescheduled. */
+  void klee_thread_preempt(int yield);
+
+  /* Block current thread in the specified waiting list */
+  void klee_thread_sleep(uint64_t wlist);
+
+  /* Enable one or all threads in the specified waiting list */
+  void klee_thread_notify(uint64_t wlist, int all);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Basic/KTest.cpp
+++ b/lib/Basic/KTest.cpp
@@ -39,6 +39,27 @@ static int write_uint32(FILE *f, unsigned value) {
   return fwrite(data, 1, 4, f)==4;
 }
 
+static int read_uint64(FILE *f, unsigned long *value_out) {
+  unsigned char data[8];
+  if (fread(data, 8, 1, f)!=1)
+    return 0;
+  *value_out = (((((((((((((((data[0]<<8) + data[1])<<8) + data[2])<<8) + data[3])<<8) + data[4])<<8) + data[5])<<8) + data[6])<<8) + data[7])<<8);
+  return 1;
+}
+
+static int write_uint64(FILE *f, unsigned long value) {
+  unsigned char data[8];
+  data[0] = value>>56;
+  data[1] = value>>48;
+  data[2] = value>>40;
+  data[3] = value>>32;
+  data[4] = value>>24;
+  data[5] = value>>16;
+  data[6] = value>> 8;
+  data[7] = value>> 0;
+  return fwrite(data, 1, 8, f)==8;
+}
+
 static int read_string(FILE *f, char **value_out) {
   unsigned len;
   if (!read_uint32(f, &len))
@@ -118,7 +139,7 @@ KTest *kTest_fromFile(const char *path) {
   res->args = (char**) calloc(res->numArgs, sizeof(*res->args));
   if (!res->args) 
     goto error;
-  
+
   for (i=0; i<res->numArgs; i++)
     if (!read_string(f, &res->args[i]))
       goto error;
@@ -146,6 +167,16 @@ KTest *kTest_fromFile(const char *path) {
       goto error;
   }
 
+  if (!read_uint32(f, &res->numSchedSteps))
+    goto error;
+  res->schedSteps = (unsigned long*) calloc(res->numSchedSteps, sizeof(*res->schedSteps));
+  if (!res->schedSteps)
+    goto error;
+
+  for (i=0; i<res->numSchedSteps; i++)
+    if (!read_uint64(f, &res->schedSteps[i]))
+      goto error;
+
   fclose(f);
 
   return res;
@@ -167,6 +198,8 @@ KTest *kTest_fromFile(const char *path) {
       }
       free(res->objects);
     }
+    if (res->schedSteps)
+      free(res->schedSteps);
     free(res);
   }
 
@@ -210,6 +243,13 @@ int kTest_toFile(KTest *bo, const char *path) {
       goto error;
   }
 
+  if (!write_uint32(f, bo->numSchedSteps))
+    goto error;
+  for (i=0; i<bo->numSchedSteps; i++) {
+    if (!write_uint64(f, bo->schedSteps[i]))
+      goto error;
+  }
+
   fclose(f);
 
   return 1;
@@ -236,5 +276,6 @@ void kTest_free(KTest *bo) {
     free(bo->objects[i].bytes);
   }
   free(bo->objects);
+  free(bo->schedSteps);
   free(bo);
 }

--- a/lib/Basic/KTest.cpp
+++ b/lib/Basic/KTest.cpp
@@ -43,7 +43,7 @@ static int read_uint64(FILE *f, unsigned long *value_out) {
   unsigned char data[8];
   if (fread(data, 8, 1, f)!=1)
     return 0;
-  *value_out = (((((((((((((((data[0]<<8) + data[1])<<8) + data[2])<<8) + data[3])<<8) + data[4])<<8) + data[5])<<8) + data[6])<<8) + data[7])<<8);
+  *value_out = (((((((((((((data[0]<<8) + data[1])<<8) + data[2])<<8) + data[3])<<8) + data[4])<<8) + data[5])<<8) + data[6])<<8) + data[7];
   return 1;
 }
 

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -40,36 +40,7 @@ namespace {
   DebugLogStateMerge("debug-log-state-merge");
 }
 
-/***/
-
-StackFrame::StackFrame(KInstIterator _caller, KFunction *_kf)
-  : caller(_caller), kf(_kf), callPathNode(0), 
-    minDistToUncoveredOnReturn(0), varargs(0) {
-  locals = new Cell[kf->numRegisters];
-}
-
-StackFrame::StackFrame(const StackFrame &s) 
-  : caller(s.caller),
-    kf(s.kf),
-    callPathNode(s.callPathNode),
-    allocas(s.allocas),
-    minDistToUncoveredOnReturn(s.minDistToUncoveredOnReturn),
-    varargs(s.varargs) {
-  locals = new Cell[s.kf->numRegisters];
-  for (unsigned i=0; i<s.kf->numRegisters; i++)
-    locals[i] = s.locals[i];
-}
-
-StackFrame::~StackFrame() { 
-  delete[] locals; 
-}
-
-/***/
-
 ExecutionState::ExecutionState(KFunction *kf) :
-    pc(kf->instructions),
-    prevPC(pc),
-
     queryCost(0.), 
     weight(1),
     depth(0),
@@ -77,12 +48,24 @@ ExecutionState::ExecutionState(KFunction *kf) :
     instsSinceCovNew(0),
     coveredNew(false),
     forkDisabled(false),
-    ptreeNode(0) {
-  pushFrame(0, kf);
+    ptreeNode(0),
+
+    wlistCounter(1),
+    preemptions(0) {
+  setupMain(kf);
 }
 
 ExecutionState::ExecutionState(const std::vector<ref<Expr> > &assumptions)
-    : constraints(assumptions), queryCost(0.), ptreeNode(0) {}
+  : constraints(assumptions), queryCost(0.), ptreeNode(0),
+    wlistCounter(1), preemptions(0) {
+  setupMain(NULL);
+}
+
+void ExecutionState::setupMain(KFunction *kf) {
+  Thread mainThread = Thread(0, kf);
+  threads.insert(std::make_pair(mainThread.tid, mainThread));
+  crtThreadIt = threads.begin();
+}
 
 ExecutionState::~ExecutionState() {
   for (unsigned int i=0; i<symbolics.size(); i++)
@@ -93,16 +76,14 @@ ExecutionState::~ExecutionState() {
     if (mo->refCount == 0)
       delete mo;
   }
-
-  while (!stack.empty()) popFrame();
+  for (threads_ty::iterator it = threads.begin(); it != threads.end(); it++) {
+    Thread &t = it->second;
+    while (!t.stack.empty()) popFrame(t);
+  }
 }
 
 ExecutionState::ExecutionState(const ExecutionState& state):
     fnAliases(state.fnAliases),
-    pc(state.pc),
-    prevPC(state.prevPC),
-    stack(state.stack),
-    incomingBBIndex(state.incomingBBIndex),
 
     addressSpace(state.addressSpace),
     constraints(state.constraints),
@@ -120,7 +101,13 @@ ExecutionState::ExecutionState(const ExecutionState& state):
     coveredLines(state.coveredLines),
     ptreeNode(state.ptreeNode),
     symbolics(state.symbolics),
-    arrayNames(state.arrayNames)
+    arrayNames(state.arrayNames),
+
+    threads(state.threads),
+    waitingLists(state.waitingLists),
+    wlistCounter(state.wlistCounter),
+    preemptions(state.preemptions),
+    schedulingHistory(state.schedulingHistory)
 {
   for (unsigned int i=0; i<symbolics.size(); i++)
     symbolics[i].first->refCount++;
@@ -135,20 +122,25 @@ ExecutionState *ExecutionState::branch() {
 
   weight *= .5;
   falseState->weight -= weight;
+  falseState->crtThreadIt = falseState->threads.find(crtThreadIt->second.tid);
 
   return falseState;
 }
 
 void ExecutionState::pushFrame(KInstIterator caller, KFunction *kf) {
-  stack.push_back(StackFrame(caller,kf));
+  stack().push_back(StackFrame(caller,kf));
+}
+
+void ExecutionState::popFrame(Thread &t) {
+  StackFrame &sf = t.stack.back();
+  for (std::vector<const MemoryObject*>::iterator it = sf.allocas.begin(),
+        ie = sf.allocas.end(); it != ie; ++it)
+    addressSpace.unbindObject(*it);
+  t.stack.pop_back();
 }
 
 void ExecutionState::popFrame() {
-  StackFrame &sf = stack.back();
-  for (std::vector<const MemoryObject*>::iterator it = sf.allocas.begin(), 
-         ie = sf.allocas.end(); it != ie; ++it)
-    addressSpace.unbindObject(*it);
-  stack.pop_back();
+  popFrame(crtThread());
 }
 
 void ExecutionState::addSymbolic(const MemoryObject *mo, const Array *array) { 
@@ -172,6 +164,68 @@ void ExecutionState::removeFnAlias(std::string fn) {
   fnAliases.erase(fn);
 }
 
+Thread& ExecutionState::createThread(Thread::thread_id_t tid, KFunction *kf) {
+  Thread newThread = Thread(tid,  kf);
+  threads.insert(std::make_pair(newThread.tid, newThread));
+  return threads.find(tid)->second;
+}
+
+void ExecutionState::terminateThread(threads_ty::iterator thrIt) {
+  assert(threads.size() > 1);
+  assert(thrIt != crtThreadIt); // We assume the scheduler found a new thread first
+  assert(!thrIt->second.enabled);
+  assert(thrIt->second.waitingList == 0);
+  threads.erase(thrIt);
+}
+
+void ExecutionState::sleepThread(Thread::wlist_id_t wlist) {
+  assert(crtThread().enabled);
+  assert(wlist > 0);
+
+  crtThread().enabled = false;
+  crtThread().waitingList = wlist;
+
+  std::set<Thread::thread_id_t> &wl = waitingLists[wlist];
+
+  wl.insert(crtThread().tid);
+}
+
+void ExecutionState::notifyOne(Thread::wlist_id_t wlist, Thread::thread_id_t tid) {
+  assert(wlist > 0);
+
+  std::set<Thread::thread_id_t> &wl = waitingLists[wlist];
+
+  if (wl.erase(tid) != 1) {
+    assert(0 && "thread was not waiting");
+  }
+
+  Thread &thread = threads.find(tid)->second;
+  assert(!thread.enabled);
+  thread.enabled = true;
+  thread.waitingList = 0;
+
+  if (wl.size() == 0)
+    waitingLists.erase(wlist);
+}
+
+void ExecutionState::notifyAll(Thread::wlist_id_t wlist) {
+  assert(wlist > 0);
+
+  std::set<Thread::thread_id_t> &wl = waitingLists[wlist];
+
+  if (wl.size() > 0) {
+    for (std::set<Thread::thread_id_t>::iterator it = wl.begin(); it != wl.end(); it++) {
+      Thread &thread = threads.find(*it)->second;
+      thread.enabled = true;
+      thread.waitingList = 0;
+    }
+
+    wl.clear();
+  }
+
+  waitingLists.erase(wlist);
+}
+
 /**/
 
 llvm::raw_ostream &klee::operator<<(llvm::raw_ostream &os, const MemoryMap &mm) {
@@ -191,7 +245,14 @@ bool ExecutionState::merge(const ExecutionState &b) {
   if (DebugLogStateMerge)
     llvm::errs() << "-- attempting merge of A:" << this << " with B:" << &b
                  << "--\n";
-  if (pc != b.pc)
+  if (pc() != b.pc())
+    return false;
+
+  // XXX being conservative, how should be merged states with multiple threads?
+  if (threads.size() != 1 || b.threads.size() != 1)
+    return false;
+
+  if (crtThread().tid != b.crtThread().tid) // No merge if different thread
     return false;
 
   // XXX is it even possible for these to differ? does it matter? probably
@@ -200,16 +261,16 @@ bool ExecutionState::merge(const ExecutionState &b) {
     return false;
 
   {
-    std::vector<StackFrame>::const_iterator itA = stack.begin();
-    std::vector<StackFrame>::const_iterator itB = b.stack.begin();
-    while (itA!=stack.end() && itB!=b.stack.end()) {
+    std::vector<StackFrame>::const_iterator itA = stack().begin();
+    std::vector<StackFrame>::const_iterator itB = b.stack().begin();
+    while (itA!=stack().end() && itB!=b.stack().end()) {
       // XXX vaargs?
       if (itA->caller!=itB->caller || itA->kf!=itB->kf)
         return false;
       ++itA;
       ++itB;
     }
-    if (itA!=stack.end() || itB!=b.stack.end())
+    if (itA!=stack().end() || itB!=b.stack().end())
       return false;
   }
 
@@ -305,9 +366,9 @@ bool ExecutionState::merge(const ExecutionState &b) {
   // it seems like it can make a difference, even though logically
   // they must contradict each other and so inA => !inB
 
-  std::vector<StackFrame>::iterator itA = stack.begin();
-  std::vector<StackFrame>::const_iterator itB = b.stack.begin();
-  for (; itA!=stack.end(); ++itA, ++itB) {
+  std::vector<StackFrame>::iterator itA = stack().begin();
+  std::vector<StackFrame>::const_iterator itB = b.stack().begin();
+  for (; itA!=stack().end(); ++itA, ++itB) {
     StackFrame &af = *itA;
     const StackFrame &bf = *itB;
     for (unsigned i=0; i<af.kf->numRegisters; i++) {
@@ -350,9 +411,9 @@ bool ExecutionState::merge(const ExecutionState &b) {
 
 void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
   unsigned idx = 0;
-  const KInstruction *target = prevPC;
-  for (ExecutionState::stack_ty::const_reverse_iterator
-         it = stack.rbegin(), ie = stack.rend();
+  const KInstruction *target = prevPC();
+  for (Thread::stack_ty::const_reverse_iterator
+         it = stack().rbegin(), ie = stack().rend();
        it != ie; ++it) {
     const StackFrame &sf = *it;
     Function *f = sf.kf->function;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -715,7 +715,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
        MaxStaticCPForkPct!=1. || MaxStaticCPSolvePct != 1.) &&
       statsTracker->elapsed() > 60.) {
     StatisticManager &sm = *theStatisticManager;
-    CallPathNode *cpn = current.stack.back().callPathNode;
+    CallPathNode *cpn = current.stack().back().callPathNode;
     if ((MaxStaticForkPct<1. &&
          sm.getIndexedValue(stats::forks, sm.getIndex()) > 
          stats::forks*MaxStaticForkPct) ||
@@ -744,7 +744,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
   bool success = solver->evaluate(current, condition, res);
   solver->setTimeout(0);
   if (!success) {
-    current.pc = current.prevPC;
+    current.pc() = current.prevPC();
     terminateStateEarly(current, "Query timed out (fork).");
     return StatePair(0, 0);
   }
@@ -1040,7 +1040,7 @@ const Cell& Executor::eval(KInstruction *ki, unsigned index,
     return kmodule->constantTable[index];
   } else {
     unsigned index = vnumber;
-    StackFrame &sf = state.stack.back();
+    StackFrame &sf = state.stack().back();
     return sf.locals[index];
   }
 }
@@ -1093,8 +1093,8 @@ Executor::toConstant(ExecutionState &state,
   std::string str;
   llvm::raw_string_ostream os(str);
   os << "silently concretizing (reason: " << reason << ") expression " << e
-     << " to value " << value << " (" << (*(state.pc)).info->file << ":"
-     << (*(state.pc)).info->line << ")";
+     << " to value " << value << " (" << (*(state.pc())).info->file << ":"
+     << (*(state.pc())).info->line << ")";
 
   if (AllExternalWarnings)
     klee_warning(reason, os.str().c_str());
@@ -1151,17 +1151,17 @@ void Executor::executeGetValue(ExecutionState &state,
 
 void Executor::stepInstruction(ExecutionState &state) {
   if (DebugPrintInstructions) {
-    printFileLine(state, state.pc);
+    printFileLine(state, state.pc());
     llvm::errs().indent(10) << stats::instructions << " ";
-    llvm::errs() << *(state.pc->inst) << '\n';
+    llvm::errs() << *(state.pc()->inst) << '\n';
   }
 
   if (statsTracker)
     statsTracker->stepInstruction(state);
 
   ++stats::instructions;
-  state.prevPC = state.pc;
-  ++state.pc;
+  state.prevPC() = state.pc();
+  ++state.pc();
 
   if (stats::instructions==StopAfterNInstructions)
     haltExecution = true;
@@ -1171,8 +1171,10 @@ void Executor::executeCall(ExecutionState &state,
                            KInstruction *ki,
                            Function *f,
                            std::vector< ref<Expr> > &arguments) {
-  Instruction *i = ki->inst;
-  if (f && f->isDeclaration()) {
+  Instruction *i = NULL;
+  if (ki)
+    i = ki->inst;
+  if (ki && f && f->isDeclaration()) {
     switch(f->getIntrinsicID()) {
     case Intrinsic::not_intrinsic:
       // state may be destroyed by this call, cannot touch
@@ -1182,7 +1184,7 @@ void Executor::executeCall(ExecutionState &state,
       // va_arg is handled by caller and intrinsic lowering, see comment for
       // ExecutionState::varargs
     case Intrinsic::vastart:  {
-      StackFrame &sf = state.stack.back();
+      StackFrame &sf = state.stack().back();
       assert(sf.varargs && 
              "vastart called in function with no vararg object");
 
@@ -1239,11 +1241,11 @@ void Executor::executeCall(ExecutionState &state,
     // instead of the actual instruction, since we can't make a KInstIterator
     // from just an instruction (unlike LLVM).
     KFunction *kf = kmodule->functionMap[f];
-    state.pushFrame(state.prevPC, kf);
-    state.pc = kf->instructions;
+    state.pushFrame(state.prevPC(), kf);
+    state.pc() = kf->instructions;
         
     if (statsTracker)
-      statsTracker->framePushed(state, &state.stack[state.stack.size()-2]);
+      statsTracker->framePushed(state, &state.stack()[state.stack().size()-2]);
  
      // TODO: support "byval" parameter attribute
      // TODO: support zeroext, signext, sret attributes
@@ -1268,7 +1270,7 @@ void Executor::executeCall(ExecutionState &state,
         return;
       }
             
-      StackFrame &sf = state.stack.back();
+      StackFrame &sf = state.stack().back();
       unsigned size = 0;
       for (unsigned i = funcArgs; i < callingArgs; i++) {
         // FIXME: This is really specific to the architecture, not the pointer
@@ -1289,7 +1291,7 @@ void Executor::executeCall(ExecutionState &state,
       }
 
       MemoryObject *mo = sf.varargs = memory->allocate(size, true, false, 
-                                                       state.prevPC->inst);
+                                                       state.prevPC()->inst);
       if (!mo) {
         terminateStateOnExecError(state, "out of memory (varargs)");
         return;
@@ -1342,12 +1344,12 @@ void Executor::transferToBasicBlock(BasicBlock *dst, BasicBlock *src,
   // instructions know which argument to eval, set the pc, and continue.
   
   // XXX this lookup has to go ?
-  KFunction *kf = state.stack.back().kf;
+  KFunction *kf = state.stack().back().kf;
   unsigned entry = kf->basicBlockEntry[dst];
-  state.pc = &kf->instructions[entry];
-  if (state.pc->inst->getOpcode() == Instruction::PHI) {
-    PHINode *first = static_cast<PHINode*>(state.pc->inst);
-    state.incomingBBIndex = first->getBasicBlockIndex(src);
+  state.pc() = &kf->instructions[entry];
+  if (state.pc()->inst->getOpcode() == Instruction::PHI) {
+    PHINode *first = static_cast<PHINode*>(state.pc()->inst);
+    state.incomingBBIndex(first->getBasicBlockIndex(src));
   }
 }
 
@@ -1425,7 +1427,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     // Control flow
   case Instruction::Ret: {
     ReturnInst *ri = cast<ReturnInst>(i);
-    KInstIterator kcaller = state.stack.back().caller;
+    KInstIterator kcaller = state.stack().back().caller;
     Instruction *caller = kcaller ? kcaller->inst : 0;
     bool isVoidReturn = (ri->getNumOperands() == 0);
     ref<Expr> result = ConstantExpr::alloc(0, Expr::Bool);
@@ -1434,9 +1436,18 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
       result = eval(ki, 0, state).value;
     }
     
-    if (state.stack.size() <= 1) {
+    if (state.stack().size() <= 1) {
       assert(!caller && "caller set on initial stack frame");
-      terminateStateOnExit(state);
+      if (state.threads.size() == 1) {
+        //main exit
+        terminateStateOnExit(state);
+      } else {
+        // Invoke pthread_exit()
+        Function *f = kmodule->module->getFunction("pthread_exit");
+        std::vector<ref<Expr> > arguments;
+        arguments.push_back(result);
+        executeCall(state, NULL, f, arguments);
+      }
     } else {
       state.popFrame();
 
@@ -1446,8 +1457,8 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
       if (InvokeInst *ii = dyn_cast<InvokeInst>(caller)) {
         transferToBasicBlock(ii->getNormalDest(), caller->getParent(), state);
       } else {
-        state.pc = kcaller;
-        ++state.pc;
+        state.pc() = kcaller;
+        ++state.pc();
       }
 
       if (!isVoidReturn) {
@@ -1492,13 +1503,13 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 #if LLVM_VERSION_CODE < LLVM_VERSION(3, 1)
   case Instruction::Unwind: {
     for (;;) {
-      KInstruction *kcaller = state.stack.back().caller;
+      KInstruction *kcaller = state.stack().back().caller;
       state.popFrame();
 
       if (statsTracker)
         statsTracker->framePopped(state);
 
-      if (state.stack.empty()) {
+      if (state.stack().empty()) {
         terminateStateOnExecError(state, "unwind from initial stack frame");
         break;
       } else {
@@ -1527,7 +1538,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
       // requires that we still be in the context of the branch
       // instruction (it reuses its statistic id). Should be cleaned
       // up with convenient instruction specific data.
-      if (statsTracker && state.stack.back().kf->trackCoverage)
+      if (statsTracker && state.stack().back().kf->trackCoverage)
         statsTracker->markBranchVisited(branches.first, branches.second);
 
       if (branches.first)
@@ -1731,9 +1742,9 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
   }
   case Instruction::PHI: {
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 0)
-    ref<Expr> result = eval(ki, state.incomingBBIndex, state).value;
+    ref<Expr> result = eval(ki, state.incomingBBIndex(), state).value;
 #else
-    ref<Expr> result = eval(ki, state.incomingBBIndex * 2, state).value;
+    ref<Expr> result = eval(ki, state.incomingBBIndex() * 2, state).value;
 #endif
     bindLocal(ki, state, result);
     break;
@@ -2524,7 +2535,7 @@ void Executor::run(ExecutionState &initialState) {
       lastState = it->first;
       unsigned numSeeds = it->second.size();
       ExecutionState &state = *lastState;
-      KInstruction *ki = state.pc;
+      KInstruction *ki = state.pc();
       stepInstruction(state);
 
       executeInstruction(state, ki);
@@ -2574,7 +2585,7 @@ void Executor::run(ExecutionState &initialState) {
 
   while (!states.empty() && !haltExecution) {
     ExecutionState &state = searcher->selectState();
-    KInstruction *ki = state.pc;
+    KInstruction *ki = state.pc();
     stepInstruction(state);
 
     executeInstruction(state, ki);
@@ -2694,7 +2705,7 @@ void Executor::terminateState(ExecutionState &state) {
 
   std::set<ExecutionState*>::iterator it = addedStates.find(&state);
   if (it==addedStates.end()) {
-    state.pc = state.prevPC;
+    state.pc() = state.prevPC();
 
     removedStates.insert(&state);
   } else {
@@ -2729,16 +2740,16 @@ const InstructionInfo & Executor::getLastNonKleeInternalInstruction(const Execut
     Instruction ** lastInstruction) {
   // unroll the stack of the applications state and find
   // the last instruction which is not inside a KLEE internal function
-  ExecutionState::stack_ty::const_reverse_iterator it = state.stack.rbegin(),
-      itE = state.stack.rend();
+  Thread::stack_ty::const_reverse_iterator it = state.stack().rbegin(),
+      itE = state.stack().rend();
 
   // don't check beyond the outermost function (i.e. main())
   itE--;
 
   const InstructionInfo * ii = 0;
   if (kmodule->internalFunctions.count(it->kf->function) == 0){
-    ii =  state.prevPC->info;
-    *lastInstruction = state.prevPC->inst;
+    ii =  state.prevPC()->info;
+    *lastInstruction = state.prevPC()->inst;
     //  Cannot return yet because even though
     //  it->function is not an internal function it might of
     //  been called from an internal function.
@@ -2762,8 +2773,8 @@ const InstructionInfo & Executor::getLastNonKleeInternalInstruction(const Execut
 
   if (!ii) {
     // something went wrong, play safe and return the current instruction info
-    *lastInstruction = state.prevPC->inst;
-    return *state.prevPC->info;
+    *lastInstruction = state.prevPC()->inst;
+    return *state.prevPC()->info;
   }
   return *ii;
 }
@@ -2943,7 +2954,7 @@ ObjectState *Executor::bindObjectInState(ExecutionState &state,
   // matter because all we use this list for is to unbind the object
   // on function return.
   if (isLocal)
-    state.stack.back().allocas.push_back(mo);
+    state.stack().back().allocas.push_back(mo);
 
   return os;
 }
@@ -2957,7 +2968,7 @@ void Executor::executeAlloc(ExecutionState &state,
   size = toUnique(state, size);
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(size)) {
     MemoryObject *mo = memory->allocate(CE->getZExtValue(), isLocal, false, 
-                                        state.prevPC->inst);
+                                        state.prevPC()->inst);
     if (!mo) {
       bindLocal(target, state, 
                 ConstantExpr::alloc(0, Context::get().getPointerWidth()));
@@ -3165,7 +3176,7 @@ void Executor::executeMemoryOperation(ExecutionState &state,
                                       inBounds);
     solver->setTimeout(0);
     if (!success) {
-      state.pc = state.prevPC;
+      state.pc() = state.prevPC();
       terminateStateEarly(state, "Query timed out (bounds check).");
       return;
     }
@@ -3398,7 +3409,7 @@ void Executor::runFunctionAsMain(Function *f,
         char *s = i<argc ? argv[i] : envp[i-(argc+1)];
         int j, len = strlen(s);
         
-        MemoryObject *arg = memory->allocate(len+1, false, true, state->pc->inst);
+        MemoryObject *arg = memory->allocate(len+1, false, true, state->pc()->inst);
         ObjectState *os = bindObjectInState(*state, arg, false);
         for (j=0; j<len+1; j++)
           os->write8(j, s[j]);

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2747,6 +2747,15 @@ void Executor::terminateState(ExecutionState &state) {
 
   interpreterHandler->incPathsExplored();
 
+  if (DebugExploredSchedules && (state.schedulingHistory.size() > 0)) {
+    std::string Str;
+    llvm::raw_string_ostream msg(Str);
+    msg << "Explored schedule: ";
+    for (std::vector<Thread::thread_id_t>::iterator it = state.schedulingHistory.begin(); it != state.schedulingHistory.end(); ++it)
+       msg << *it << ' ';
+    klee_message("%s", msg.str().c_str());
+  }
+
   std::set<ExecutionState*>::iterator it = addedStates.find(&state);
   if (it==addedStates.end()) {
     state.pc() = state.prevPC();

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -303,12 +303,12 @@ private:
   Cell& getArgumentCell(ExecutionState &state,
                         KFunction *kf,
                         unsigned index) {
-    return state.stack.back().locals[kf->getArgRegister(index)];
+    return state.stack().back().locals[kf->getArgRegister(index)];
   }
 
   Cell& getDestCell(ExecutionState &state,
                     KInstruction *target) {
-    return state.stack.back().locals[target->dest];
+    return state.stack().back().locals[target->dest];
   }
 
   void bindLocal(KInstruction *target, 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -411,7 +411,7 @@ private:
                      double maxInstTime);
 
   KFunction* resolveFunction(ref<Expr> address);
-                
+
 public:
   Executor(const InterpreterOptions &opts, InterpreterHandler *ie);
   virtual ~Executor();

--- a/lib/Core/ExecutorTimers.cpp
+++ b/lib/Core/ExecutorTimers.cpp
@@ -14,6 +14,7 @@
 #include "PTree.h"
 #include "StatsTracker.h"
 #include "ExecutorTimerInfo.h"
+#include "Thread.h"
 
 #include "klee/ExecutionState.h"
 #include "klee/Internal/Module/InstructionInfoTable.h"
@@ -140,13 +141,13 @@ void Executor::processTimers(ExecutionState *current,
           ExecutionState *es = *it;
           *os << "(" << es << ",";
           *os << "[";
-          ExecutionState::stack_ty::iterator next = es->stack.begin();
+          Thread::stack_ty::iterator next = es->stack().begin();
           ++next;
-          for (ExecutionState::stack_ty::iterator sfIt = es->stack.begin(),
-                 sf_ie = es->stack.end(); sfIt != sf_ie; ++sfIt) {
+          for (Thread::stack_ty::iterator sfIt = es->stack().begin(),
+                 sf_ie = es->stack().end(); sfIt != sf_ie; ++sfIt) {
             *os << "('" << sfIt->kf->function->getName().str() << "',";
-            if (next == es->stack.end()) {
-              *os << es->prevPC->info->line << "), ";
+            if (next == es->stack().end()) {
+              *os << es->prevPC()->info->line << "), ";
             } else {
               *os << next->caller->info->line << "), ";
               ++next;
@@ -154,11 +155,11 @@ void Executor::processTimers(ExecutionState *current,
           }
           *os << "], ";
 
-          StackFrame &sf = es->stack.back();
-          uint64_t md2u = computeMinDistToUncovered(es->pc,
+          StackFrame &sf = es->stack().back();
+          uint64_t md2u = computeMinDistToUncovered(es->pc(),
                                                     sf.minDistToUncoveredOnReturn);
           uint64_t icnt = theStatisticManager->getIndexedValue(stats::instructions,
-                                                               es->pc->info->id);
+                                                               es->pc()->info->id);
           uint64_t cpicnt = sf.callPathNode->statistics.getValue(stats::instructions);
 
           *os << "{";

--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -195,12 +195,12 @@ double WeightedRandomSearcher::getWeight(ExecutionState *es) {
     return es->weight;
   case InstCount: {
     uint64_t count = theStatisticManager->getIndexedValue(stats::instructions,
-                                                          es->pc->info->id);
+                                                          es->pc()->info->id);
     double inv = 1. / std::max((uint64_t) 1, count);
     return inv * inv;
   }
   case CPInstCount: {
-    StackFrame &sf = es->stack.back();
+    StackFrame &sf = es->stack().back();
     uint64_t count = sf.callPathNode->statistics.getValue(stats::instructions);
     double inv = 1. / std::max((uint64_t) 1, count);
     return inv;
@@ -209,8 +209,8 @@ double WeightedRandomSearcher::getWeight(ExecutionState *es) {
     return (es->queryCost < .1) ? 1. : 1./es->queryCost;
   case CoveringNew:
   case MinDistToUncovered: {
-    uint64_t md2u = computeMinDistToUncovered(es->pc,
-                                              es->stack.back().minDistToUncoveredOnReturn);
+    uint64_t md2u = computeMinDistToUncovered(es->pc(),
+                                              es->stack().back().minDistToUncoveredOnReturn);
 
     double invMD2U = 1. / (md2u ? md2u : 10000);
     if (type==CoveringNew) {
@@ -303,7 +303,7 @@ BumpMergingSearcher::~BumpMergingSearcher() {
 
 Instruction *BumpMergingSearcher::getMergePoint(ExecutionState &es) {  
   if (mergeFunction) {
-    Instruction *i = es.pc->inst;
+    Instruction *i = es.pc()->inst;
 
     if (i->getOpcode()==Instruction::Call) {
       CallSite cs(cast<CallInst>(i));
@@ -323,7 +323,7 @@ entry:
       statesAtMerge.begin();
     ExecutionState *es = it->second;
     statesAtMerge.erase(it);
-    ++es->pc;
+    ++es->pc();
 
     baseSearcher->addState(es);
   }
@@ -347,7 +347,7 @@ entry:
         executor.terminateState(es);
       } else {
         it->second = &es; // the bump
-        ++mergeWith->pc;
+        ++mergeWith->pc();
 
         baseSearcher->addState(mergeWith);
       }
@@ -381,7 +381,7 @@ MergingSearcher::~MergingSearcher() {
 
 Instruction *MergingSearcher::getMergePoint(ExecutionState &es) {
   if (mergeFunction) {
-    Instruction *i = es.pc->inst;
+    Instruction *i = es.pc()->inst;
 
     if (i->getOpcode()==Instruction::Call) {
       CallSite cs(cast<CallInst>(i));
@@ -462,7 +462,7 @@ ExecutionState &MergingSearcher::selectState() {
 
       // step past merge and toss base back in pool
       statesAtMerge.erase(statesAtMerge.find(base));
-      ++base->pc;
+      ++base->pc();
       baseSearcher->addState(base);
     }  
   }

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -12,6 +12,7 @@
 #include "Memory.h"
 #include "SpecialFunctionHandler.h"
 #include "TimingSolver.h"
+#include "Thread.h"
 
 #include "klee/ExecutionState.h"
 
@@ -24,8 +25,13 @@
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
 #include "llvm/IR/Module.h"
+#include "llvm/IR/LLVMContext.h"
 #else
 #include "llvm/Module.h"
+#include "llvm/Type.h"
+#include "llvm/DerivedTypes.h"
+#include "llvm/InstrTypes.h"
+#include "llvm/LLVMContext.h"
 #endif
 #include "llvm/ADT/Twine.h"
 
@@ -62,6 +68,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   addDNR("klee_abort", handleAbort),
   addDNR("klee_silent_exit", handleSilentExit),  
   addDNR("klee_report_error", handleReportError),
+  addDNR("klee_thread_terminate", handleThreadTerminate),
 
   add("calloc", handleCalloc, true),
   add("free", handleFree, false),
@@ -85,6 +92,12 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("klee_print_range", handlePrintRange, false),
   add("klee_set_forking", handleSetForking, false),
   add("klee_stack_trace", handleStackTrace, false),
+  add("klee_get_context", handleGetContext, false),
+  add("klee_get_wlist", handleGetWList, true),
+  add("klee_thread_create", handleThreadCreate, false),
+  add("klee_thread_notify", handleThreadNotify, false),
+  add("klee_thread_preempt", handleThreadPreempt, false),
+  add("klee_thread_sleep", handleThreadSleep, false),
   add("klee_warning", handleWarning, false),
   add("klee_warning_once", handleWarningOnce, false),
   add("klee_alias_function", handleAliasFunction, false),
@@ -454,7 +467,7 @@ void SpecialFunctionHandler::handleWarning(ExecutionState &state,
   assert(arguments.size()==1 && "invalid number of arguments to klee_warning");
 
   std::string msg_str = readStringAtAddress(state, arguments[0]);
-  klee_warning("%s: %s", state.stack.back().kf->function->getName().data(), 
+  klee_warning("%s: %s", state.stack().back().kf->function->getName().data(), 
                msg_str.c_str());
 }
 
@@ -465,7 +478,7 @@ void SpecialFunctionHandler::handleWarningOnce(ExecutionState &state,
          "invalid number of arguments to klee_warning_once");
 
   std::string msg_str = readStringAtAddress(state, arguments[0]);
-  klee_warning_once(0, "%s: %s", state.stack.back().kf->function->getName().data(),
+  klee_warning_once(0, "%s: %s", state.stack().back().kf->function->getName().data(),
                     msg_str.c_str());
 }
 
@@ -638,7 +651,7 @@ void SpecialFunctionHandler::handleDefineFixedObject(ExecutionState &state,
   
   uint64_t address = cast<ConstantExpr>(arguments[0])->getZExtValue();
   uint64_t size = cast<ConstantExpr>(arguments[1])->getZExtValue();
-  MemoryObject *mo = executor.memory->allocateFixed(address, size, state.prevPC->inst);
+  MemoryObject *mo = executor.memory->allocateFixed(address, size, state.prevPC()->inst);
   executor.bindObjectInState(state, mo, false);
   mo->isUserSpecified = true; // XXX hack;
 }
@@ -745,3 +758,125 @@ void SpecialFunctionHandler::handleDivRemOverflow(ExecutionState &state,
                                  "overflow on division or remainder",
                                  "overflow.err");
 }
+
+void SpecialFunctionHandler::handleThreadCreate(ExecutionState &state,
+                                                KInstruction *target,
+                                                std::vector<ref<Expr> > &arguments) {
+  assert(arguments.size() == 3 && "invalid number of arguments to klee_thread_create");
+
+  ref<Expr> tid = executor.toUnique(state, arguments[0]);
+
+  if (!isa<ConstantExpr>(tid)) {
+    executor.terminateStateOnError(state, "klee_thread_create", "user.err");
+    return;
+  }
+
+  /* TODO executor.executeThreadCreate(state, cast<ConstantExpr>(tid)->getZExtValue(),
+                               arguments[1], arguments[2]);*/
+}
+
+void SpecialFunctionHandler::handleThreadTerminate(ExecutionState &state,
+                                                   KInstruction *target,
+                                                   std::vector<ref<Expr> > &arguments) {
+  assert(arguments.empty() && "invalid number of arguments to klee_thread_terminate");
+
+  /* TODO executor.executeThreadExit(state);*/
+}
+
+void SpecialFunctionHandler::handleThreadPreempt(ExecutionState &state,
+                                                 KInstruction *target,
+                                                 std::vector<ref<Expr> > &arguments) {
+  assert(arguments.size() == 1 && "invalid number of arguments to klee_thread_preempt");
+
+  if (!isa<ConstantExpr>(arguments[0])) {
+    executor.terminateStateOnError(state, "klee_thread_preempt", "user.err");
+  }
+
+  /* TODO executor.schedule(state, !arguments[0]->isZero(), false);*/
+}
+
+void SpecialFunctionHandler::handleThreadSleep(ExecutionState &state,
+                                               KInstruction *target,
+                                               std::vector<ref<Expr> > &arguments) {
+
+  assert(arguments.size() == 1 && "invalid number of arguments to klee_thread_sleep");
+
+  ref<Expr> wlistExpr = executor.toUnique(state, arguments[0]);
+
+  if (!isa<ConstantExpr>(wlistExpr)) {
+    executor.terminateStateOnError(state, "klee_thread_sleep", "user.err");
+    return;
+  }
+
+  state.sleepThread(cast<ConstantExpr>(wlistExpr)->getZExtValue());
+  /* TODO executor.schedule(state, false, false);*/
+}
+
+void SpecialFunctionHandler::handleThreadNotify(ExecutionState &state,
+                                                KInstruction *target,
+                                                std::vector<ref<Expr> > &arguments) {
+  assert(arguments.size() == 2 && "invalid number of arguments to klee_thread_notify");
+
+  ref<Expr> wlist = executor.toUnique(state, arguments[0]);
+  ref<Expr> all = executor.toUnique(state, arguments[1]);
+
+  if (!isa<ConstantExpr>(wlist) || !isa<ConstantExpr>(all)) {
+    executor.terminateStateOnError(state, "klee_thread_notify", "user.err");
+    return;
+  }
+
+  if (all->isZero()) {
+    /* TODO executor.executeThreadNotifyOne(state, cast<ConstantExpr>(wlist)->getZExtValue());*/
+  } else {
+    // It's simple enough such that it can be handled by the state class itself
+    state.notifyAll(cast<ConstantExpr>(wlist)->getZExtValue());
+  }
+}
+
+void SpecialFunctionHandler::handleGetWList(ExecutionState &state,
+                                            KInstruction *target,
+                                            std::vector<ref<Expr> > &arguments) {
+  assert(arguments.empty() && "invalid number of arguments to klee_get_wlist");
+
+  Thread::wlist_id_t id = state.getWaitingList();
+
+  executor.bindLocal(target, state, ConstantExpr::create(id,
+                     executor.getWidthForLLVMType(target->inst->getType())));
+}
+
+void SpecialFunctionHandler::handleGetContext(ExecutionState &state,
+                                              KInstruction *target,
+                                              std::vector<ref<Expr> > &arguments) {
+  assert(arguments.size() == 1 && "invalid number of arguments to klee_get_context");
+
+  ref<Expr> tidAddr = executor.toUnique(state, arguments[0]);
+
+  if (!isa<ConstantExpr>(tidAddr)) {
+    executor.terminateStateOnError(state, "klee_get_context requires constant args",
+                                   "user.err");
+    return;
+  }
+
+  if (!tidAddr->isZero()) {
+    if (!writeConcreteValue(state, tidAddr, state.crtThread().getTid(),
+         executor.getWidthForLLVMType(Type::getInt64Ty(getGlobalContext()))))
+      return;
+  }
+}
+
+bool SpecialFunctionHandler::writeConcreteValue(ExecutionState &state,
+                                                ref<Expr> address, uint64_t value, 
+                                                Expr::Width width) {
+  ObjectPair op;
+
+  if (!state.addressSpace.resolveOne(cast<ConstantExpr>(address), op)) {
+    executor.terminateStateOnError(state, "invalid pointer for writing concrete value into", "user.err");
+    return false;
+  }
+
+  ObjectState *os = state.addressSpace.getWriteable(op.first, op.second);
+  os->write(op.first->getOffsetExpr(address), ConstantExpr::create(value, width));
+
+  return true;
+}
+

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -865,7 +865,7 @@ void SpecialFunctionHandler::handleGetContext(ExecutionState &state,
 }
 
 bool SpecialFunctionHandler::writeConcreteValue(ExecutionState &state,
-                                                ref<Expr> address, uint64_t value, 
+                                                ref<Expr> address, uint64_t value,
                                                 Expr::Width width) {
   ObjectPair op;
 

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -771,8 +771,8 @@ void SpecialFunctionHandler::handleThreadCreate(ExecutionState &state,
     return;
   }
 
-  /* TODO executor.executeThreadCreate(state, cast<ConstantExpr>(tid)->getZExtValue(),
-                               arguments[1], arguments[2]);*/
+  executor.executeThreadCreate(state, cast<ConstantExpr>(tid)->getZExtValue(),
+                               arguments[1], arguments[2]);
 }
 
 void SpecialFunctionHandler::handleThreadTerminate(ExecutionState &state,
@@ -780,7 +780,7 @@ void SpecialFunctionHandler::handleThreadTerminate(ExecutionState &state,
                                                    std::vector<ref<Expr> > &arguments) {
   assert(arguments.empty() && "invalid number of arguments to klee_thread_terminate");
 
-  /* TODO executor.executeThreadExit(state);*/
+  executor.executeThreadExit(state);
 }
 
 void SpecialFunctionHandler::handleThreadPreempt(ExecutionState &state,
@@ -792,7 +792,7 @@ void SpecialFunctionHandler::handleThreadPreempt(ExecutionState &state,
     executor.terminateStateOnError(state, "klee_thread_preempt", "user.err");
   }
 
-  /* TODO executor.schedule(state, !arguments[0]->isZero(), false);*/
+  executor.schedule(state, !arguments[0]->isZero(), false);
 }
 
 void SpecialFunctionHandler::handleThreadSleep(ExecutionState &state,
@@ -809,7 +809,7 @@ void SpecialFunctionHandler::handleThreadSleep(ExecutionState &state,
   }
 
   state.sleepThread(cast<ConstantExpr>(wlistExpr)->getZExtValue());
-  /* TODO executor.schedule(state, false, false);*/
+  executor.schedule(state, false, false);
 }
 
 void SpecialFunctionHandler::handleThreadNotify(ExecutionState &state,
@@ -826,7 +826,7 @@ void SpecialFunctionHandler::handleThreadNotify(ExecutionState &state,
   }
 
   if (all->isZero()) {
-    /* TODO executor.executeThreadNotifyOne(state, cast<ConstantExpr>(wlist)->getZExtValue());*/
+    executor.executeThreadNotifyOne(state, cast<ConstantExpr>(wlist)->getZExtValue());
   } else {
     // It's simple enough such that it can be handled by the state class itself
     state.notifyAll(cast<ConstantExpr>(wlist)->getZExtValue());

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -10,6 +10,8 @@
 #ifndef KLEE_SPECIALFUNCTIONHANDLER_H
 #define KLEE_SPECIALFUNCTIONHANDLER_H
 
+#include "klee/Expr.h"
+
 #include <iterator>
 #include <map>
 #include <vector>
@@ -91,6 +93,8 @@ namespace klee {
     /* Convenience routines */
 
     std::string readStringAtAddress(ExecutionState &state, ref<Expr> address);
+   
+    bool writeConcreteValue(ExecutionState &state, ref<Expr> address, uint64_t value, Expr::Width width);
     
     /* Handlers */
 
@@ -109,9 +113,11 @@ namespace klee {
     HANDLER(handleExit);
     HANDLER(handleAliasFunction);
     HANDLER(handleFree);
+    HANDLER(handleGetContext);
     HANDLER(handleGetErrno);
     HANDLER(handleGetObjSize);
     HANDLER(handleGetValue);
+    HANDLER(handleGetWList);
     HANDLER(handleIsSymbolic);
     HANDLER(handleMakeSymbolic);
     HANDLER(handleMalloc);
@@ -129,6 +135,11 @@ namespace klee {
     HANDLER(handleSetForking);
     HANDLER(handleSilentExit);
     HANDLER(handleStackTrace);
+    HANDLER(handleThreadCreate);
+    HANDLER(handleThreadNotify);
+    HANDLER(handleThreadPreempt);
+    HANDLER(handleThreadSleep);
+    HANDLER(handleThreadTerminate);
     HANDLER(handleUnderConstrained);
     HANDLER(handleWarning);
     HANDLER(handleWarningOnce);

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -24,6 +24,7 @@
 #include "CoreStats.h"
 #include "Executor.h"
 #include "MemoryManager.h"
+#include "Thread.h"
 #include "UserSearcher.h"
 #include "../Solver/SolverStats.h"
 
@@ -284,9 +285,9 @@ void StatsTracker::stepInstruction(ExecutionState &es) {
       }
     }
 
-    Instruction *inst = es.pc->inst;
-    const InstructionInfo &ii = *es.pc->info;
-    StackFrame &sf = es.stack.back();
+    Instruction *inst = es.pc()->inst;
+    const InstructionInfo &ii = *es.pc()->info;
+    StackFrame &sf = es.stack().back();
     theStatisticManager->setIndex(ii.id);
     if (UseCallPaths)
       theStatisticManager->setContext(&sf.callPathNode->statistics);
@@ -316,24 +317,29 @@ void StatsTracker::stepInstruction(ExecutionState &es) {
 /* Should be called _after_ the es->pushFrame() */
 void StatsTracker::framePushed(ExecutionState &es, StackFrame *parentFrame) {
   if (OutputIStats) {
-    StackFrame &sf = es.stack.back();
+    StackFrame &sf = es.stack().back();
+    framePushed(&sf,parentFrame);
+  }
+}
 
+void StatsTracker::framePushed(StackFrame *frame, StackFrame *parentFrame) {
+  if (OutputIStats) {
     if (UseCallPaths) {
       CallPathNode *parent = parentFrame ? parentFrame->callPathNode : 0;
-      CallPathNode *cp = callPathManager.getCallPath(parent, 
-                                                     sf.caller ? sf.caller->inst : 0, 
-                                                     sf.kf->function);
-      sf.callPathNode = cp;
+      CallPathNode *cp = callPathManager.getCallPath(parent,
+                    frame->caller ? frame->caller->inst : 0,
+                    frame->kf->function);
+      frame->callPathNode = cp;
       cp->count++;
     }
 
-    if (updateMinDistToUncovered) {
-      uint64_t minDistAtRA = 0;
-      if (parentFrame)
-        minDistAtRA = parentFrame->minDistToUncoveredOnReturn;
-      
-      sf.minDistToUncoveredOnReturn = sf.caller ?
-        computeMinDistToUncovered(sf.caller, minDistAtRA) : 0;
+  if (updateMinDistToUncovered) {
+    uint64_t minDistAtRA = 0;
+    if (parentFrame)
+      minDistAtRA = parentFrame->minDistToUncoveredOnReturn;
+
+      frame->minDistToUncoveredOnReturn = frame->caller ?
+      computeMinDistToUncovered(frame->caller, minDistAtRA) : 0;
     }
   }
 }
@@ -432,10 +438,10 @@ void StatsTracker::updateStateStatistics(uint64_t addend) {
   for (std::set<ExecutionState*>::iterator it = executor.states.begin(),
          ie = executor.states.end(); it != ie; ++it) {
     ExecutionState &state = **it;
-    const InstructionInfo &ii = *state.pc->info;
+    const InstructionInfo &ii = *state.pc()->info;
     theStatisticManager->incrementIndexedValue(stats::states, ii.id, addend);
     if (UseCallPaths)
-      state.stack.back().callPathNode->statistics.incrementValue(stats::states, addend);
+      state.stack().back().callPathNode->statistics.incrementValue(stats::states, addend);
   }
 }
 
@@ -856,13 +862,13 @@ void StatsTracker::computeReachableUncovered() {
          ie = executor.states.end(); it != ie; ++it) {
     ExecutionState *es = *it;
     uint64_t currentFrameMinDist = 0;
-    for (ExecutionState::stack_ty::iterator sfIt = es->stack.begin(),
-           sf_ie = es->stack.end(); sfIt != sf_ie; ++sfIt) {
-      ExecutionState::stack_ty::iterator next = sfIt + 1;
+    for (Thread::stack_ty::iterator sfIt = es->stack().begin(),
+           sf_ie = es->stack().end(); sfIt != sf_ie; ++sfIt) {
+      Thread::stack_ty::iterator next = sfIt + 1;
       KInstIterator kii;
 
-      if (next==es->stack.end()) {
-        kii = es->pc;
+      if (next==es->stack().end()) {
+        kii = es->pc();
       } else {
         kii = next->caller;
         ++kii;

--- a/lib/Core/StatsTracker.h
+++ b/lib/Core/StatsTracker.h
@@ -61,6 +61,7 @@ namespace klee {
     ~StatsTracker();
 
     // called after a new StackFrame has been pushed (for callpath tracing)
+    void framePushed(StackFrame *frame, StackFrame *parentFrame);
     void framePushed(ExecutionState &es, StackFrame *parentFrame);
 
     // called after a StackFrame has been popped 

--- a/lib/Core/Thread.cpp
+++ b/lib/Core/Thread.cpp
@@ -72,7 +72,7 @@ StackFrame::~StackFrame() {
 
 /* Thread class methods */
 
-Thread::Thread(thread_id_t tid, KFunction * kf) 
+Thread::Thread(thread_id_t tid, KFunction * kf)
   : enabled(true), waitingList(0) {
 
   this->tid = tid;

--- a/lib/Core/Thread.cpp
+++ b/lib/Core/Thread.cpp
@@ -1,0 +1,86 @@
+/*
+ * Cloud9 Parallel Symbolic Execution Engine
+ *
+ * Copyright (c) 2011, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *
+ * Stefan Bucur <stefan.bucur@epfl.ch>
+ * Vlad Ureche <vlad.ureche@epfl.ch>
+ * Cristian Zamfir <cristian.zamfir@epfl.ch>
+ * Ayrat Khalimov <ayrat.khalimov@epfl.ch>
+ * Prof. George Candea <george.candea@epfl.ch>
+ *
+ * External Contributors:
+ * Calin Iorgulescu <calin.iorgulescu@gmail.com>
+ * Tudor Cazangiu <tudor.cazangiu@gmail.com>
+ *
+ * Stefan Bucur <sbucur@google.com> (contributions done while at Google)
+ * Lorenzo Martignoni <martignlo@google.com>
+ * Burak Emir <bqe@google.com>
+ *
+*/
+
+#include "Thread.h"
+
+using namespace klee;
+
+StackFrame::StackFrame(KInstIterator _caller, KFunction *_kf)
+  : caller(_caller), kf(_kf), callPathNode(0),
+    minDistToUncoveredOnReturn(0), varargs(0) {
+  locals = new Cell[kf->numRegisters];
+}
+
+StackFrame::StackFrame(const StackFrame &s)
+  : caller(s.caller),
+    kf(s.kf),
+    callPathNode(s.callPathNode),
+    allocas(s.allocas),
+    minDistToUncoveredOnReturn(s.minDistToUncoveredOnReturn),
+    varargs(s.varargs) {
+  locals = new Cell[s.kf->numRegisters];
+  for (unsigned i=0; i<s.kf->numRegisters; i++)
+    locals[i] = s.locals[i];
+}
+
+StackFrame::~StackFrame() {
+  delete[] locals;
+}
+
+/* Thread class methods */
+
+Thread::Thread(thread_id_t tid, KFunction * kf) 
+  : enabled(true), waitingList(0) {
+
+  this->tid = tid;
+
+  if (kf) {
+    stack.push_back(StackFrame(0, kf));
+
+    pc = kf->instructions;
+    prevPC = pc;
+  }
+}

--- a/lib/Core/Thread.h
+++ b/lib/Core/Thread.h
@@ -1,0 +1,117 @@
+/*
+ * Cloud9 Parallel Symbolic Execution Engine
+ *
+ * Copyright (c) 2011, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *
+ * Stefan Bucur <stefan.bucur@epfl.ch>
+ * Vlad Ureche <vlad.ureche@epfl.ch>
+ * Cristian Zamfir <cristian.zamfir@epfl.ch>
+ * Ayrat Khalimov <ayrat.khalimov@epfl.ch>
+ * Prof. George Candea <george.candea@epfl.ch>
+ *
+ * External Contributors:
+ * Calin Iorgulescu <calin.iorgulescu@gmail.com>
+ * Tudor Cazangiu <tudor.cazangiu@gmail.com>
+ *
+ * Stefan Bucur <sbucur@google.com> (contributions done while at Google)
+ * Lorenzo Martignoni <martignlo@google.com>
+ * Burak Emir <bqe@google.com>
+ *
+*/
+
+#ifndef THREADING_H_
+#define THREADING_H_
+
+#include "klee/Expr.h"
+#include "klee/Internal/Module/Cell.h"
+#include "klee/Internal/Module/KInstIterator.h"
+#include "klee/Internal/Module/KModule.h"
+
+#include "AddressSpace.h"
+#include "CallPathManager.h"
+
+#include <map>
+
+namespace klee {
+
+struct StackFrame {
+    KInstIterator caller;
+    KFunction *kf;
+    CallPathNode *callPathNode;
+
+    std::vector<const MemoryObject*> allocas;
+    Cell *locals;
+
+    /// Minimum distance to an uncovered instruction once the function
+    /// returns. This is not a good place for this but is used to
+    /// quickly compute the context sensitive minimum distance to an
+    /// uncovered instruction. This value is updated by the StatsTracker
+    /// periodically.
+    unsigned minDistToUncoveredOnReturn;
+
+    // For vararg functions: arguments not passed via parameter are
+    // stored (packed tightly) in a local (alloca) memory object. This
+    // is setup to match the way the front-end generates vaarg code (it
+    // does not pass vaarg through as expected). VACopy is lowered inside
+    // of intrinsic lowering.
+    MemoryObject *varargs;
+
+    StackFrame(KInstIterator caller, KFunction *kf);
+    StackFrame(const StackFrame &s);
+    ~StackFrame();
+};
+
+
+class Thread {
+  friend class Executor;
+  friend class ExecutionState;
+
+public:
+  typedef std::vector<StackFrame> stack_ty;
+  typedef uint64_t thread_id_t;
+  typedef uint64_t wlist_id_t;
+
+private:
+  KInstIterator pc, prevPC;
+  unsigned incomingBBIndex;
+
+  stack_ty stack;
+
+  bool enabled;
+  wlist_id_t waitingList;
+
+  thread_id_t tid;
+public:
+  Thread(thread_id_t tid, KFunction *start_function);
+
+  thread_id_t getTid() const { return tid; }
+};
+
+}
+
+#endif /* THREADING_H_ */

--- a/lib/Core/Thread.h
+++ b/lib/Core/Thread.h
@@ -60,30 +60,30 @@
 namespace klee {
 
 struct StackFrame {
-    KInstIterator caller;
-    KFunction *kf;
-    CallPathNode *callPathNode;
+  KInstIterator caller;
+  KFunction *kf;
+  CallPathNode *callPathNode;
 
-    std::vector<const MemoryObject*> allocas;
-    Cell *locals;
+  std::vector<const MemoryObject*> allocas;
+  Cell *locals;
 
-    /// Minimum distance to an uncovered instruction once the function
-    /// returns. This is not a good place for this but is used to
-    /// quickly compute the context sensitive minimum distance to an
-    /// uncovered instruction. This value is updated by the StatsTracker
-    /// periodically.
-    unsigned minDistToUncoveredOnReturn;
+  /// Minimum distance to an uncovered instruction once the function
+  /// returns. This is not a good place for this but is used to
+  /// quickly compute the context sensitive minimum distance to an
+  /// uncovered instruction. This value is updated by the StatsTracker
+  /// periodically.
+  unsigned minDistToUncoveredOnReturn;
 
-    // For vararg functions: arguments not passed via parameter are
-    // stored (packed tightly) in a local (alloca) memory object. This
-    // is setup to match the way the front-end generates vaarg code (it
-    // does not pass vaarg through as expected). VACopy is lowered inside
-    // of intrinsic lowering.
-    MemoryObject *varargs;
+  // For vararg functions: arguments not passed via parameter are
+  // stored (packed tightly) in a local (alloca) memory object. This
+  // is setup to match the way the front-end generates vaarg code (it
+  // does not pass vaarg through as expected). VACopy is lowered inside
+  // of intrinsic lowering.
+  MemoryObject *varargs;
 
-    StackFrame(KInstIterator caller, KFunction *kf);
-    StackFrame(const StackFrame &s);
-    ~StackFrame();
+  StackFrame(KInstIterator caller, KFunction *kf);
+  StackFrame(const StackFrame &s);
+  ~StackFrame();
 };
 
 

--- a/runtime/POSIX/klee_init_env.c
+++ b/runtime/POSIX/klee_init_env.c
@@ -12,6 +12,7 @@
 #define _LARGEFILE64_SOURCE
 #endif
 #include "fd.h"
+#include "threads.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -193,5 +194,6 @@ usage: (klee_init_env) [options] [program arguments]\n\
   klee_init_fds(sym_files, sym_file_len, 
 		sym_stdout_flag, save_all_writes_flag, 
 		fd_fail);
+  klee_init_threads();
 }
 

--- a/runtime/POSIX/semaphores.c
+++ b/runtime/POSIX/semaphores.c
@@ -1,0 +1,163 @@
+/*
+ * Cloud9 Parallel Symbolic Execution Engine
+ *
+ * Copyright (c) 2011, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *
+ * Stefan Bucur <stefan.bucur@epfl.ch>
+ * Vlad Ureche <vlad.ureche@epfl.ch>
+ * Cristian Zamfir <cristian.zamfir@epfl.ch>
+ * Ayrat Khalimov <ayrat.khalimov@epfl.ch>
+ * Prof. George Candea <george.candea@epfl.ch>
+ *
+ * External Contributors:
+ * Calin Iorgulescu <calin.iorgulescu@gmail.com>
+ * Tudor Cazangiu <tudor.cazangiu@gmail.com>
+ *
+ * Stefan Bucur <sbucur@google.com> (contributions done while at Google)
+ * Lorenzo Martignoni <martignlo@google.com>
+ * Burak Emir <bqe@google.com>
+ *
+ */
+
+#include "threads.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include <klee/klee.h>
+
+
+////////////////////////////////////////////////////////////////////////////////
+// POSIX Semaphores
+////////////////////////////////////////////////////////////////////////////////
+#define SEM_VALUE_MAX 32000
+#define __SIZEOF_SEM_T	32
+
+typedef union
+{
+  char __size[__SIZEOF_SEM_T];
+  long int __align;
+} sem_posix_t;
+
+static sem_data_t *_get_sem_data(sem_posix_t *sem) {
+  sem_data_t *sdata = *((sem_data_t**)sem);
+
+  return sdata;
+}
+
+int sem_init(sem_posix_t *sem, int pshared, unsigned int value) {
+  if (pshared != 0) 
+        klee_report_error(__FILE__, __LINE__, "semaphore shared between processes is not supported", "user.err");
+  
+  if(value > SEM_VALUE_MAX) {
+    errno = EINVAL;
+    return -1;
+  }
+  
+  sem_data_t *sdata = (sem_data_t*)malloc(sizeof(sem_data_t));
+  memset(sdata, 0, sizeof(sem_data_t));
+
+  *((sem_data_t**)sem) = sdata;
+
+  sdata->wlist = klee_get_wlist();
+  sdata->count = value;
+
+  return 0;
+}
+
+int sem_destroy(sem_posix_t *sem) {
+  sem_data_t *sdata = _get_sem_data(sem);
+
+  free(sdata);
+
+  return 0;
+}
+
+static int _atomic_sem_lock(sem_data_t *sdata, char try) {
+  sdata->count--;
+  if (sdata->count < 0) {
+    if (try) {
+      sdata->count++;
+      errno = EBUSY;
+      return -1;
+    } else {
+      __thread_sleep(sdata->wlist);
+    }
+  }
+
+  return 0;
+}
+
+int sem_wait(sem_posix_t *sem) {
+  //__thread_preempt(0);
+
+  sem_data_t *sdata = _get_sem_data(sem);
+
+  int res = _atomic_sem_lock(sdata, 0);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+int sem_trywait(sem_posix_t *sem) {
+  //__thread_preempt(0);
+
+  sem_data_t *sdata = _get_sem_data(sem);
+
+  int res = _atomic_sem_lock(sdata, 1);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+static int _atomic_sem_unlock(sem_data_t *sdata) {
+  sdata->count++;
+
+  if (sdata->count <= 0)
+    __thread_notify_one(sdata->wlist);
+
+  return 0;
+}
+
+int sem_post(sem_posix_t *sem) {
+  //__thread_preempt(0);
+
+  sem_data_t *sdata = _get_sem_data(sem);
+
+  int res = _atomic_sem_unlock(sdata);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}

--- a/runtime/POSIX/threads.c
+++ b/runtime/POSIX/threads.c
@@ -1,0 +1,745 @@
+/*
+ * Cloud9 Parallel Symbolic Execution Engine
+ *
+ * Copyright (c) 2011, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *
+ * Stefan Bucur <stefan.bucur@epfl.ch>
+ * Vlad Ureche <vlad.ureche@epfl.ch>
+ * Cristian Zamfir <cristian.zamfir@epfl.ch>
+ * Ayrat Khalimov <ayrat.khalimov@epfl.ch>
+ * Prof. George Candea <george.candea@epfl.ch>
+ *
+ * External Contributors:
+ * Calin Iorgulescu <calin.iorgulescu@gmail.com>
+ * Tudor Cazangiu <tudor.cazangiu@gmail.com>
+ *
+ * Stefan Bucur <sbucur@google.com> (contributions done while at Google)
+ * Lorenzo Martignoni <martignlo@google.com>
+ * Burak Emir <bqe@google.com>
+ *
+ */
+
+#include "threads.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#include <klee/klee.h>
+
+////////////////////////////////////////////////////////////////////////////////
+// The PThreads API
+////////////////////////////////////////////////////////////////////////////////
+
+pthread_t pthread_self(void) {
+  pthread_t result;
+
+  klee_get_context(&result);
+
+  return result;
+}
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+    void *(*start_routine)(void*), void *arg) {
+  unsigned int newIdx = MAX_THREADS;
+  unsigned int i;
+  for (i = 0; i < MAX_THREADS; i++) {
+    if (!__tsync.threads[i].allocated) {
+      __tsync.threads[i].allocated = 1;
+      newIdx = i;
+      break;
+    }
+  }
+
+  if (newIdx == MAX_THREADS) {
+    errno = EAGAIN;
+    return -1;
+  }
+
+  thread_data_t *tdata = &__tsync.threads[newIdx];
+  tdata->terminated = 0;
+  tdata->joinable = 1; // TODO: Read this from an attribute
+  tdata->wlist = klee_get_wlist();
+
+  klee_thread_create(newIdx, start_routine, arg);
+  *thread = newIdx;
+
+  __thread_preempt(0);
+
+  return 0;
+}
+
+void pthread_exit(void *value_ptr) {
+  unsigned int idx = pthread_self();
+  thread_data_t *tdata = &__tsync.threads[idx];
+
+  if (tdata->joinable) {
+    tdata->terminated = 1;
+    tdata->ret_value = value_ptr;
+
+    __thread_notify_all(tdata->wlist);
+  } else {
+    memset(&__tsync.threads[idx], 0, sizeof(__tsync.threads[idx]));
+  }
+
+  klee_thread_terminate(); // Does not return
+}
+
+
+int pthread_join(pthread_t thread, void **value_ptr) {
+  if (thread >= MAX_THREADS) {
+    errno = ESRCH;
+    return -1;
+  }
+
+  if (thread == pthread_self()) {
+    errno = EDEADLK;
+    return -1;
+  }
+
+  thread_data_t *tdata = &__tsync.threads[thread];
+
+  if (!tdata->allocated) {
+    errno = ESRCH;
+    return -1;
+  }
+
+  if (!tdata->joinable) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (!tdata->terminated)
+    __thread_sleep(tdata->wlist);
+
+  if (value_ptr) {
+    *value_ptr = tdata->ret_value;
+  }
+
+  memset(&__tsync.threads[thread], 0, sizeof(__tsync.threads[thread]));
+
+  return 0;
+}
+
+int pthread_detach(pthread_t thread) {
+  if (thread >= MAX_THREADS) {
+    errno = ESRCH;
+  }
+
+  thread_data_t *tdata = &__tsync.threads[thread];
+
+  if (!tdata->allocated) {
+    errno = ESRCH;
+    return -1;
+  }
+
+  if (!tdata->joinable) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (tdata->terminated) {
+    memset(&__tsync.threads[thread], 0, sizeof(__tsync.threads[thread]));
+  } else {
+    tdata->joinable = 0;
+  }
+
+  return 0;
+}
+
+int pthread_attr_init(pthread_attr_t *attr) {
+  klee_warning("pthread_attr_init does nothing");
+  return 0;
+}
+
+int pthread_attr_destroy(pthread_attr_t *attr) {
+  klee_warning("pthread_attr_destroy does nothing");
+  return 0;
+}
+
+int pthread_once(pthread_once_t *once_control, void (*init_routine)(void)) {
+  if (*once_control == 0) {
+    init_routine();
+
+    *once_control = 1;
+  }
+
+  return 0;
+}
+
+int pthread_equal(pthread_t thread1, pthread_t thread2) {
+  return thread1 == thread2;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// POSIX Mutexes
+////////////////////////////////////////////////////////////////////////////////
+
+static void _mutexattr_init(pthread_mutexattr_t *attr) {
+  memset(attr,0,sizeof(pthread_mutexattr_t));
+}
+
+static int _get_mutexattr_data(const pthread_mutexattr_t *attr) {
+  return attr->__align;
+}
+
+static void _set_mutexattr_data(pthread_mutexattr_t *attr, int val) {
+  attr->__align = val;
+}
+
+int pthread_mutexattr_init(pthread_mutexattr_t *attr)
+{
+  _mutexattr_init(attr);
+
+  return 0;
+}
+int pthread_mutexattr_destroy(pthread_mutexattr_t *attr)
+{
+  return 0;
+}
+int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type)
+{
+  _set_mutexattr_data(attr, type);
+  return 0;
+}
+
+static void _mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr) {
+  mutex_data_t *mdata = (mutex_data_t*)malloc(sizeof(mutex_data_t));
+  memset(mdata, 0, sizeof(mutex_data_t));
+
+  *((mutex_data_t**)mutex) = mdata;
+
+  mdata->wlist = klee_get_wlist();
+  mdata->taken = 0;
+  mdata->queued = 0;
+  if(attr != 0) {
+    if(_get_mutexattr_data(attr) == PTHREAD_MUTEX_RECURSIVE)
+      mdata->count = 0;
+    else
+      mdata->count = -1;
+  }
+  else
+    mdata->count = -1;
+}
+
+static mutex_data_t *_get_mutex_data(pthread_mutex_t *mutex) {
+  mutex_data_t *mdata = *((mutex_data_t**)mutex);
+
+  if (mdata == STATIC_MUTEX_VALUE) {
+    _mutex_init(mutex, 0);
+
+    mdata = *((mutex_data_t**)mutex);
+  }
+
+  return mdata;
+}
+
+int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr) {
+  _mutex_init(mutex, attr);
+
+  return 0;
+}
+
+int pthread_mutex_destroy(pthread_mutex_t *mutex) {
+  mutex_data_t *mdata = _get_mutex_data(mutex);
+
+  free(mdata);
+
+  return 0;
+}
+
+static int _atomic_mutex_lock(mutex_data_t *mdata, char try) {
+  if (mdata->taken && mdata->count >= 0 && mdata->owner == pthread_self()) {
+    mdata->count++;
+    return 0;
+  }
+  else if (mdata->queued > 0 || mdata->taken) {
+    if (try) {
+      errno = EBUSY;
+      return -1;
+    } else {
+      mdata->queued++;
+      __thread_sleep(mdata->wlist);
+      mdata->queued--;
+    }
+  }
+  mdata->taken = 1;
+  mdata->owner = pthread_self();
+  if(mdata->count != -1)
+    mdata->count = 1;
+
+  return 0;
+}
+
+int pthread_mutex_lock(pthread_mutex_t *mutex) {
+  //__thread_preempt(0);
+
+  mutex_data_t *mdata = _get_mutex_data(mutex);
+
+  int res = _atomic_mutex_lock(mdata, 0);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+int pthread_mutex_trylock(pthread_mutex_t *mutex) {
+  //__thread_preempt(0);
+
+  mutex_data_t *mdata = _get_mutex_data(mutex);
+
+  int res = _atomic_mutex_lock(mdata, 1);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+static int _atomic_mutex_unlock(mutex_data_t *mdata) {
+  if (mdata->taken && mdata->count > 0 && mdata->owner == pthread_self()) {
+    mdata->count--;
+    if(mdata->count != 0)
+      return 0;
+  }
+  else if (!mdata->taken || mdata->owner != pthread_self()) {
+    errno = EPERM;
+    return -1;
+  }
+
+  mdata->taken = 0;
+
+  if (mdata->queued > 0)
+    __thread_notify_one(mdata->wlist);
+
+  return 0;
+}
+
+int pthread_mutex_unlock(pthread_mutex_t *mutex) {
+  //__thread_preempt(0);
+
+  mutex_data_t *mdata = _get_mutex_data(mutex);
+
+  int res = _atomic_mutex_unlock(mdata);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// POSIX Condition Variables
+////////////////////////////////////////////////////////////////////////////////
+
+static void _cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr) {
+  condvar_data_t *cdata = (condvar_data_t*)malloc(sizeof(condvar_data_t));
+  memset(cdata, 0, sizeof(condvar_data_t));
+
+  *((condvar_data_t**)cond) = cdata;
+
+  cdata->wlist = klee_get_wlist();
+}
+
+static condvar_data_t *_get_condvar_data(pthread_cond_t *cond) {
+  condvar_data_t *cdata = *((condvar_data_t**)cond);
+
+  if (cdata == STATIC_CVAR_VALUE) {
+    _cond_init(cond, 0);
+
+    cdata = *((condvar_data_t**)cond);
+  }
+
+  return cdata;
+}
+
+int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr) {
+  _cond_init(cond, attr);
+
+  return 0;
+}
+
+int pthread_cond_destroy(pthread_cond_t *cond) {
+  condvar_data_t *cdata = _get_condvar_data(cond);
+
+  free(cdata);
+
+  return 0;
+}
+
+int pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex,
+    const struct timespec *abstime) {
+  assert(0 && "not implemented");
+  return -1;
+}
+
+static int _atomic_cond_wait(condvar_data_t *cdata, mutex_data_t *mdata) {
+  if (cdata->queued > 0) {
+    if (cdata->mutex != mdata) {
+      errno = EINVAL;
+      return -1;
+    }
+  } else {
+    cdata->mutex = mdata;
+  }
+
+  if (_atomic_mutex_unlock(mdata) != 0) {
+    errno = EPERM;
+    return -1;
+  }
+
+  cdata->queued++;
+  __thread_sleep(cdata->wlist);
+  cdata->queued--;
+
+  if (_atomic_mutex_lock(mdata, 0) != 0) {
+    errno = EPERM;
+    return -1;
+  }
+
+  return 0;
+}
+
+int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
+  //__thread_preempt(0);
+
+  condvar_data_t *cdata = _get_condvar_data(cond);
+  mutex_data_t *mdata = _get_mutex_data(mutex);
+
+  int res = _atomic_cond_wait(cdata, mdata);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+static int _atomic_cond_notify(condvar_data_t *cdata, char all) {
+  if (cdata->queued > 0) {
+    if (all)
+      __thread_notify_all(cdata->wlist);
+    else
+      __thread_notify_one(cdata->wlist);
+  }
+
+  return 0;
+}
+
+int pthread_cond_broadcast(pthread_cond_t *cond) {
+  //__thread_preempt(0);
+
+  condvar_data_t *cdata = _get_condvar_data(cond);
+
+  int res = _atomic_cond_notify(cdata, 1);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+int pthread_cond_signal(pthread_cond_t *cond) {
+  //__thread_preempt(0);
+
+  condvar_data_t *cdata = _get_condvar_data(cond);
+
+  int res = _atomic_cond_notify(cdata, 0);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// POSIX Barriers
+////////////////////////////////////////////////////////////////////////////////
+
+static void _barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count) {
+  barrier_data_t *bdata = (barrier_data_t*)malloc(sizeof(barrier_data_t));
+  memset(bdata, 0, sizeof(barrier_data_t));
+
+  *((barrier_data_t**)barrier) = bdata;
+
+  bdata->wlist = klee_get_wlist();
+  bdata->curr_event = 0;
+  bdata->init_count = count;
+  bdata->left = count;
+}
+
+static barrier_data_t *_get_barrier_data(pthread_barrier_t *barrier) {
+  barrier_data_t *bdata = *((barrier_data_t**)barrier);
+
+  if (bdata == STATIC_BARRIER_VALUE) {
+    _barrier_init(barrier, 0, 0);
+
+    bdata = *((barrier_data_t**)barrier);
+  }
+
+  return bdata;
+}
+
+int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count) {
+  _barrier_init(barrier, attr, count);
+
+  return 0;
+}
+
+int pthread_barrier_destroy(pthread_barrier_t *barrier) {
+  barrier_data_t *bdata = _get_barrier_data(barrier);
+
+  free(bdata);
+
+  return 0;
+}
+
+int pthread_barrier_wait(pthread_barrier_t *barrier) {
+  barrier_data_t *bdata = *((barrier_data_t**)barrier);
+  int result = 0;
+
+  if (bdata == STATIC_BARRIER_VALUE) {
+      errno = EINVAL;
+      return -1;
+  }
+
+  --bdata->left;
+
+  if (bdata->left == 0) {
+    ++bdata->curr_event;
+    bdata->left = bdata->init_count;
+
+    __thread_notify_all(bdata->wlist);
+
+    result = PTHREAD_BARRIER_SERIAL_THREAD;
+
+    __thread_preempt(0);
+  }
+  else {
+    __thread_sleep(bdata->wlist);
+  }
+
+  return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// POSIX Read Write Locks
+////////////////////////////////////////////////////////////////////////////////
+
+static void _rwlock_init(pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attr) {
+  rwlock_data_t *rwdata = (rwlock_data_t*)malloc(sizeof(rwlock_data_t));
+  memset(rwdata, 0, sizeof(rwlock_data_t));
+
+  *((rwlock_data_t**)rwlock) = rwdata;
+
+  rwdata->wlist_readers = klee_get_wlist();
+  rwdata->wlist_writers = klee_get_wlist();
+  rwdata->nr_readers = 0;
+}
+
+static rwlock_data_t *_get_rwlock_data(pthread_rwlock_t *rwlock) {
+  rwlock_data_t *rwdata = *((rwlock_data_t**)rwlock);
+
+  if (rwdata == STATIC_RWLOCK_VALUE) {
+    _rwlock_init(rwlock, 0);
+
+    rwdata = *((rwlock_data_t**)rwlock);
+  }
+
+  return rwdata;
+}
+
+int pthread_rwlock_init(pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attr) {
+  _rwlock_init(rwlock, attr);
+
+  return 0;
+}
+
+int pthread_rwlock_destroy(pthread_rwlock_t *rwlock) {
+  rwlock_data_t *rwdata = _get_rwlock_data(rwlock);
+
+  free(rwdata);
+
+  return 0;
+}
+
+static int _atomic_rwlock_rdlock(rwlock_data_t *rwdata, char try) {
+  if (rwdata == STATIC_RWLOCK_VALUE) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (rwdata->writer == 0 && rwdata->nr_writers_queued == 0) {
+    if (++rwdata->nr_readers == 0) {
+      --rwdata->nr_readers;
+      errno = EAGAIN;
+      return -1;
+    }
+
+    return 0;
+  }
+
+  if (try != 0) {
+    errno = EBUSY;
+    return -1;
+  }
+  else {
+    if (++rwdata->nr_readers_queued == 0) {
+      --rwdata->nr_readers_queued;
+      errno = EAGAIN;
+      return -1;
+    }
+
+    __thread_sleep(rwdata->wlist_readers);
+    ++rwdata->nr_readers;
+    --rwdata->nr_readers_queued;
+  }
+
+  return 0;
+}
+
+int pthread_rwlock_rdlock(pthread_rwlock_t *rwlock) {
+  //__thread_preempt(0);
+
+  rwlock_data_t *rwdata = *((rwlock_data_t**)rwlock);
+
+  int res = _atomic_rwlock_rdlock(rwdata, 0);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+int pthread_rwlock_tryrdlock(pthread_rwlock_t *rwlock) {
+  //__thread_preempt(0);
+
+  rwlock_data_t *rwdata = *((rwlock_data_t**)rwlock);
+
+  int res = _atomic_rwlock_rdlock(rwdata, 1);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+static int _atomic_rwlock_wrlock(rwlock_data_t *rwdata, char try) {
+  if (rwdata == STATIC_RWLOCK_VALUE) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (rwdata->writer == 0 && rwdata->nr_readers == 0) {
+    rwdata->writer = pthread_self();
+    return 0;
+  }
+
+  if (try != 0) {
+    errno = EBUSY;
+    return -1;
+  }
+  else {
+    if (++rwdata->nr_writers_queued == 0) {
+      --rwdata->nr_writers_queued;
+      errno = EAGAIN;
+      return -1;
+    }
+
+    __thread_sleep(rwdata->wlist_writers);
+    rwdata->writer = pthread_self();
+    --rwdata->nr_writers_queued;
+  }
+
+  return 0;
+}
+
+int pthread_rwlock_wrlock(pthread_rwlock_t *rwlock) {
+  //__thread_preempt(0);
+
+  rwlock_data_t *rwdata = *((rwlock_data_t**)rwlock);
+
+  int res = _atomic_rwlock_wrlock(rwdata, 0);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+int pthread_rwlock_trywrlock(pthread_rwlock_t *rwlock) {
+  //__thread_preempt(0);
+
+  rwlock_data_t *rwdata = *((rwlock_data_t**)rwlock);
+
+  int res = _atomic_rwlock_wrlock(rwdata, 1);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}
+
+static int _atomic_rwlock_unlock(rwlock_data_t *rwdata) {
+  if (rwdata == STATIC_RWLOCK_VALUE) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (rwdata->writer != 0)
+    rwdata->writer = 0;
+  else {
+    if (rwdata->nr_readers > 0)
+      --rwdata->nr_readers;
+  }
+
+  if (rwdata->nr_readers == 0 && rwdata->nr_writers_queued)
+    __thread_notify_one(rwdata->wlist_writers);
+  else {
+    if (rwdata->nr_readers_queued > 0)
+      __thread_notify_all(rwdata->wlist_readers);
+  }
+
+  return 0;
+}
+
+int pthread_rwlock_unlock(pthread_rwlock_t *rwlock) {
+  //__thread_preempt(0);
+
+  rwlock_data_t *rwdata = *((rwlock_data_t**)rwlock);
+
+  int res = _atomic_rwlock_unlock(rwdata);
+
+  if (res == 0)
+    __thread_preempt(0);
+
+  return res;
+}

--- a/runtime/POSIX/threads.h
+++ b/runtime/POSIX/threads.h
@@ -109,7 +109,8 @@ typedef struct {
   unsigned int nr_readers;
   unsigned int nr_readers_queued;
   unsigned int nr_writers_queued;
-  int writer;
+  unsigned int writer;
+  char writer_taken;
 } rwlock_data_t;
 
 typedef struct {

--- a/runtime/POSIX/threads.h
+++ b/runtime/POSIX/threads.h
@@ -1,0 +1,150 @@
+/*
+ * Cloud9 Parallel Symbolic Execution Engine
+ *
+ * Copyright (c) 2011, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *
+ * Stefan Bucur <stefan.bucur@epfl.ch>
+ * Vlad Ureche <vlad.ureche@epfl.ch>
+ * Cristian Zamfir <cristian.zamfir@epfl.ch>
+ * Ayrat Khalimov <ayrat.khalimov@epfl.ch>
+ * Prof. George Candea <george.candea@epfl.ch>
+ *
+ * External Contributors:
+ * Calin Iorgulescu <calin.iorgulescu@gmail.com>
+ * Tudor Cazangiu <tudor.cazangiu@gmail.com>
+ *
+ * Stefan Bucur <sbucur@google.com> (contributions done while at Google)
+ * Lorenzo Martignoni <martignlo@google.com>
+ * Burak Emir <bqe@google.com>
+ *
+ */
+
+#ifndef THREADS_H_
+#define THREADS_H_
+
+#include <stdint.h>
+#include <sys/types.h>
+#include <klee/klee.h>
+
+#define MAX_THREADS     16
+
+typedef uint64_t wlist_id_t;
+
+#define DEFAULT_THREAD  0
+
+#define PTHREAD_ONCE_INIT       0
+
+#define STATIC_MUTEX_VALUE      0
+#define STATIC_CVAR_VALUE       0
+#define STATIC_BARRIER_VALUE    0
+#define STATIC_RWLOCK_VALUE     0
+
+#define PTHREAD_BARRIER_SERIAL_THREAD    -1
+
+typedef struct {
+  wlist_id_t wlist;
+
+  void *ret_value;
+
+  char allocated;
+  char terminated;
+  char joinable;
+} thread_data_t;
+
+typedef struct {
+  wlist_id_t wlist;
+
+  char taken;
+  unsigned int owner;
+  int count;
+  unsigned int queued;
+
+  char allocated;
+} mutex_data_t;
+
+typedef struct {
+  wlist_id_t wlist;
+
+  mutex_data_t *mutex;
+  unsigned int queued;
+} condvar_data_t;
+
+typedef struct {
+  wlist_id_t wlist;
+
+  unsigned int curr_event;
+  unsigned int left;
+  unsigned int init_count;
+} barrier_data_t;
+
+typedef struct {
+  wlist_id_t wlist_readers;
+  wlist_id_t wlist_writers;
+
+  unsigned int nr_readers;
+  unsigned int nr_readers_queued;
+  unsigned int nr_writers_queued;
+  int writer;
+} rwlock_data_t;
+
+typedef struct {
+    wlist_id_t wlist;
+
+    int count;
+    char allocated;
+} sem_data_t;
+
+typedef struct {
+  thread_data_t threads[MAX_THREADS];
+} tsync_data_t;
+
+extern tsync_data_t __tsync;
+
+void klee_init_threads(void);
+
+static inline void __thread_preempt(int yield) {
+  klee_thread_preempt(yield);
+}
+
+static inline void __thread_sleep(uint64_t wlist) {
+  klee_thread_sleep(wlist);
+}
+
+static inline void __thread_notify(uint64_t wlist, int all) {
+  klee_thread_notify(wlist, all);
+}
+
+static inline void __thread_notify_one(uint64_t wlist) {
+  __thread_notify(wlist, 0);
+}
+
+static inline void __thread_notify_all(uint64_t wlist) {
+  __thread_notify(wlist, 1);
+}
+
+#endif /* THREADS_H_ */

--- a/runtime/POSIX/threads_init.c
+++ b/runtime/POSIX/threads_init.c
@@ -1,0 +1,74 @@
+/*
+ * Cloud9 Parallel Symbolic Execution Engine
+ *
+ * Copyright (c) 2011, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *
+ * Stefan Bucur <stefan.bucur@epfl.ch>
+ * Vlad Ureche <vlad.ureche@epfl.ch>
+ * Cristian Zamfir <cristian.zamfir@epfl.ch>
+ * Ayrat Khalimov <ayrat.khalimov@epfl.ch>
+ * Prof. George Candea <george.candea@epfl.ch>
+ *
+ * External Contributors:
+ * Calin Iorgulescu <calin.iorgulescu@gmail.com>
+ * Tudor Cazangiu <tudor.cazangiu@gmail.com>
+ *
+ * Stefan Bucur <sbucur@google.com> (contributions done while at Google)
+ * Lorenzo Martignoni <martignlo@google.com>
+ * Burak Emir <bqe@google.com>
+ *
+ */
+
+#include "threads.h"
+
+#include <string.h>
+
+#include <klee/klee.h>
+
+tsync_data_t __tsync;
+
+void klee_init_threads(void) {
+    // Initialize all thread structures
+    int i;
+    for(i = 0; i < MAX_THREADS; i++) {
+        thread_data_t *slot = &__tsync.threads[i];
+        slot->allocated = 0;
+        slot->terminated = 0;
+        slot->ret_value = 0;
+        slot->joinable = 0;
+        slot->wlist = 0;
+    }
+
+    // Main thread initialization
+    thread_data_t *def_data = &__tsync.threads[DEFAULT_THREAD];
+    def_data->allocated = 1;
+    def_data->terminated = 0;
+    def_data->ret_value = 0;
+    def_data->joinable = 1; // Why not?
+    def_data->wlist = klee_get_wlist();
+}

--- a/test/Runtime/Synchronization/Mutex.c
+++ b/test/Runtime/Synchronization/Mutex.c
@@ -1,0 +1,47 @@
+// RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
+// RUN: %klee --no-output --exit-on-error --posix-runtime --libc=uclibc %t1.bc --sym-arg 1 --sym-arg 1
+
+#include <assert.h>
+#include <pthread.h>
+ 
+#define ITERATIONS 10000
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+int sharedData=0;
+ 
+void *threadCode(void *p)
+{
+  int i;
+  int err;
+  for(i=0; i<ITERATIONS; ++i) {
+    err = pthread_mutex_lock(&mutex);
+    assert(err == 0 && "Mutex lock");
+    ++sharedData;
+    err = pthread_mutex_unlock(&mutex);
+    assert(err == 0 && "Mutex unlock");
+  }
+  return NULL;
+}
+ 
+int main(int argc, char **argv) {
+  int i;
+  int err;
+  int num_threads = argc;
+  pthread_t thread[num_threads];
+
+  for (i=0; i<num_threads; ++i) {
+    err = pthread_create(&thread[i], NULL, threadCode, NULL);
+    assert(err == 0 && "Thread create");
+  }
+ 
+  for (i=0; i <num_threads; ++i) {
+   pthread_join(thread[i], NULL);
+  assert(err == 0 && "Thread join");
+  }
+ 
+  assert(sharedData == num_threads*ITERATIONS);
+
+  err = pthread_mutex_destroy(&mutex);
+  assert(err == 0 && "Mutex destroy");
+  return 0;
+}
+

--- a/test/Runtime/Synchronization/ReentrantMutex.c
+++ b/test/Runtime/Synchronization/ReentrantMutex.c
@@ -1,0 +1,60 @@
+// RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
+// RUN: %klee --no-output --exit-on-error --posix-runtime --libc=uclibc %t1.bc --sym-args 0 3 1
+
+#include <assert.h>
+#include <pthread.h>
+ 
+#define ITERATIONS 10000
+pthread_mutex_t mutex;
+int sharedData=0;
+ 
+void *threadCode(void *p)
+{
+  int i;
+  int err;
+  for(i=0; i<ITERATIONS; ++i) {
+    err = pthread_mutex_lock(&mutex);
+    assert(err == 0 && "First lock");
+    err = pthread_mutex_lock(&mutex);
+    assert(err == 0 && "Second lock");
+    ++sharedData;
+    err = pthread_mutex_unlock(&mutex);
+    assert(err == 0 && "First unlock");
+    err = pthread_mutex_unlock(&mutex);
+    assert(err == 0 && "Second unlock");
+  }
+  return NULL;
+}
+ 
+int main(int argc, char **argv) {
+  int i;
+  int err;
+  int num_threads = argc;
+  pthread_t thread[num_threads];
+
+  pthread_mutexattr_t attr;
+  err = pthread_mutexattr_init(&attr);
+  assert(err == 0 && "Attribute init");
+  err = pthread_mutexattr_settype(&attr,PTHREAD_MUTEX_RECURSIVE);
+  assert(err == 0 && "Settype");
+  err = pthread_mutex_init(&mutex, &attr);
+  assert(err == 0 && "Mutex init");
+
+  for (i=0; i<num_threads; ++i) {
+    err = pthread_create(&thread[i], NULL, threadCode, NULL);
+    assert(err == 0 && "Thread create");
+  }
+ 
+  for (i=0; i <num_threads; ++i) {
+   pthread_join(thread[i], NULL);
+  assert(err == 0 && "Thread join");
+  }
+ 
+  assert(sharedData == num_threads*ITERATIONS);
+
+  err = pthread_mutex_destroy(&mutex);
+  assert(err == 0 && "Mutex destroy");
+  err = pthread_mutexattr_destroy(&attr);
+  assert(err == 0 && "Attribute destroy");
+  return 0;
+}

--- a/test/Runtime/Synchronization/SemaphorePOSIX.c
+++ b/test/Runtime/Synchronization/SemaphorePOSIX.c
@@ -1,0 +1,67 @@
+// RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
+// RUN: %klee --no-output --exit-on-error --posix-runtime --libc=uclibc %t1.bc --sym-args 0 3 1
+
+#include <assert.h>
+#include <pthread.h>
+#include <semaphore.h>
+ 
+#define ITERATIONS 10000
+sem_t sem_writer;
+sem_t sem_reader;
+ 
+void *writerCode(void *p)
+{
+  int i;
+  int err;
+  for(i=0; i<ITERATIONS; ++i) {
+    err = sem_wait(&sem_writer);
+    assert(err == 0 && "Wait on writer semaphore");
+    err = sem_post(&sem_reader);
+    assert(err == 0 && "Post to reader semaphore");
+  }
+  return NULL;
+}
+ 
+void *readerCode(void *p)
+{
+  int i;
+  int err;
+  for(i=0; i<ITERATIONS; ++i) {
+    err = sem_wait(&sem_reader);
+    assert(err == 0 && "Wait on reader semaphore");
+    err = sem_post(&sem_writer);
+    assert(err == 0 && "Post to writer semaphore");
+  }
+  return NULL;
+}
+
+int main(int argc, char **argv) {
+  int i;
+  int err;
+  int num_threads = 2*argc;
+  pthread_t thread[num_threads];
+
+  err = sem_init(&sem_writer, 0, 2);
+  assert(err == 0 && "Writer semaphore init");
+  err = sem_init(&sem_reader, 0, 0);
+  assert(err == 0 && "Reader semaphore init");
+
+  for (i=0; i<num_threads; ++i) {
+    if(i%2 == 0)
+      err = pthread_create(&thread[i], NULL, writerCode, NULL);
+    else
+      err = pthread_create(&thread[i], NULL, readerCode, NULL);
+    assert(err == 0 && "Thread create");
+  }
+ 
+  for (i=0; i <num_threads; ++i) {
+   pthread_join(thread[i], NULL);
+  assert(err == 0 && "Thread join");
+  }
+
+  err = sem_destroy(&sem_writer);
+  assert(err == 0 && "Writer semaphore destroy");
+  err = sem_destroy(&sem_reader);
+  assert(err == 0 && "Reader semaphore destroy");
+  return 0;
+}

--- a/test/Runtime/Synchronization/dg.exp
+++ b/test/Runtime/Synchronization/dg.exp
@@ -1,0 +1,5 @@
+load_lib llvm.exp
+
+if { [klee_supports_posix_runtime] } {
+    RunLLVMTests [lsort [glob -nocomplain $srcdir/$subdir/*.{ll,llx,c,cpp,tr}]]
+}

--- a/test/Runtime/Synchronization/lit.local.cfg
+++ b/test/Runtime/Synchronization/lit.local.cfg
@@ -1,0 +1,10 @@
+def getRoot(config):
+    if not config.parent:
+        return config
+    return getRoot(config.parent)
+
+if not getRoot(config).enable_uclibc:
+    config.unsupported = True
+
+if not getRoot(config).enable_posix_runtime:
+    config.unsupported = True

--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -447,6 +447,11 @@ void klee_make_symbolic(void *addr, size_t nbytes, const char *name) {
   }
 }
 
+uint64_t klee_get_wlist(void) {
+  static uint64_t counter = 0;
+  return counter++;
+}
+
 /* Redefined here so that we can check the value read. */
 int klee_range(int start, int end, const char* name) {
   int r;

--- a/tools/klee-replay/threads_init.c
+++ b/tools/klee-replay/threads_init.c
@@ -1,0 +1,1 @@
+#include "../../runtime/POSIX/threads_init.c"

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -439,11 +439,15 @@ void KleeHandler::processTestCase(const ExecutionState &state,
         assert(o->bytes);
         std::copy(out[i].second.begin(), out[i].second.end(), o->bytes);
       }
-      
+
+      b.numSchedSteps = state.schedulingHistory.size();
+      b.schedSteps = new long unsigned[b.numSchedSteps];
+      std::copy(state.schedulingHistory.begin(),state.schedulingHistory.end(),b.schedSteps);
+
       if (!kTest_toFile(&b, getOutputFilename(getTestFilename("ktest", id)).c_str())) {
         klee_warning("unable to write output test case, losing it");
       }
-      
+
       for (unsigned i=0; i<b.numObjects; i++)
         delete[] b.objects[i].bytes;
       delete[] b.objects;
@@ -720,6 +724,7 @@ static const char *modelledExternals[] = {
   "klee_assume", 
   "klee_check_memory_access",
   "klee_define_fixed_object",
+  "klee_get_context",
   "klee_get_errno", 
   "klee_get_valuef",
   "klee_get_valued",
@@ -727,7 +732,8 @@ static const char *modelledExternals[] = {
   "klee_get_valuell",
   "klee_get_value_i32",
   "klee_get_value_i64",
-  "klee_get_obj_size", 
+  "klee_get_obj_size",
+  "klee_get_wlist",
   "klee_is_symbolic", 
   "klee_make_symbolic", 
   "klee_mark_global", 
@@ -742,6 +748,11 @@ static const char *modelledExternals[] = {
   "klee_warning_once", 
   "klee_alias_function",
   "klee_stack_trace",
+  "klee_thread_create",
+  "klee_thread_notify",
+  "klee_thread_preempt",
+  "klee_thread_sleep",
+  "klee_thread_terminate",
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 1)
   "llvm.dbg.declare",
   "llvm.dbg.value",

--- a/tools/ktest-tool/ktest-tool
+++ b/tools/ktest-tool/ktest-tool
@@ -45,18 +45,23 @@ class KTest:
             bytes = f.read(size)
             objects.append( (name,bytes) )
 
+        numSchedSteps, = struct.unpack('>i', f.read(4))
+        schedSteps = []
+        for i in range(numSchedSteps):
+            schedSteps.append(struct.unpack('>Q',f.read(8))[0])
         # Create an instance
-        b = KTest(version, args, symArgvs, symArgvLen, objects)
+        b = KTest(version, args, symArgvs, symArgvLen, objects, schedSteps)
         # Augment with extra filename field
         b.filename = path
         return b
     
-    def __init__(self, version, args, symArgvs, symArgvLen, objects):
+    def __init__(self, version, args, symArgvs, symArgvLen, objects, schedSteps):
         self.version = version
         self.symArgvs = symArgvs
         self.symArgvLen = symArgvLen
         self.args = args
         self.objects = objects
+        self.schedSteps = schedSteps
 
         # add a field that represents the name of the program used to
         # generate this .ktest file:
@@ -95,16 +100,18 @@ def main(args):
         print('num objects: %r' % len(b.objects))
         for i,(name,data) in enumerate(b.objects):
             if opts.trimZeros:
-                str = trimZeros(data)
+                strData = trimZeros(data)
             else:
-                str = data
+                strData = data
 
             print('object %4d: name: %r' % (i, name))
             print('object %4d: size: %r' % (i, len(data)))
             if opts.writeInts and len(data) == 4: 
-                print('object %4d: data: %r' % (i, struct.unpack('i',str)[0]))
+                print('object %4d: data: %r' % (i, struct.unpack('i',strData)[0]))
             else:
-                print('object %4d: data: %r' % (i, str))
+                print('object %4d: data: %r' % (i, strData))
+        print('num scheduling steps: %r' % len(b.schedSteps))
+        print('scheduling steps: %s' % ','.join([str(x) for x in b.schedSteps]))
         if file != args[-1]:
             print()
 


### PR DESCRIPTION
A review of the multithread support from Cloud9 presented in pull request: https://github.com/klee/klee/pull/211
This allows KLEE to execute C programs with pthread and semaphore calls and create new states based on thread scheduling.

In this version have cleaned and formatted the code, and cleaned up the git history (the main reason to open a new pull request).

The main points of the patch are:

1- added to the POSIX runtime a set of pthread calls for thread management, mutexes, condition variables and barriers. The pthread calls use 6 new klee_\* special functions to define their behaviour: create, terminate, preempt, sleep, notify, retrieve thread id and retrieve current waiting list.
2- the scheduling is colaborative; the program under test must inform explicitly to KLEE that it can be preempted (using klee_thread_preempt). Some preemption points are hard coded in the pthread call definitions (mostly at the beginning and end of the call). If the user would like to have thread context changes in any other point must insert manually the call.
3- if a thread must wait for a specific action from other thread (mutex release, thread termination...), they are dsiable and put to sleep in a specific waiting list for the relevant event. The thread fulfilling the condition will wake-up one o more threads from the waiting list
4- ExecutionState now is composed by a collection of Threads, each one with its own program counter, incomingBBIndex, call stack. StackFrame struct was moved into the new Thread class. One of the Thread instances will correspond to the current active thread in the state, a set of shortcut methods allows to reference directly the Thread pc, callstack... from the ExecutionState instance.
6- Executor contains a new overloaded fork that clones the current state and add it to the execution pool. The schedule method of Executor is called when a thread is preempted and creates new states for alternative schedules, its behavior depends if the preemption is a real yield, a sleep or only a possible context change.
7- the Thread class keeps an account of each scheduling selection done in each preemption (even if the thread is not preempted at all). This shceduling history is added to the KTest instance; the ktest-tool has been also updated to show the scheduling.
8- new options:
-debug-sched-explored: after terminating an state prints the scheduling steps performed for that state
-debug-sched-history: print in each preemption from which thread to which thread is changing (with fork on schedule more that one new state can appear)
-fork-on-schedule: in each preemption create always new states (fork) for each alternative thread that could become the active one
-scheduler-preemption-bound: limits the number of possible preemptions (not yields) per thread to the given number
-no-scheduler-bound: make the option above unlimited (this increases enormously the number of generated tests)
9- note that the number of generated test cases will grow a lot, because each specific interleaving will reach a different ending state (to minimize this would require implement a partial order reduction algorithm).
10- the Executor::merge method will not merge two states that contains more than one thread, that should maintain the functionality in the sequential case, but I am not sure how that should work for a multithread case.
11- the Cloud9 license is conserved in the new files (directories indicated in LICENSE.TXT)

It would be nice if some (@ccadar, @ddunbar) can give it a try
