### PR TITLE
Fix incorrect position of ``Not`` in ``Expr::Kind``

### DIFF
--- a/include/klee/Expr.h
+++ b/include/klee/Expr.h
@@ -128,6 +128,9 @@ public:
     ZExt,
     SExt,
 
+    // Bit
+    Not,
+
     // All subsequent kinds are binary.
 
     // Arithmetic
@@ -140,7 +143,6 @@ public:
     SRem,
 
     // Bit
-    Not,
     And,
     Or,
     Xor,


### PR DESCRIPTION
Fix incorrect position of ``Not`` in ``Expr::Kind`` which meant it was included

in the range of ``BinaryKindFirst`` and ``BinaryKindLast``. ``NotExpr``
is a unary expr not a binary expression.