### PR TITLE
Removed Language: Cpp Entry from .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,4 @@
 ---
-Language: Cpp
 BasedOnStyle:  LLVM
 Standard: Cpp03
 ...


### PR DESCRIPTION
The entry is incompatible to Clang 3.4.2 which does not support `Language:` configuration key. With the `Language: Cpp` entry in `.clang-format` the `git clang-format` would say:
```
YAML:2:11: error: unknown key 'Language'
Language: Cpp
          ^~~
Error reading /home/dcsandr/software/klee/.clang-format: Invalid argument
Can't find usable .clang-format, using LLVM style
```