### PR TITLE
Wrong std::vector usage after reserve() call.

### DIFF
--- a/lib/Module/PhiCleaner.cpp
+++ b/lib/Module/PhiCleaner.cpp
@@ -40,13 +40,9 @@ bool klee::PhiCleanerPass::runOnFunction(Function &f) {
             break;
 
         if (i!=numBlocks) {
-          std::vector<Value*> values;
-          values.reserve(numBlocks);
-          for (unsigned i=0; i<numBlocks; i++)
-            values[i] = pi->getIncomingValueForBlock(reference->getIncomingBlock(i));
           for (unsigned i=0; i<numBlocks; i++) {
             pi->setIncomingBlock(i, reference->getIncomingBlock(i));
-            pi->setIncomingValue(i, values[i]);
+            pi->setIncomingValue(i, pi->getIncomingValueForBlock(reference->getIncomingBlock(i)));
           }
           changed = true;
         }

--- a/lib/Module/PhiCleaner.cpp
+++ b/lib/Module/PhiCleaner.cpp
@@ -39,12 +39,16 @@ bool klee::PhiCleanerPass::runOnFunction(Function &f) {
           if (pi->getIncomingBlock(i) != reference->getIncomingBlock(i))
             break;
 
-        if (i!=numBlocks) {
-          for (unsigned i=0; i<numBlocks; i++) {
-            pi->setIncomingBlock(i, reference->getIncomingBlock(i));
-            pi->setIncomingValue(i, pi->getIncomingValueForBlock(reference->getIncomingBlock(i)));
-          }
-          changed = true;
+        if (i != numBlocks) {
+            std::vector<Value*> values;
+            values.reserve(numBlocks);
+            for (unsigned i = 0; i<numBlocks; i++)
+                values.push_back(pi->getIncomingValueForBlock(reference->getIncomingBlock(i)));
+            for (unsigned i = 0; i<numBlocks; i++) {
+                pi->setIncomingBlock(i, reference->getIncomingBlock(i));
+                pi->setIncomingValue(i, values[i]);
+            }
+            changed = true;
         }
 
         // see if it uses any previously defined phi nodes


### PR DESCRIPTION
Wrong std::vector 'values' usage after vector's capacity reserve. It is the error to use [] operator for accessing vector's elements after reserving operation. In such cases push_back/emplace methods should be used. But in this source code the usage of std::vector is redundant. So vector 'values' was iliminated.