### PR TITLE
Executor: do not crash on non-sized globals

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -504,7 +504,12 @@ void Executor::initializeGlobals(ExecutionState &state) {
       // hack where we check the object file information.
 
       LLVM_TYPE_Q Type *ty = i->getType()->getElementType();
-      uint64_t size = kmodule->targetData->getTypeStoreSize(ty);
+      uint64_t size = 0;
+      if (ty->isSized()) {
+	size = kmodule->targetData->getTypeStoreSize(ty);
+      } else {
+        llvm::errs() << "Type for " << i->getName() << " is not sized\n";
+      }
 
       // XXX - DWD - hardcode some things until we decide how to fix.
 #ifndef WINDOWS


### PR DESCRIPTION
This is a followup of issue #172.

Sometimes, globals are not sized and ->getTypeStoreSize on such type
crashes inside the LLVM. Check whether type is sized prior to calling
the function above.

This is a minimalistic example of Y being unsized with no effect on
the actual code:
struct X;
extern struct X Y;
void *ptr = &Y;

int main()
{
        return 0;
}
==== EOF ====

Signed-off-by: Jiri Slaby <jslaby@suse.cz>