### PR TITLE
Add soname for Runtest dynamic library

### DIFF
--- a/runtime/Runtest/Makefile
+++ b/runtime/Runtest/Makefile
@@ -15,5 +15,47 @@ SHARED_LIBRARY=1
 LINK_LIBS_IN_SHARED = 1
 DONT_BUILD_RELINKED = 1
 NO_PEDANTIC=1
+# Increment version appropriately if ABI/API changes, more details:
+# http://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html#AEN135
+SHARED_VERSION=1.0
 
 include $(LEVEL)/Makefile.common
+
+#LDFLAGS += -Wl,-soname,lib$(LIBRARYNAME)$(SHLIBEXT)
+ifeq ($(HOST_OS),Darwin)
+    # set dylib internal version number to llvmCore submission number
+    ifdef LLVM_SUBMIT_VERSION
+        LLVMLibsOptions := $(LLVMLibsOptions) -Wl,-current_version \
+                        -Wl,$(SHARED_VERSION) \
+                        -Wl,-compatibility_version -Wl,1
+    endif
+    # Include everything from the .a's into the shared library.
+    LLVMLibsOptions    := $(LLVMLibsOptions) -all_load
+    # extra options to override libtool defaults
+    LLVMLibsOptions    := $(LLVMLibsOptions)  \
+                         -Wl,-dead_strip
+
+    # Mac OS X 10.4 and earlier tools do not allow a second -install_name on command line
+    DARWIN_VERS := $(shell echo $(TARGET_TRIPLE) | sed 's/.*darwin\([0-9]*\).*/\1/')
+    ifneq ($(DARWIN_VERS),8)
+       LLVMLibsOptions    := $(LLVMLibsOptions)  \
+                            -Wl,-install_name \
+                            -Wl,"@rpath/lib$(LIBRARYNAME)$(SHLIBEXT)"
+    endif
+endif
+
+ifeq ($(HOST_OS), $(filter $(HOST_OS), DragonFly Linux FreeBSD GNU/kFreeBSD OpenBSD GNU Bitrig))
+    # Include everything from the .a's into the shared library.
+    LLVMLibsOptions := -Wl,--whole-archive $(LLVMLibsOptions) \
+                       -Wl,--no-whole-archive
+endif
+
+ifeq ($(HOST_OS), $(filter $(HOST_OS), DragonFly Linux FreeBSD GNU/kFreeBSD GNU))
+    # Add soname to the library.
+    LLVMLibsOptions += -Wl,--soname,lib$(LIBRARYNAME)$(SHLIBEXT).$(SHARED_VERSION)
+endif
+
+ifeq ($(HOST_OS), $(filter $(HOST_OS), Linux GNU GNU/kFreeBSD))
+    # Don't allow unresolved symbols.
+    LLVMLibsOptions += -Wl,--no-undefined
+endif


### PR DESCRIPTION
Based on llvm-shlib/Makefile

SHARED_VERSION reflects the API version of the library itself

Should fix #237 