### PR TITLE
Fix SELinux signatures in runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_install:
     ###########################################################################
     # Install stuff
     ###########################################################################
-    - sudo apt-get install gcc-4.8 g++-4.8 libcap-dev cmake
+    - sudo apt-get install gcc-4.8 g++-4.8 libcap-dev libselinux1-dev cmake
     # Make gcc4.8 the default gcc version
     - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 20
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 20

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -534,11 +534,30 @@ if test "x${have_cap}" = xno; then
 capability checking support for klee-replay.])
 fi
 
-AC_LANG_POP([C])
-
 AC_CHECK_HEADERS([selinux/selinux.h],
         AC_SUBST(HAVE_SELINUX, 1),
         AC_SUBST(HAVE_SELINUX, 0))
+
+if test "$HAVE_SELINUX" = "1"; then
+   # Test what function signature we need to use for SELinux. The signatures
+   # have changed between 2.2 and 2.3. In particular, the type of the "security
+   # context" parameter was changed from char * to const char *, with this
+   # patch: [PATCH] Get rid of security_context_t and fix const declarations.
+   # [http://www.spinics.net/lists/selinux/msg14827.html]
+   AC_CACHE_CHECK([for selinux security context type constness],
+                  [klee_cv_sel_ctx_const],
+   [AC_COMPILE_IFELSE(
+     [AC_LANG_PROGRAM([[
+#include <selinux/selinux.h>
+int setcon(char *context);]])],
+     [klee_cv_sel_ctx_const=''],
+     [klee_cv_sel_ctx_const='const'])])
+   AC_DEFINE_UNQUOTED([KLEE_SELINUX_CTX_CONST], [$klee_cv_sel_ctx_const],
+     [Define to empty or 'const' depending on how SELinux qualifies its
+      security context parameters.])
+fi
+
+AC_LANG_POP([C])
 
 dnl **************************************************************************
 dnl Test for features

--- a/configure
+++ b/configure
@@ -4634,11 +4634,69 @@ $as_echo "$as_me: WARNING: Library cap and its header file sys/capability.h not 
 capability checking support for klee-replay." >&2;}
 fi
 
+for ac_header in selinux/selinux.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "selinux/selinux.h" "ac_cv_header_selinux_selinux_h" "$ac_includes_default"
+if test "x$ac_cv_header_selinux_selinux_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SELINUX_SELINUX_H 1
+_ACEOF
+ HAVE_SELINUX=1
+
+else
+  HAVE_SELINUX=0
+
+fi
+
+done
+
+
+if test "$HAVE_SELINUX" = "1"; then
+   # Test what function signature we need to use for SELinux. The signatures
+   # have changed between 2.2 and 2.3. In particular, the type of the "security
+   # context" parameter was changed from char * to const char *, with this
+   # patch: [PATCH] Get rid of security_context_t and fix const declarations.
+   # [http://www.spinics.net/lists/selinux/msg14827.html]
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for selinux security context type constness" >&5
+$as_echo_n "checking for selinux security context type constness... " >&6; }
+if ${klee_cv_sel_ctx_const+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <selinux/selinux.h>
+int setcon(char *context);
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  klee_cv_sel_ctx_const=''
+else
+  klee_cv_sel_ctx_const='const'
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $klee_cv_sel_ctx_const" >&5
+$as_echo "$klee_cv_sel_ctx_const" >&6; }
+
+cat >>confdefs.h <<_ACEOF
+#define KLEE_SELINUX_CTX_CONST $klee_cv_sel_ctx_const
+_ACEOF
+
+fi
+
 ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
 
 
 ac_ext=cpp
@@ -4773,24 +4831,6 @@ ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-for ac_header in selinux/selinux.h
-do :
-  ac_fn_cxx_check_header_mongrel "$LINENO" "selinux/selinux.h" "ac_cv_header_selinux_selinux_h" "$ac_includes_default"
-if test "x$ac_cv_header_selinux_selinux_h" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_SELINUX_SELINUX_H 1
-_ACEOF
- HAVE_SELINUX=1
-
-else
-  HAVE_SELINUX=0
-
-fi
-
-done
-
 
 
 for ac_header in malloc/malloc.h

--- a/include/klee/Config/config.h.in
+++ b/include/klee/Config/config.h.in
@@ -69,6 +69,10 @@
 /* Z3 needs a Z3_context passed to Z3_get_error_msg() */
 #undef HAVE_Z3_GET_ERROR_MSG_NEEDS_CONTEXT
 
+/* Define to empty or 'const' depending on how SELinux qualifies its security
+   context parameters. */
+#undef KLEE_SELINUX_CTX_CONST
+
 /* LLVM version is release (instead of development) */
 #undef LLVM_IS_RELEASE
 

--- a/runtime/POSIX/selinux.c
+++ b/runtime/POSIX/selinux.c
@@ -23,7 +23,7 @@
 int exe_selinux = 1;
 
 /* NULL is the default policy behavior */
-security_context_t create_con = NULL;
+KLEE_SELINUX_CTX_CONST char *create_con = NULL;
 
 
 int is_selinux_enabled() {
@@ -33,13 +33,13 @@ int is_selinux_enabled() {
 
 /***/
 
-int getfscreatecon(security_context_t *context) {
-  *context = create_con;
+int getfscreatecon(char **context) {
+  *context = (char *)create_con;
   return 0;
 }
 
 
-int setfscreatecon(security_context_t context) {
+int setfscreatecon(KLEE_SELINUX_CTX_CONST char *context) {
   if (context == NULL) {
     create_con = context;
     return 0;
@@ -56,7 +56,7 @@ int setfscreatecon(security_context_t context) {
 
 /***/
 
-int setfilecon(const char *path, security_context_t con) {
+int setfilecon(const char *path, KLEE_SELINUX_CTX_CONST char *con) {
   if (con)
     return 0;
   
@@ -64,17 +64,17 @@ int setfilecon(const char *path, security_context_t con) {
   return -1;  
 }
 
-int lsetfilecon(const char *path, security_context_t con) {
+int lsetfilecon(const char *path, KLEE_SELINUX_CTX_CONST char *con) {
   return setfilecon(path, con);
 }
 
-int fsetfilecon(int fd, security_context_t con) {
+int fsetfilecon(int fd, KLEE_SELINUX_CTX_CONST char *con) {
   return setfilecon("", con);
 }
 
 /***/
 
-void freecon(security_context_t con) {}
-void freeconary(security_context_t *con) {}
+void freecon(char *con) {}
+void freeconary(char **con) {}
 
 #endif


### PR DESCRIPTION
Fixes https://github.com/klee/klee/issues/303:

The SELinux function signatures have changed between version 2.2 and
2.3. In particular, the type of the "security context" parameters were
changed from char * to const char *, with the following patch:
https://github.com/SELinuxProject/selinux/commit/9eb9c9327563014ad6a807814e7975424642d5b9.

Recent Linux distributions (e.g., Ubuntu 15.10) ship with the updated
version of libselinux. This PR makes the runtime compatible with these
changes by replacing security_context_t typedef with its original char *
definition and defining it as const only if the installed library does
so. Whether the systems library uses const char * type is detected with 
the configure script.