### PR TITLE
Added missing copyright headers per klee/issue #301

### DIFF
--- a/include/klee/Internal/ADT/DiscretePDF.inc
+++ b/include/klee/Internal/ADT/DiscretePDF.inc
@@ -1,6 +1,11 @@
-//===- DiscretePDF.inc - --*- C++ -*-===//
-
+//===- DiscretePDF.inc - --*- C++ -*---------------------------------------===//
 //
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
 
 namespace klee {
 

--- a/include/klee/util/PrintContext.h
+++ b/include/klee/util/PrintContext.h
@@ -1,3 +1,12 @@
+//===-- PrintContext.h ------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
 #ifndef PRINTCONTEXT_H_
 #define PRINTCONTEXT_H_
 

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -1,3 +1,12 @@
+//===-- CmdLineOptions.cpp --------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
 /*
  * This file groups command line options definitions and associated
  * data that are common to both KLEE and Kleaver.

--- a/lib/Solver/MetaSMTBuilder.h
+++ b/lib/Solver/MetaSMTBuilder.h
@@ -1,4 +1,14 @@
- /*
+//===-- MetaSMTBuilder.h ----------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+
+/*
  * MetaSMTBuilder.h
  *
  *  Created on: 8 Aug 2012

--- a/scripts/IStatsMerge.py
+++ b/scripts/IStatsMerge.py
@@ -1,5 +1,14 @@
 #!/usr/bin/python
 
+# ===-- IStatsMerge.py ----------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 from __future__ import division
 
 import sys, os

--- a/scripts/IStatsSum.py
+++ b/scripts/IStatsSum.py
@@ -1,5 +1,14 @@
 #!/usr/bin/python
 
+# ===-- IStatsSum.py ------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 from __future__ import division
 
 import sys, os

--- a/scripts/coverageServer.py
+++ b/scripts/coverageServer.py
@@ -1,4 +1,14 @@
 #!/usr/bin/python
+
+# ===-- coverageServer.py -------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 from flask import *
 from functools import wraps
 from subprocess import call

--- a/scripts/genTempFiles.sh
+++ b/scripts/genTempFiles.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# ===-- genTempFiles.sh ---------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 if [ -z "$1" ] ; then
 	echo "No directory given"
 	exit 1

--- a/scripts/klee-chroot-env
+++ b/scripts/klee-chroot-env
@@ -1,6 +1,15 @@
 #!/usr/bin/env python2
 #-*- coding: utf-8 -*-
 #
+# ===-- klee-chroot-env ---------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+#
 # Buiding chroot environment for the program under test.
 #
 # This script uses `ldd' to get the shared libraries required by a program,

--- a/scripts/klee-clang
+++ b/scripts/klee-clang
@@ -1,5 +1,14 @@
 #!/usr/bin/env python
 
+# ===-- klee-clang --------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 import os, sys
 import subprocess
 import re

--- a/scripts/klee-control
+++ b/scripts/klee-control
@@ -1,5 +1,14 @@
 #!/usr/bin/python
 
+# ===-- klee-control ------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 import os, signal, popen2
 
 def getPID(dir):

--- a/scripts/klee-gcc
+++ b/scripts/klee-gcc
@@ -1,5 +1,14 @@
 #!/usr/bin/env python
 
+# ===-- klee-gcc ----- ----------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 import os, sys
 
 def isLinkCommand():

--- a/scripts/objdump
+++ b/scripts/objdump
@@ -1,5 +1,14 @@
 #!/usr/bin/python
 
+# ===-- objdump -----------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 """
 An objdump wrapper for use with klee & kcachegrind.
 

--- a/tools/gen-random-bout/gen-random-bout.cpp
+++ b/tools/gen-random-bout/gen-random-bout.cpp
@@ -1,3 +1,12 @@
+//===-- gen-random-bout.cpp -------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tools/kleaver/main.cpp
+++ b/tools/kleaver/main.cpp
@@ -1,3 +1,12 @@
+//===-- main.cpp ------------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
 #include "expr/Lexer.h"
 #include "expr/Parser.h"
 

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -1,5 +1,15 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+
+# ===-- klee-stats --------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 """Output statistics logged by Klee."""
 
 # use '/' to mean true division and '//' to mean floor division

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1,5 +1,14 @@
 /* -*- mode: c++; c-basic-offset: 2; -*- */
 
+//===-- main.cpp ------------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
 #include "klee/ExecutionState.h"
 #include "klee/Expr.h"
 #include "klee/Interpreter.h"

--- a/tools/ktest-tool/ktest-tool
+++ b/tools/ktest-tool/ktest-tool
@@ -1,5 +1,14 @@
 #!/usr/bin/env python
 
+# ===-- ktest-tool --------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 import os
 import struct
 import sys

--- a/unittests/Makefile
+++ b/unittests/Makefile
@@ -1,4 +1,11 @@
 ##===- unittests/Makefile ----------------------------------*- Makefile -*-===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
 
 LEVEL = ..
 

--- a/unittests/Ref/RefTest.cpp
+++ b/unittests/Ref/RefTest.cpp
@@ -1,3 +1,12 @@
+//===-- RefTest.cpp ---------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
 /* Regression test for a bug caused by assigning a ref to itself.
    More details at http://keeda.stanford.edu/pipermail/klee-commits/2012-February/000904.html */
 

--- a/utils/emacs/klee-pc-mode.el
+++ b/utils/emacs/klee-pc-mode.el
@@ -1,3 +1,12 @@
+;;===-- klee-pc-mode.el ---------------------------------------------------===;;
+;; 
+;;                     The KLEE Symbolic Virtual Machine
+;; 
+;; This file is distributed under the University of Illinois Open Source
+;; License. See LICENSE.TXT for details.
+;; 
+;;===----------------------------------------------------------------------===;;
+
 (provide 'klee-pc-mode)
 
 (require 'font-lock)

--- a/utils/hacks/TreeGraphs/Animate.py
+++ b/utils/hacks/TreeGraphs/Animate.py
@@ -1,5 +1,14 @@
 #!/usr/bin/python
 
+# ===-- Animate.py --------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 import os
 import TreeGraph
 import Image

--- a/utils/hacks/TreeGraphs/DumpTreeStream.py
+++ b/utils/hacks/TreeGraphs/DumpTreeStream.py
@@ -1,5 +1,14 @@
 #!/usr/bin/python
 
+# ===-- DumpTreeStream.py -------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 from __future__ import division
 
 import sys, os, struct

--- a/utils/hacks/TreeGraphs/Graphics/Canvas/__init__.py
+++ b/utils/hacks/TreeGraphs/Graphics/Canvas/__init__.py
@@ -1,3 +1,13 @@
+# ===-- __init__.py -------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
+
 from __future__ import division
 
 ###

--- a/utils/hacks/TreeGraphs/Graphics/Geometry/Intersect2D.py
+++ b/utils/hacks/TreeGraphs/Graphics/Geometry/Intersect2D.py
@@ -1,3 +1,12 @@
+# ===-- Intersect2D.py ----------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 import vec2, math
 
 def intersectLineCircle((p, no), (C, r)):

--- a/utils/hacks/TreeGraphs/Graphics/Geometry/mat2.py
+++ b/utils/hacks/TreeGraphs/Graphics/Geometry/mat2.py
@@ -1,3 +1,12 @@
+# ===-- mat2.py -----------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 import vec2
 
 def det(m):

--- a/utils/hacks/TreeGraphs/Graphics/Geometry/mat3.py
+++ b/utils/hacks/TreeGraphs/Graphics/Geometry/mat3.py
@@ -1,3 +1,12 @@
+# ===-- mat3.py -----------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 import vec3,mat2
 
 def identity():

--- a/utils/hacks/TreeGraphs/Graphics/Geometry/mat4.py
+++ b/utils/hacks/TreeGraphs/Graphics/Geometry/mat4.py
@@ -1,3 +1,12 @@
+# ===-- mat4.py -----------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 import vec4,mat3
 
 def identity():

--- a/utils/hacks/TreeGraphs/Graphics/Geometry/quat.py
+++ b/utils/hacks/TreeGraphs/Graphics/Geometry/quat.py
@@ -1,3 +1,12 @@
+# ===-- quat.py -----------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 from __future__ import division
 
 import math

--- a/utils/hacks/TreeGraphs/Graphics/Geometry/vec2.py
+++ b/utils/hacks/TreeGraphs/Graphics/Geometry/vec2.py
@@ -1,3 +1,12 @@
+# ===-- vec2.py -----------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 from __future__ import division
 from math import ceil,floor,sqrt,atan2,pi,cos,sin
 import random

--- a/utils/hacks/TreeGraphs/Graphics/Geometry/vec3.py
+++ b/utils/hacks/TreeGraphs/Graphics/Geometry/vec3.py
@@ -1,3 +1,12 @@
+# ===-- vec3.py -----------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 from __future__ import division
 from math import ceil,floor,sqrt
 from random import random as _random

--- a/utils/hacks/TreeGraphs/Graphics/Geometry/vec4.py
+++ b/utils/hacks/TreeGraphs/Graphics/Geometry/vec4.py
@@ -1,3 +1,12 @@
+# ===-- vec4.py -----------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 from __future__ import division
 from math import ceil,floor,sqrt
 import vec3

--- a/utils/hacks/TreeGraphs/TreeGraph.py
+++ b/utils/hacks/TreeGraphs/TreeGraph.py
@@ -1,5 +1,14 @@
 #!/usr/bin/python
 
+# ===-- TreeGraph.py ------------------------------------------------------===##
+# 
+#                      The KLEE Symbolic Virtual Machine
+# 
+#  This file is distributed under the University of Illinois Open Source
+#  License. See LICENSE.TXT for details.
+# 
+# ===----------------------------------------------------------------------===##
+
 from __future__ import division
 import sys
 from types import GeneratorType


### PR DESCRIPTION
There was a discussion in issue #301 about copyright. This pull request adds the usual KLEE copyright header to those files that didn't have one.
