### PR TITLE
remove synthesized `rule of three` of KInstIterator

### DIFF
--- a/include/klee/Internal/Module/KInstIterator.h
+++ b/include/klee/Internal/Module/KInstIterator.h
@@ -19,13 +19,6 @@ namespace klee {
   public:
     KInstIterator() : it(0) {}
     KInstIterator(KInstruction **_it) : it(_it) {}
-    KInstIterator(const KInstIterator &b) : it(b.it) {}
-    ~KInstIterator() {}
-
-    KInstIterator &operator=(const KInstIterator &b) {
-      it = b.it;
-      return *this;
-    }
 
     bool operator==(const KInstIterator &b) const {
       return it==b.it;


### PR DESCRIPTION
The "rule of three" of `KInstIterator` class is synthesized version. The `KInstIterator` isn't deep copy, so it's redundant to write them explicitly.