### PR TITLE
Allow cross checking of solvers

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -44,8 +44,16 @@ enum QueryLoggingSolverType
  */
 extern llvm::cl::list<QueryLoggingSolverType> queryLoggingOptions;
 
-enum CoreSolverType { STP_SOLVER, METASMT_SOLVER, DUMMY_SOLVER, Z3_SOLVER };
+enum CoreSolverType {
+  STP_SOLVER,
+  METASMT_SOLVER,
+  DUMMY_SOLVER,
+  Z3_SOLVER,
+  NO_SOLVER
+};
 extern llvm::cl::opt<CoreSolverType> CoreSolverToUse;
+
+extern llvm::cl::opt<CoreSolverType> DebugCrossCheckCoreSolverWith;
 
 #ifdef ENABLE_METASMT
 

--- a/include/klee/Internal/Support/ErrorHandling.h
+++ b/include/klee/Internal/Support/ErrorHandling.h
@@ -23,7 +23,7 @@ namespace klee {
 extern FILE *klee_warning_file;
 extern FILE *klee_message_file;
 
-/// Print "KLEE: ERROR" followed by the msg in printf format and a
+/// Print "KLEE: ERROR: " followed by the msg in printf format and a
 /// newline on stderr and to warnings.txt, then exit with an error.
 void klee_error(const char *msg, ...)
     __attribute__((format(printf, 1, 2), noreturn));
@@ -37,11 +37,11 @@ void klee_message(const char *msg, ...) __attribute__((format(printf, 1, 2)));
 void klee_message_to_file(const char *msg, ...)
     __attribute__((format(printf, 1, 2)));
 
-/// Print "KLEE: WARNING" followed by the msg in printf format and a
+/// Print "KLEE: WARNING: " followed by the msg in printf format and a
 /// newline on stderr and to warnings.txt.
 void klee_warning(const char *msg, ...) __attribute__((format(printf, 1, 2)));
 
-/// Print "KLEE: WARNING" followed by the msg in printf format and a
+/// Print "KLEE: WARNING: " followed by the msg in printf format and a
 /// newline on stderr and to warnings.txt. However, the warning is only
 /// printed once for each unique (id, msg) pair (as pointers).
 void klee_warning_once(const void *id, const char *msg, ...)

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -141,7 +141,7 @@ llvm::cl::opt<CoreSolverType> CoreSolverToUse(
     llvm::cl::init(DEFAULT_CORE_SOLVER));
 
 llvm::cl::opt<CoreSolverType> DebugCrossCheckCoreSolverWith(
-    "debug-cross-check-core-solver",
+    "debug-crosscheck-core-solver",
     llvm::cl::desc(
         "Specifiy a solver to use for cross checking with the core solver"),
     llvm::cl::values(clEnumValN(STP_SOLVER, "stp", "stp"),

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -139,6 +139,19 @@ llvm::cl::opt<CoreSolverType> CoreSolverToUse(
                      clEnumValN(Z3_SOLVER, "z3", "Z3" Z3_IS_DEFAULT_STR),
                      clEnumValEnd),
     llvm::cl::init(DEFAULT_CORE_SOLVER));
+
+llvm::cl::opt<CoreSolverType> DebugCrossCheckCoreSolverWith(
+    "debug-cross-check-core-solver",
+    llvm::cl::desc(
+        "Specifiy a solver to use for cross checking with the core solver"),
+    llvm::cl::values(clEnumValN(STP_SOLVER, "stp", "stp"),
+                     clEnumValN(METASMT_SOLVER, "metasmt", "metaSMT"),
+                     clEnumValN(DUMMY_SOLVER, "dummy", "Dummy solver"),
+                     clEnumValN(Z3_SOLVER, "z3", "Z3"),
+                     clEnumValN(NO_SOLVER, "none",
+                                "Do not cross check (default)"),
+                     clEnumValEnd),
+    llvm::cl::init(NO_SOLVER));
 }
 #undef STP_IS_DEFAULT_STR
 #undef METASMT_IS_DEFAULT_STR

--- a/lib/Basic/ConstructSolverChain.cpp
+++ b/lib/Basic/ConstructSolverChain.cpp
@@ -1,4 +1,4 @@
-//===-- ConstructSolverChain.cpp ------------------------------------------------*- C++ -*-===//
+//===-- ConstructSolverChain.cpp ------------------------------------++ -*-===//
 //
 //                     The KLEE Symbolic Virtual Machine
 //
@@ -14,69 +14,55 @@
 #include "klee/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace klee
-{
-        Solver *constructSolverChain(Solver *coreSolver,
-                                     std::string querySMT2LogPath,
-                                     std::string baseSolverQuerySMT2LogPath,
-                                     std::string queryPCLogPath,
-                                     std::string baseSolverQueryPCLogPath)
-	{
-	  Solver *solver = coreSolver;
+namespace klee {
+Solver *constructSolverChain(Solver *coreSolver, std::string querySMT2LogPath,
+                             std::string baseSolverQuerySMT2LogPath,
+                             std::string queryPCLogPath,
+                             std::string baseSolverQueryPCLogPath) {
+  Solver *solver = coreSolver;
 
-	  if (optionIsSet(queryLoggingOptions, SOLVER_PC))
-	  {
-		solver = createPCLoggingSolver(solver,
-					       baseSolverQueryPCLogPath,
-					       MinQueryTimeToLog);
-		llvm::errs() << "Logging queries that reach solver in .pc format to "
-			  << baseSolverQueryPCLogPath.c_str() << "\n";
-	  }
+  if (optionIsSet(queryLoggingOptions, SOLVER_PC)) {
+    solver = createPCLoggingSolver(solver, baseSolverQueryPCLogPath,
+                                   MinQueryTimeToLog);
+    llvm::errs() << "Logging queries that reach solver in .pc format to "
+                 << baseSolverQueryPCLogPath.c_str() << "\n";
+  }
 
-	  if (optionIsSet(queryLoggingOptions, SOLVER_SMTLIB))
-	  {
-		solver = createSMTLIBLoggingSolver(solver,
-						   baseSolverQuerySMT2LogPath,
-						   MinQueryTimeToLog);
-		llvm::errs() << "Logging queries that reach solver in .smt2 format to "
-			  << baseSolverQuerySMT2LogPath.c_str() << "\n";
-	  }
+  if (optionIsSet(queryLoggingOptions, SOLVER_SMTLIB)) {
+    solver = createSMTLIBLoggingSolver(solver, baseSolverQuerySMT2LogPath,
+                                       MinQueryTimeToLog);
+    llvm::errs() << "Logging queries that reach solver in .smt2 format to "
+                 << baseSolverQuerySMT2LogPath.c_str() << "\n";
+  }
 
-	  if (UseFastCexSolver)
-		solver = createFastCexSolver(solver);
+  if (UseFastCexSolver)
+    solver = createFastCexSolver(solver);
 
-	  if (UseCexCache)
-		solver = createCexCachingSolver(solver);
+  if (UseCexCache)
+    solver = createCexCachingSolver(solver);
 
-	  if (UseCache)
-		solver = createCachingSolver(solver);
+  if (UseCache)
+    solver = createCachingSolver(solver);
 
-	  if (UseIndependentSolver)
-		solver = createIndependentSolver(solver);
+  if (UseIndependentSolver)
+    solver = createIndependentSolver(solver);
 
-	  if (DebugValidateSolver)
-		solver = createValidatingSolver(solver, coreSolver);
+  if (DebugValidateSolver)
+    solver = createValidatingSolver(solver, coreSolver);
 
-	  if (optionIsSet(queryLoggingOptions, ALL_PC))
-	  {
-		solver = createPCLoggingSolver(solver,
-					       queryPCLogPath,
-					       MinQueryTimeToLog);
-		llvm::errs() << "Logging all queries in .pc format to "
-			  << queryPCLogPath.c_str() << "\n";
-	  }
+  if (optionIsSet(queryLoggingOptions, ALL_PC)) {
+    solver = createPCLoggingSolver(solver, queryPCLogPath, MinQueryTimeToLog);
+    llvm::errs() << "Logging all queries in .pc format to "
+                 << queryPCLogPath.c_str() << "\n";
+  }
 
-	  if (optionIsSet(queryLoggingOptions, ALL_SMTLIB))
-	  {
-		solver = createSMTLIBLoggingSolver(solver,querySMT2LogPath,
-						   MinQueryTimeToLog);
-		llvm::errs() << "Logging all queries in .smt2 format to "
-			  << querySMT2LogPath.c_str() << "\n";
-	  }
+  if (optionIsSet(queryLoggingOptions, ALL_SMTLIB)) {
+    solver =
+        createSMTLIBLoggingSolver(solver, querySMT2LogPath, MinQueryTimeToLog);
+    llvm::errs() << "Logging all queries in .smt2 format to "
+                 << querySMT2LogPath.c_str() << "\n";
+  }
 
-	  return solver;
-	}
-
+  return solver;
 }
-
-
+}

--- a/lib/Basic/ConstructSolverChain.cpp
+++ b/lib/Basic/ConstructSolverChain.cpp
@@ -62,6 +62,10 @@ Solver *constructSolverChain(Solver *coreSolver, std::string querySMT2LogPath,
     llvm::errs() << "Logging all queries in .smt2 format to "
                  << querySMT2LogPath.c_str() << "\n";
   }
+  if (DebugCrossCheckCoreSolverWith != NO_SOLVER) {
+    Solver *oracleSolver = createCoreSolver(DebugCrossCheckCoreSolverWith);
+    solver = createValidatingSolver(/*s=*/solver, /*oracle=*/oracleSolver);
+  }
 
   return solver;
 }

--- a/lib/Solver/CoreSolver.cpp
+++ b/lib/Solver/CoreSolver.cpp
@@ -83,11 +83,15 @@ Solver *createCoreSolver(CoreSolverType cst) {
     return createDummySolver();
   case Z3_SOLVER:
 #ifdef ENABLE_Z3
+    llvm::errs() << "Using Z3 solver backend\n";
     return new Z3Solver();
 #else
     llvm::errs() << "Not compiled with Z3 support\n";
     return NULL;
 #endif
+  case NO_SOLVER:
+    llvm::errs() << "Invalid solver\n";
+    return NULL;
   default:
     llvm_unreachable("Unsupported CoreSolverType");
   }


### PR DESCRIPTION
Now that we have better support multiple solvers it is possible to cross check the core solver against another. This PR adds support for doing this using the new ``-debug-cross-check-core-solver=`` option.

Practically I see this being useful to cross check STP and Z3.