### PR TITLE
Support memory reads of sizes less than i8

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3179,6 +3179,11 @@ void Executor::executeMemoryOperation(ExecutionState &state,
         }          
       } else {
         ref<Expr> result = os->read(offset, type);
+
+        if(result->getWidth() > type) {
+            // truncate back to correct size
+            result = ExtractExpr::create(result, 0, type);
+        }
         
         if (interpreterOpts.MakeConcreteSymbolic)
           result = replaceReadWithSymbolic(state, result);
@@ -3223,6 +3228,10 @@ void Executor::executeMemoryOperation(ExecutionState &state,
         }
       } else {
         ref<Expr> result = os->read(mo->getOffsetExpr(address), type);
+        if(result->getWidth() > type) {
+            // truncate back to correct size
+            result = ExtractExpr::create(result, 0, type);
+        }
         bindLocal(target, *bound, result);
       }
     }

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -468,6 +468,7 @@ ref<Expr> ObjectState::read(ref<Expr> offset, Expr::Width width) const {
 
   // Otherwise, follow the slow general case.
   unsigned NumBytes = width / 8;
+  NumBytes = NumBytes == 0 ? 1 : NumBytes;
   assert(width == NumBytes * 8 && "Invalid read size!");
   ref<Expr> Res(0);
   for (unsigned i = 0; i != NumBytes; ++i) {
@@ -488,6 +489,7 @@ ref<Expr> ObjectState::read(unsigned offset, Expr::Width width) const {
 
   // Otherwise, follow the slow general case.
   unsigned NumBytes = width / 8;
+  NumBytes = NumBytes == 0 ? 1 : NumBytes;
   assert(width == NumBytes * 8 && "Invalid width for read size!");
   ref<Expr> Res(0);
   for (unsigned i = 0; i != NumBytes; ++i) {

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -520,6 +520,7 @@ void ObjectState::write(ref<Expr> offset, ref<Expr> value) {
 
   // Otherwise, follow the slow general case.
   unsigned NumBytes = w / 8;
+  NumBytes = NumBytes == 0 ? 1 : NumBytes;
   assert(w == NumBytes * 8 && "Invalid write size!");
   for (unsigned i = 0; i != NumBytes; ++i) {
     unsigned idx = Context::get().isLittleEndian() ? i : (NumBytes - i - 1);
@@ -554,6 +555,7 @@ void ObjectState::write(unsigned offset, ref<Expr> value) {
 
   // Otherwise, follow the slow general case.
   unsigned NumBytes = w / 8;
+  NumBytes = NumBytes == 0 ? 1 : NumBytes;
   assert(w == NumBytes * 8 && "Invalid write size!");
   for (unsigned i = 0; i != NumBytes; ++i) {
     unsigned idx = Context::get().isLittleEndian() ? i : (NumBytes - i - 1);


### PR DESCRIPTION
Hi,

It looks like KLEE does not support memory reads/writes of sizes smaller than i8 (other than the special case for boolean). I encountered this problem when running KLEE on bitcode emitted by mcsema and attempted a fix. The read case is more complete than the write case, and seemed to work. 

Please let me know if I'm going about the fix in the correct way. 

Thanks,
Artem
