### PR TITLE
Clean Intrinsic::objectsize

### DIFF
--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -206,6 +206,14 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         break;
       }
 
+      case Intrinsic::objectsize: {
+        Value *unknownSize = ConstantInt::get(ii->getType(), -1);
+        ii->replaceAllUsesWith(unknownSize);
+        ii->eraseFromParent();
+        dirty = true;
+        break;
+      }
+
       case Intrinsic::dbg_value:
       case Intrinsic::dbg_declare:
         // Remove these regardless of lower intrinsics flag. This can


### PR DESCRIPTION
Fixes this runtime error:
```
LLVM ERROR: Code generator does not support intrinsic function 'llvm.objectsize.i64.p0i8'!
```

I'm new to LLVM and to this project.
Would love to get some guidance on adding a unit test for this.