### PR TITLE
Try to fix #348

### DIFF
--- a/lib/Solver/IndependentSolver.cpp
+++ b/lib/Solver/IndependentSolver.cpp
@@ -438,65 +438,38 @@ bool IndependentSolver::computeValue(const Query& query, ref<Expr> &result) {
   return solver->impl->computeValue(Query(tmp, query.expr), result);
 }
 
-bool canPerformConcreteAssignment(const std::vector<const Array*> &objects, const ref<Expr> e) {
-  // Get the arrays used in the constraint. If an array isn't in objects we
-  // don't have an assignment for it so skip it because can't evaluate to a
-  // constant. This means we might not be checking every constraint which is
-  // not ideal but the alternative would require getting an assignment for
-  // all arrays which is wasteful given that the client didn't ask for them
-  IndependentElementSet ieSet(e);
-  for (std::vector<const Array *>::const_iterator ai = objects.begin(),
-                                                  ae = objects.end();
-       ai != ae; ++ai) {
-    ieSet.wholeObjects.erase(*ai);
-    ieSet.elements.erase(*ai);
-  }
-
-  if (ieSet.wholeObjects.size() > 0 || ieSet.elements.size() > 0) {
-    // There are arrays used in ``e`` that aren't in objects,
-    // therefore we can't perform a complete assignment
-    return false;
-  }
-  return true;
-}
-
 // Helper function used only for assertions to make sure point created
-// during computeInitialValues is in fact correct. This function is
-// a "best effort" check because if the query uses an Array that an
-// assignment is not given for then that Query cannot be fully evaluated so
-// this function only checks that all expressions that can be fully
-// assigned to evaluate to true.
+// during computeInitialValues is in fact correct. The ``retMap`` is used
+// in the case ``objects`` doesn't contain all the assignments needed.
 bool assertCreatedPointEvaluatesToTrue(const Query &query,
                                        const std::vector<const Array*> &objects,
-                                       std::vector< std::vector<unsigned char> > &values){
+                                       std::vector< std::vector<unsigned char> > &values,
+                                       std::map<const Array*, std::vector<unsigned char> > &retMap){
   // _allowFreeValues is set to true so that if there are missing bytes in the assigment
   // we will end up with a non ConstantExpr after evaluating the assignment and fail
   Assignment assign = Assignment(objects, values, /*_allowFreeValues=*/true);
+
+  // Add any additional bindings.
+  // The semantics of std::map should be to not insert a (key, value)
+  // pair if it already exists so we should continue to use the assignment
+  // from ``objects`` and ``values``.
+  if (retMap.size() > 0)
+    assign.bindings.insert(retMap.begin(), retMap.end());
+
   for(ConstraintManager::constraint_iterator it = query.constraints.begin();
       it != query.constraints.end(); ++it){
-    ref<Expr> constraint = *it;
-
-    if (!canPerformConcreteAssignment(objects, constraint)) {
-      // We have to skip checking assigning to this constraint
-      continue;
-    }
-
     ref<Expr> ret = assign.evaluate(*it);
 
-    assert(isa<ConstantExpr>(ret) && "Could not use assignment to evaluate constraint");
+    assert(isa<ConstantExpr>(ret) && "assignment evaluation did not result in constant");
     ref<ConstantExpr> evaluatedConstraint = dyn_cast<ConstantExpr>(ret);
     if(evaluatedConstraint->isFalse()){
       return false;
     }
   }
   ref<Expr> neg = Expr::createIsZero(query.expr);
-  if (canPerformConcreteAssignment(objects, neg)) {
-    ref<Expr> q = assign.evaluate(neg);
-    assert(isa<ConstantExpr>(q) && "assignment evaluation did not result in constant");
-    return cast<ConstantExpr>(q)->isTrue();
-  }
-  // Can't assign to query expression
-  return true;
+  ref<Expr> q = assign.evaluate(neg);
+  assert(isa<ConstantExpr>(q) && "assignment evaluation did not result in constant");
+  return cast<ConstantExpr>(q)->isTrue();
 }
 
 bool IndependentSolver::computeInitialValues(const Query& query,
@@ -569,7 +542,7 @@ bool IndependentSolver::computeInitialValues(const Query& query,
       values.push_back(retMap[arr]);
     }
   }
-  assert(assertCreatedPointEvaluatesToTrue(query, objects, values) && "should satisfy the equation");
+  assert(assertCreatedPointEvaluatesToTrue(query, objects, values, retMap) && "should satisfy the equation");
   delete factors;
   return true;
 }

--- a/test/regression/2016-03-22-independence-solver-missing-objects-for-assignment.kquery
+++ b/test/regression/2016-03-22-independence-solver-missing-objects-for-assignment.kquery
@@ -1,0 +1,15 @@
+# RUN: %kleaver %s 2>&1 | FileCheck %s
+array n_args[4] : w32 -> w8 = symbolic
+array n_args_1[4] : w32 -> w8 = symbolic
+array A-data-stat[144] : w32 -> w8 = symbolic
+array stdin-stat[144] : w32 -> w8 = symbolic
+(query [(Ult N0:(ReadLSB w32 0 n_args) 2)
+(Slt 0 N0)
+(Ult N1:(ReadLSB w32 0 n_args_1) 3)
+(Slt 0 N1)
+(Slt 1 N1)
+(Eq false (Eq 0 (And w64 (ReadLSB w64 8 A-data-stat) 2147483647)))
+(Ult (ReadLSB w64 56 A-data-stat) 65536)
+(Eq false (Eq 0 (And w64 (ReadLSB w64 8 stdin-stat) 2147483647)))]
+(Eq false (Ult (ReadLSB w64 56 stdin-stat) 65536)) [] [n_args])
+# CHECK: INVALID

--- a/test/regression/lit.local.cfg
+++ b/test/regression/lit.local.cfg
@@ -1,0 +1,2 @@
+# Look for .kquery files too
+config.suffixes.add('.kquery')


### PR DESCRIPTION
The problem was that ``assertCreatedPointEvaluatesToTrue()`` used in the
IndependentSolver assumed that it would be given an assignment for every
array. If this wasn't the case the ``Assignment`` object by default
would just replace every read of an unknown array with a byte filled
with zeros.

This problem would appear if
``IndependentSolver::getInitialValues(...)`` was called without asking
for assignment for used arrays.

I saw two ways of fixing this

* Get an assignment for all arrays even if the client didn't ask
  for them. This guarantees that
  we can compute a concrete assignment.

* Just do a "best effort" check and only check expressions that can
  be fully assigned to.

I chose the latter because the first option seems pretty wasteful,
especially for an assert.

The second option isn't ideal though as it would be possible to
compute an assignment that for the whole query leads to "unsat"
but we wouldn't notice.