### PR TITLE
Make creation of human readable test cases optional rather than default

### DIFF
--- a/test/Feature/PreferCex.c
+++ b/test/Feature/PreferCex.c
@@ -1,6 +1,6 @@
 // RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --exit-on-error %t1.bc
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error --prefer-cex %t1.bc
 // RUN: ktest-tool %t.klee-out/test000001.ktest | FileCheck %s
 
 #include <assert.h>


### PR DESCRIPTION
Previously, default Klee would go through every byte in a test case
and attempt to bound it to be between 0 and 127, making it human
readable.  While this may be useful when initially attempting to 
understand Klee, it also means that the time required to create large
test suites was greatly increased.  By making this behavior default off, 
unsuspecting users won't incur these costs.

When tested on the core-utils suite, I noticed a 3-4X drop for the default
search (i.e. when all paths produce a tests case).  Given the relatively
small benefits of the option (I almost never look directly at a test case)
it seems like it would be much better to make this behavior opt in rather
than opt out. Should you guys decide that it is important for new users to
be able to examine and understand the created test cases, then one
suggestion I have would be to have the option turned on in tutorials
while noting how expensive the entire process can be when used on
larger artifacts.

If you would like more specific numbers, please let me know.