### PR TITLE
Removing -fstack-protector-strong for clang <= 3.4

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -5,6 +5,13 @@ include $(LEVEL)/Makefile.config
 # Include LLVM's Master Makefile config and rules.
 include $(LLVM_OBJ_ROOT)/Makefile.config
 
+# Filters out -fstack-protector-strong which is not understood by clang 3.4 or below
+# yet is present in Makefile.config of some distros such as Debian Jessie
+ifeq ($(shell test $(LLVM_VERSION_MAJOR) -le 3 -a $(LLVM_VERSION_MINOR) -le 4; echo $$?),0)
+  CFLAGS := $(filter-out -fstack-protector-strong,$(CFLAGS))
+  CXXFLAGS := $(filter-out -fstack-protector-strong,$(CXXFLAGS))
+endif
+
 # Assertions should be enabled by default for KLEE (but they can still
 # be disabled by running make with DISABLE_ASSERTIONS=1
 DISABLE_ASSERTIONS := 0


### PR DESCRIPTION
It's not supported and breaks compilation. This affects in particular
Debian Jessie and probably all derived distros, too