### PR TITLE
Fixed a bug with how non power 2 types were written to memory

### DIFF
--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -530,7 +530,10 @@ void ObjectState::write(unsigned offset, ref<Expr> value) {
   // Check for writes of constant values.
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(value)) {
     Expr::Width w = CE->getWidth();
-    if (w <= 64) {
+    //assuming width can't be 0 so I can miss half of power of two check
+    assert(w > 0);
+    //also checks that w is a power of two
+    if (w <= 64 && !(w & (w - 1))) {
       uint64_t val = CE->getZExtValue();
       switch (w) {
       default: assert(0 && "Invalid write size!");

--- a/test/regression/2015-06-22-struct-write.c
+++ b/test/regression/2015-06-22-struct-write.c
@@ -1,0 +1,21 @@
+// RUN: %llvmgcc %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out -exit-on-error %t.bc
+
+#include <assert.h>
+#include <klee/klee.h>
+
+union U0 {
+	signed f3 :18;
+};
+
+static union U0 u = { 0UL };
+
+int main(int argc, char **argv) {
+  u.f3 = 534;
+
+  klee_assert(u.f3 == 534);
+
+  return 0;
+}
+


### PR DESCRIPTION
This is meant to fix a bug which manifests itself in the following two snippets:

```C
union U0 {
	signed f3 :18;
};

static union U0 g_988 = { 0UL };

int main(int argc, char* argv[]) {
	g_988.f3 = 534;
	printf("f3 %d \n", g_988.f3);
	return 0;
}
```
This one works on the current master if pragma pack(1) is removed:
```C
#include <stdio.h>
#pragma pack(1)
struct S0 {
	signed f0 :20;
};

static struct S0 x;
int main(int argc, char* argv[]) {

	x = (struct S0 ) { .f0 = 32 };
	printf("integer %d\n", x.f0);
	return x.f0;
}
```

What happens is that in these cases w = 24, which makes it jump to Int8 case in the switch(w), which causes the wrong value to be stored. I've added a check to make sure that w is a power of 2, so it definitively fits into one of the switch cases and uses the slow version in all the others. 

I think this is a better option than adding Int24 into the switch since then all the others are also needed.