### PR TITLE
Make the super-set check in CexCachingSolver default off

### DIFF
--- a/lib/Solver/CexCachingSolver.cpp
+++ b/lib/Solver/CexCachingSolver.cpp
@@ -35,6 +35,11 @@ namespace {
                  cl::init(false));
 
   cl::opt<bool>
+  CexCacheSuperSet("cex-cache-superset",
+                 cl::desc("try substituting SAT super-set counterexample before asking the SMT solver (default=false)"),
+                 cl::init(false));
+
+  cl::opt<bool>
   CexCacheExperimental("cex-cache-exp", cl::init(false));
 
 }
@@ -124,8 +129,10 @@ bool CexCachingSolver::searchForAssignment(KeyType &key, Assignment *&result) {
   if (CexCacheTryAll) {
     // Look for a satisfying assignment for a superset, which is trivially an
     // assignment for any subset.
-    Assignment **lookup = cache.findSuperset(key, NonNullAssignment());
-    
+    Assignment **lookup = 0;
+    if (CexCacheSuperSet)
+      lookup = cache.findSuperset(key, NonNullAssignment());
+
     // Otherwise, look for a subset which is unsatisfiable, see below.
     if (!lookup) 
       lookup = cache.findSubset(key, NullAssignment());
@@ -151,7 +158,9 @@ bool CexCachingSolver::searchForAssignment(KeyType &key, Assignment *&result) {
 
     // Look for a satisfying assignment for a superset, which is trivially an
     // assignment for any subset.
-    Assignment **lookup = cache.findSuperset(key, NonNullAssignment());
+    Assignment **lookup = 0;
+    if (CexCacheSuperSet)
+      lookup = cache.findSuperset(key, NonNullAssignment());
 
     // Otherwise, look for a subset which is unsatisfiable -- if the subset is
     // unsatisfiable then no additional constraints can produce a valid


### PR DESCRIPTION
The super-set check in the CexCachingSolver takes MUCH longer than the
sub-set check.  Upon closer inspection, the super-set check gets slower
and slower as more counterexamples fill the UBTree.  Pretty quickly,
the cost of the super-set check becomes larger than the time required
to simply bypass it and go to the Solver.

In the original implementation, the UBTree checks for both supersets and subsets of an incoming constraint set.  The sub-set query is very efficient, taking on average under than 1% of the overall computation.  The super-set query, however, is much less efficient.  Over the course of a run, it can account for up to 79% of the computation while on average taking up 44% of the computation.

The reason for this inefficiency is because when more and more constraint sets are placed into the UBTree, the response time for a superset query gets slower and slower.  These escalating computational costs eventually outweigh the costs of bypassing the check and sending the query directly to the solver.  Upon removing the super-set check, our experiments show that on average just less than 80% of the constraint sets that would have been caught by the super-set check end up being decided by the much less expensive subset check.  Even when there is a miss, the costs associated with an SMT call end up being significantly less than a super-set check.  It is unclear whether there is a performance bug in the super-set calculation or whether this is a constraint of the UBTree algorithm.  I submitted this pull request in order to remove the checks until the cause can be further investigated.

Numbers were calculated by averaging the values of the 89 programs in the core-utils.

