### PR TITLE
LLVM 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,10 @@ env:
 
     matrix:
     # Test experimental Z3 support
-    - LLVM_VERSION=3.8 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
-    - LLVM_VERSION=3.8 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    # LLVM 3.8 no longer distributes the testing tools - we need to be able to get them in order to test.
+    # They can be obtained by building llvm from source, but it takes too long for Travis to handle it.
+    #- LLVM_VERSION=3.8 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    #- LLVM_VERSION=3.8 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
@@ -37,8 +39,8 @@ env:
     - LLVM_VERSION=3.4 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.4 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     # Test STP version = master
-    - LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
-    - LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    #- LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    #- LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
@@ -50,8 +52,8 @@ env:
     - LLVM_VERSION=2.9 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=2.9 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     # Test STP version = 2.1.0
-    - LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
-    - LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    #- LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    #- LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
@@ -93,8 +95,8 @@ before_install:
     - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main" >> /etc/apt/sources.list.d/llvm.list'
-    - sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.8 main" >> /etc/apt/sources.list.d/llvm.list'
-    - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.8 main" >> /etc/apt/sources.list.d/llvm.list'
+    #- sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.8 main" >> /etc/apt/sources.list.d/llvm.list'
+    #- sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.8 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/delcypher:/z3/xUbuntu_12.04/ /' >> /etc/apt/sources.list.d/z3.list"
     # Needed for CMake
     - sudo add-apt-repository -y ppa:ubuntu-sdk-team/ppa

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     ###########################################################################
 
     # Check the matrix of:
-    #   LLVM       : {2.9, 3.4, 3.5, 3.6, 3.7}
+    #   LLVM       : {2.9, 3.4, 3.5, 3.6, 3.7, 3.8}
     #   SOLVERS    : {Z3, STP, STP:Z3}
     #   STP_VERSION: {2.1.0, master}
     #   UCLIBC     : {0, klee_uclibc_v1.0.0, klee_0_9_29} // Note ``0`` means disabled
@@ -28,6 +28,8 @@ env:
 
     matrix:
     # Test experimental Z3 support
+    - LLVM_VERSION=3.8 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.8 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
@@ -35,6 +37,8 @@ env:
     - LLVM_VERSION=3.4 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.4 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     # Test STP version = master
+    - LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
@@ -46,6 +50,8 @@ env:
     - LLVM_VERSION=2.9 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=2.9 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     # Test STP version = 2.1.0
+    - LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.8 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
@@ -87,6 +93,8 @@ before_install:
     - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main" >> /etc/apt/sources.list.d/llvm.list'
+    - sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.8 main" >> /etc/apt/sources.list.d/llvm.list'
+    - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.8 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/delcypher:/z3/xUbuntu_12.04/ /' >> /etc/apt/sources.list.d/z3.list"
     # Needed for CMake
     - sudo add-apt-repository -y ppa:ubuntu-sdk-team/ppa

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,25 +18,34 @@ env:
     ###########################################################################
 
     # Check the matrix of:
-    #   LLVM  : {2.9, 3.4}
-    #   SOLVERS : {Z3, STP, STP:Z3}
-    #   STP_VERSION   : {2.1.0, master}
-    #   UCLIBC: {0, klee_uclibc_v1.0.0, klee_0_9_29} // Note ``0`` means disabled
+    #   LLVM       : {2.9, 3.4, 3.5, 3.6}
+    #   SOLVERS    : {Z3, STP, STP:Z3}
+    #   STP_VERSION: {2.1.0, master}
+    #   UCLIBC     : {0, klee_uclibc_v1.0.0, klee_0_9_29} // Note ``0`` means disabled
     # with Asserts enabled.
 
     # COVERAGE set indicated that coverage data should be uplaoded to the server, only ONE job should have COVERAGE set
 
     matrix:
     # Test experimental Z3 support
+    - LLVM_VERSION=3.6 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.6 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.4 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.4 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
-    # FIXME: Enable when we want to test LLVM3.5
-    #- LLVM_VERSION=3.5 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1
-    #- LLVM_VERSION=3.5 STP_VERSION=master KLEE_UCLIBC=1 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1
+    # Test STP version = master
+    - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.5 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.5 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.4 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=1
     - LLVM_VERSION=3.4 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=2.9 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=2.9 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    # Test STP version = 2.1.0
+    - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.5 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.5 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.4 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.4 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=2.9 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
@@ -68,6 +77,8 @@ before_install:
     - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.4 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main" >> /etc/apt/sources.list.d/llvm.list'
+    - sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main" >> /etc/apt/sources.list.d/llvm.list'
+    - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/delcypher:/z3/xUbuntu_12.04/ /' >> /etc/apt/sources.list.d/z3.list"
     # Needed for CMake
     - sudo add-apt-repository -y ppa:ubuntu-sdk-team/ppa

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     ###########################################################################
 
     # Check the matrix of:
-    #   LLVM       : {2.9, 3.4, 3.5, 3.6}
+    #   LLVM       : {2.9, 3.4, 3.5, 3.6, 3.7}
     #   SOLVERS    : {Z3, STP, STP:Z3}
     #   STP_VERSION: {2.1.0, master}
     #   UCLIBC     : {0, klee_uclibc_v1.0.0, klee_0_9_29} // Note ``0`` means disabled
@@ -28,11 +28,15 @@ env:
 
     matrix:
     # Test experimental Z3 support
+    - LLVM_VERSION=3.7 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.7 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.4 SOLVERS=Z3 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.4 SOLVERS=STP:Z3 STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     # Test STP version = master
+    - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.5 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
@@ -42,6 +46,8 @@ env:
     - LLVM_VERSION=2.9 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=2.9 SOLVERS=STP STP_VERSION=master KLEE_UCLIBC=klee_0_9_29 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     # Test STP version = 2.1.0
+    - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
+    - LLVM_VERSION=3.7 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.6 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
     - LLVM_VERSION=3.5 SOLVERS=STP STP_VERSION=2.1.0 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
@@ -79,6 +85,8 @@ before_install:
     - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main" >> /etc/apt/sources.list.d/llvm.list'
+    - sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main" >> /etc/apt/sources.list.d/llvm.list'
+    - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main" >> /etc/apt/sources.list.d/llvm.list'
     - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/delcypher:/z3/xUbuntu_12.04/ /' >> /etc/apt/sources.list.d/z3.list"
     # Needed for CMake
     - sudo add-apt-repository -y ppa:ubuntu-sdk-team/ppa

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ before_install:
     ###########################################################################
     # Install stuff
     ###########################################################################
-    - sudo apt-get install gcc-4.8 g++-4.8 libcap-dev libselinux1-dev cmake
+    - sudo apt-get install gcc-4.8 g++-4.8 libcap-dev libselinux1-dev cmake libedit-dev
     # Make gcc4.8 the default gcc version
     - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 20
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 20

--- a/.travis/install-llvm-and-runtime-compiler.sh
+++ b/.travis/install-llvm-and-runtime-compiler.sh
@@ -4,7 +4,13 @@ set -ev
 sudo apt-get install -y --force-yes llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev
 
 if [ "${LLVM_VERSION}" != "2.9" ]; then
-    sudo apt-get install -y --force-yes llvm-${LLVM_VERSION}-tools clang-${LLVM_VERSION}
+    # LLVM 3.8 no longer distributes the testing tools, we need to build LLVM
+    # from source to obtain them, but it takes too long for Travis to handle.
+    # Maybe hack it somehow?
+    if [ "${LLVM_VERSION}" != "3.8" ]; then
+        sudo apt-get install -y --force-yes llvm-${LLVM_VERSION}-tools
+    fi
+    sudo apt-get install -y --force-yes clang-${LLVM_VERSION}
 else
     # Get llvm-gcc. We don't bother installing it
     wget http://llvm.org/releases/2.9/llvm-gcc4.2-2.9-x86_64-linux.tar.bz2

--- a/.travis/install-llvm-and-runtime-compiler.sh
+++ b/.travis/install-llvm-and-runtime-compiler.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -x
 set -ev
 
-sudo apt-get install -y llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev
+sudo apt-get install -y --force-yes llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev
 
 if [ "${LLVM_VERSION}" != "2.9" ]; then
-    sudo apt-get install -y llvm-${LLVM_VERSION}-tools clang-${LLVM_VERSION}
+    sudo apt-get install -y --force-yes llvm-${LLVM_VERSION}-tools clang-${LLVM_VERSION}
 else
     # Get llvm-gcc. We don't bother installing it
     wget http://llvm.org/releases/2.9/llvm-gcc4.2-2.9-x86_64-linux.tar.bz2

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1618,16 +1618,22 @@ $(ObjDir)/%.s: %.m $(ObjDir)/.dir $(BUILT_SOURCES)
 	$(Compile.C) $< -o $@ -S
 
 
+#which PARAM to send to LOPT
+LOPT_PARAM = -std-compile-opts
+ifeq ($(shell python -c "print($(LLVM_VERSION_MAJOR).$(LLVM_VERSION_MINOR) >= 3.6)"), True)
+LOPT_PARAM = -std-link-opts
+endif
+
 # make the C and C++ compilers strip debug info out of bytecode libraries.
 ifdef DEBUG_RUNTIME
 $(ObjectsBC): $(ObjDir)/%.bc: $(ObjDir)/%.ll $(LLVMAS) $(LOPT)
 	$(Echo) "Compiling $*.ll to $*.bc for $(BuildMode) build (bytecode)"
-	$(Verb) $(LLVMAS) $< -o - | $(LOPT) -std-compile-opts -o $@
+	$(Verb) $(LLVMAS) $< -o - | $(LOPT) $(LOPT_PARAM) -o $@
 else
 $(ObjectsBC): $(ObjDir)/%.bc: $(ObjDir)/%.ll $(LLVMAS) $(LOPT)
 	$(Echo) "Compiling $*.ll to $*.bc for $(BuildMode) build (bytecode)"
 	$(Verb) $(LLVMAS) $< -o - | \
-	   $(LOPT) -std-compile-opts -strip-debug -o $@
+	   $(LOPT) $(LOPT_PARAM) -strip-debug -o $@
 endif
 
 

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1618,22 +1618,16 @@ $(ObjDir)/%.s: %.m $(ObjDir)/.dir $(BUILT_SOURCES)
 	$(Compile.C) $< -o $@ -S
 
 
-#which PARAM to send to LOPT
-LOPT_PARAM = -std-compile-opts
-ifeq ($(shell python -c "print($(LLVM_VERSION_MAJOR).$(LLVM_VERSION_MINOR) >= 3.6)"), True)
-LOPT_PARAM = -std-link-opts
-endif
-
 # make the C and C++ compilers strip debug info out of bytecode libraries.
 ifdef DEBUG_RUNTIME
 $(ObjectsBC): $(ObjDir)/%.bc: $(ObjDir)/%.ll $(LLVMAS) $(LOPT)
 	$(Echo) "Compiling $*.ll to $*.bc for $(BuildMode) build (bytecode)"
-	$(Verb) $(LLVMAS) $< -o - | $(LOPT) $(LOPT_PARAM) -o $@
+	$(Verb) $(LLVMAS) $< -o - | $(LOPT) -O3 -o $@
 else
 $(ObjectsBC): $(ObjDir)/%.bc: $(ObjDir)/%.ll $(LLVMAS) $(LOPT)
 	$(Echo) "Compiling $*.ll to $*.bc for $(BuildMode) build (bytecode)"
 	$(Verb) $(LLVMAS) $< -o - | \
-	   $(LOPT) $(LOPT_PARAM) -strip-debug -o $@
+	   $(LOPT) -O3 -strip-debug -o $@
 endif
 
 

--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -62,8 +62,7 @@ extern llvm::cl::opt<klee::MetaSMTBackendType> MetaSMTBackend;
 
 //A bit of ugliness so we can use cl::list<> like cl::bits<>, see queryLoggingOptions
 template <typename T>
-static bool optionIsSet(llvm::cl::list<T> list, T option)
-{
+static bool optionIsSet(llvm::cl::list<T> &list, T option) {
     return std::find(list.begin(), list.end(), option) != list.end();
 }
 

--- a/include/klee/Internal/Support/FloatEvaluation.h
+++ b/include/klee/Internal/Support/FloatEvaluation.h
@@ -132,8 +132,15 @@ inline uint64_t mod(uint64_t l, uint64_t r, unsigned inWidth) {
 // determine if l represents NaN
 inline bool isNaN(uint64_t l, unsigned inWidth) {
   switch( inWidth ) {
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+  case FLT_BITS:
+    return std::isnan(UInt64AsFloat(l));
+  case DBL_BITS:
+    return std::isnan(UInt64AsDouble(l));
+#else
   case FLT_BITS: return llvm::IsNAN( UInt64AsFloat(l) );
   case DBL_BITS: return llvm::IsNAN( UInt64AsDouble(l) );
+#endif
   default: llvm::report_fatal_error("unsupported floating point width");
   }
 }

--- a/lib/Core/ExternalDispatcher.cpp
+++ b/lib/Core/ExternalDispatcher.cpp
@@ -23,7 +23,12 @@
 #include "llvm/Instructions.h"
 #include "llvm/LLVMContext.h"
 #endif
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+#include "llvm/ExecutionEngine/MCJIT.h"
+#else
 #include "llvm/ExecutionEngine/JIT.h"
+#endif
+
 #include "llvm/ExecutionEngine/GenericValue.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/raw_ostream.h"
@@ -89,7 +94,12 @@ ExternalDispatcher::ExternalDispatcher() {
   dispatchModule = new Module("ExternalDispatcher", getGlobalContext());
 
   std::string error;
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+  dispatchModule_uniptr.reset(dispatchModule);
+  executionEngine = EngineBuilder(std::move(dispatchModule_uniptr)).create();
+#else
   executionEngine = ExecutionEngine::createJIT(dispatchModule, &error);
+#endif
   if (!executionEngine) {
     llvm::errs() << "unable to make jit: " << error << "\n";
     abort();
@@ -98,6 +108,10 @@ ExternalDispatcher::ExternalDispatcher() {
   // If we have a native target, initialize it to ensure it is linked in and
   // usable by the JIT.
   llvm::InitializeNativeTarget();
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+  llvm::InitializeNativeTargetAsmParser();
+  llvm::InitializeNativeTargetAsmPrinter();
+#endif
 
   // from ExecutionEngine::create
   if (executionEngine) {
@@ -146,7 +160,11 @@ bool ExternalDispatcher::executeCall(Function *f, Instruction *i, uint64_t *args
       // ensures that any errors or assertions in the compilation process will
       // trigger crashes instead of being caught as aborts in the external
       // function.
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+      executionEngine->finalizeObject();
+#else
       executionEngine->recompileAndRelinkFunction(dispatcher);
+#endif
     }
   } else {
     dispatcher = it->second;
@@ -205,13 +223,12 @@ Function *ExternalDispatcher::createDispatcher(Function *target, Instruction *in
   Value **args = new Value*[cs.arg_size()];
 
   std::vector<LLVM_TYPE_Q Type*> nullary;
-  
-  Function *dispatcher = Function::Create(FunctionType::get(Type::getVoidTy(getGlobalContext()), 
-							    nullary, false),
-					  GlobalVariable::ExternalLinkage, 
-					  "",
-					  dispatchModule);
 
+  // For MCJIT functions need unique names, or wrong func can be called
+  Function *dispatcher = Function::Create(
+      FunctionType::get(Type::getVoidTy(getGlobalContext()), nullary, false),
+      GlobalVariable::ExternalLinkage, "dispatcher_" + target->getName().str(),
+      dispatchModule);
 
   BasicBlock *dBB = BasicBlock::Create(getGlobalContext(), "entry", dispatcher);
 
@@ -254,9 +271,8 @@ Function *ExternalDispatcher::createDispatcher(Function *target, Instruction *in
     dispatchModule->getOrInsertFunction(target->getName(), FTy,
                                         target->getAttributes());
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 0)
-  Instruction *result = CallInst::Create(dispatchTarget,
-                                         llvm::ArrayRef<Value *>(args, args+i),
-                                         "", dBB);
+  Instruction *result = CallInst::Create(
+      dispatchTarget, llvm::ArrayRef<Value *>(args, args + i), "", dBB);
 #else
   Instruction *result = CallInst::Create(dispatchTarget, args, args+i, "", dBB);
 #endif

--- a/lib/Core/ExternalDispatcher.cpp
+++ b/lib/Core/ExternalDispatcher.cpp
@@ -253,11 +253,16 @@ Function *ExternalDispatcher::createDispatcher(Function *target, Instruction *in
     // functions.
     LLVM_TYPE_Q Type *argTy = (i < FTy->getNumParams() ? FTy->getParamType(i) : 
                                (*ai)->getType());
-    Instruction *argI64p = 
-      GetElementPtrInst::Create(argI64s, 
-                                ConstantInt::get(Type::getInt32Ty(getGlobalContext()), 
-                                                 idx), 
-                                "", dBB);
+    Instruction *argI64p =
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+        GetElementPtrInst::Create(
+            nullptr, argI64s,
+#else
+        GetElementPtrInst::Create(
+            argI64s,
+#endif
+            ConstantInt::get(Type::getInt32Ty(getGlobalContext()), idx), "",
+            dBB);
 
     Instruction *argp = new BitCastInst(argI64p, PointerType::getUnqual(argTy),
                                         "", dBB);

--- a/lib/Core/ExternalDispatcher.h
+++ b/lib/Core/ExternalDispatcher.h
@@ -9,11 +9,11 @@
 
 #ifndef KLEE_EXTERNALDISPATCHER_H
 #define KLEE_EXTERNALDISPATCHER_H
-
+#include "klee/Config/Version.h"
 #include <map>
 #include <string>
 #include <stdint.h>
-
+#include <memory>
 namespace llvm {
   class ExecutionEngine;
   class Instruction;
@@ -27,6 +27,10 @@ namespace klee {
   private:
     typedef std::map<const llvm::Instruction*,llvm::Function*> dispatchers_ty;
     dispatchers_ty dispatchers;
+
+  #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+    std::unique_ptr<llvm::Module> dispatchModule_uniptr;
+  #endif
     llvm::Module *dispatchModule;
     llvm::ExecutionEngine *executionEngine;
     std::map<std::string, void*> preboundFunctions;

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -191,12 +191,14 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
     SmallString<128> current(objectFilename);
     if(sys::fs::make_absolute(current)) {
       bool exists = false;
-
-#if LLVM_VERSION_CODE < LLVM_VERSION(3, 5)
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+      Twine current_twine(current.str()); // requires a twine for this. so silly
+      if (!sys::fs::exists(current_twine)) {
+#elif LLVM_VERSION_CODE == LLVM_VERSION(3, 5)
+      if (!sys::fs::exists(current.str(), exists)) {
+#elif LLVM_VERSION_CODE < LLVM_VERSION(3, 5)
       error_code ec = sys::fs::exists(current.str(), exists);
       if (ec == errc::success && exists) {
-#else
-      if (!sys::fs::exists(current.str(), exists)) {
 #endif
         objectFilename = current.c_str();
       }

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -164,7 +164,8 @@ static bool instructionIsCoverable(Instruction *i) {
     } else {
       Instruction *prev = --it;
       if (isa<CallInst>(prev) || isa<InvokeInst>(prev)) {
-        Function *target = getDirectCallTarget(prev);
+        CallSite cs(prev);
+        Function *target = getDirectCallTarget(cs);
         if (target && target->doesNotReturn())
           return false;
       }

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -190,13 +190,14 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
   if (!sys::path::is_absolute(objectFilename)) {
     SmallString<128> current(objectFilename);
     if(sys::fs::make_absolute(current)) {
-      bool exists = false;
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
       Twine current_twine(current.str()); // requires a twine for this. so silly
       if (!sys::fs::exists(current_twine)) {
 #elif LLVM_VERSION_CODE == LLVM_VERSION(3, 5)
+      bool exists = false;
       if (!sys::fs::exists(current.str(), exists)) {
 #elif LLVM_VERSION_CODE < LLVM_VERSION(3, 5)
+      bool exists = false;
       error_code ec = sys::fs::exists(current.str(), exists);
       if (ec == errc::success && exists) {
 #endif

--- a/lib/Module/Checks.cpp
+++ b/lib/Module/Checks.cpp
@@ -64,14 +64,17 @@ bool DivCheckPass::runOnModule(Module &M) {
           Instruction::BinaryOps opcode = binOp->getOpcode();
           if (opcode == Instruction::SDiv || opcode == Instruction::UDiv ||
               opcode == Instruction::SRem || opcode == Instruction::URem) {
-            
-            CastInst *denominator =
-              CastInst::CreateIntegerCast(i->getOperand(1),
-                                          Type::getInt64Ty(getGlobalContext()),
-                                          false,  /* sign doesn't matter */
-                                          "int_cast_to_i64",
-                                          i);
-            
+
+            CastInst *denominator = CastInst::CreateIntegerCast(
+                i->getOperand(1), Type::getInt64Ty(getGlobalContext()),
+                false, /* sign doesn't matter */
+                "int_cast_to_i64",
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
+                static_cast<Instruction *>(i));
+#else
+                i);
+#endif
+
             // Lazily bind the function to avoid always importing it.
             if (!divZeroCheckFunction) {
               Constant *fc = M.getOrInsertFunction("klee_div_zero_check", 
@@ -121,12 +124,15 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
             ConstantInt *bitWidthC = ConstantInt::get(Type::getInt64Ty(getGlobalContext()),bitWidth,false);
             args.push_back(bitWidthC);
 
-            CastInst *shift =
-              CastInst::CreateIntegerCast(i->getOperand(1),
-                                          Type::getInt64Ty(getGlobalContext()),
-                                          false,  /* sign doesn't matter */
-                                          "int_cast_to_i64",
-                                          i);
+            CastInst *shift = CastInst::CreateIntegerCast(
+                i->getOperand(1), Type::getInt64Ty(getGlobalContext()),
+                false, /* sign doesn't matter */
+                "int_cast_to_i64",
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
+                static_cast<Instruction *>(i));
+#else
+                i);
+#endif
             args.push_back(shift);
 
 

--- a/lib/Module/InstructionInfoTable.cpp
+++ b/lib/Module/InstructionInfoTable.cpp
@@ -87,7 +87,7 @@ static void buildInstructionToLineMap(Module *m,
   }
 }
 
-static std::string getDSPIPath(DILocation Loc) {
+static std::string getDSPIPath(const DILocation &Loc) {
   std::string dir = Loc.getDirectory();
   std::string file = Loc.getFilename();
   if (dir.empty() || file[0] == '/') {
@@ -103,9 +103,15 @@ bool InstructionInfoTable::getInstructionDebugInfo(const llvm::Instruction *I,
                                                    const std::string *&File,
                                                    unsigned &Line) {
   if (MDNode *N = I->getMetadata("dbg")) {
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+    DILocation *Loc = cast<DILocation>(N);
+    File = internString(getDSPIPath(*Loc));
+    Line = Loc->getLine();
+#else
     DILocation Loc(N);
     File = internString(getDSPIPath(Loc));
     Line = Loc.getLineNumber();
+#endif
     return true;
   }
 

--- a/lib/Module/InstructionInfoTable.cpp
+++ b/lib/Module/InstructionInfoTable.cpp
@@ -134,7 +134,12 @@ InstructionInfoTable::InstructionInfoTable(Module *m)
     // if any.
     const std::string *initialFile = &dummyString;
     unsigned initialLine = 0;
-    for (inst_iterator it = inst_begin(fnIt), ie = inst_end(fnIt); it != ie;
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
+    auto fn = static_cast<Function *>(fnIt);
+#else
+    Function *fn = fnIt;
+#endif
+    for (inst_iterator it = inst_begin(fn), ie = inst_end(fn); it != ie;
          ++it) {
       if (getInstructionDebugInfo(&*it, initialFile, initialLine))
         break;
@@ -142,8 +147,8 @@ InstructionInfoTable::InstructionInfoTable(Module *m)
 
     const std::string *file = initialFile;
     unsigned line = initialLine;
-    for (inst_iterator it = inst_begin(fnIt), ie = inst_end(fnIt); it != ie;
-        ++it) {
+    for (inst_iterator it = inst_begin(fn), ie = inst_end(fn); it != ie;
+         ++it) {
       Instruction *instr = &*it;
       unsigned assemblyLine = lineTable[instr];
 
@@ -199,6 +204,10 @@ InstructionInfoTable::getFunctionInfo(const Function *f) const {
     // and construct a test case for it if it does, though.
     return dummyInfo;
   } else {
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
+    return getInfo(static_cast<const Instruction *>(f->begin()->begin()));
+#else
     return getInfo(f->begin()->begin());
+#endif
   }
 }

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -106,11 +106,25 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
           Value *pSrc = CastInst::CreatePointerCast(src, i64p, "vacopy.cast.src", ii);
           Value *val = new LoadInst(pSrc, std::string(), ii); new StoreInst(val, pDst, ii);
           Value *off = ConstantInt::get(Type::getInt64Ty(getGlobalContext()), 1);
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+          pDst =
+              GetElementPtrInst::Create(nullptr, pDst, off, std::string(), ii);
+          pSrc =
+              GetElementPtrInst::Create(nullptr, pSrc, off, std::string(), ii);
+#else
           pDst = GetElementPtrInst::Create(pDst, off, std::string(), ii);
           pSrc = GetElementPtrInst::Create(pSrc, off, std::string(), ii);
+#endif
           val = new LoadInst(pSrc, std::string(), ii); new StoreInst(val, pDst, ii);
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+          pDst =
+              GetElementPtrInst::Create(nullptr, pDst, off, std::string(), ii);
+          pSrc =
+              GetElementPtrInst::Create(nullptr, pSrc, off, std::string(), ii);
+#else
           pDst = GetElementPtrInst::Create(pDst, off, std::string(), ii);
           pSrc = GetElementPtrInst::Create(pSrc, off, std::string(), ii);
+#endif
           val = new LoadInst(pSrc, std::string(), ii); new StoreInst(val, pDst, ii);
         }
         ii->removeFromParent();

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -76,8 +76,12 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
   for (BasicBlock::iterator i = b.begin(), ie = b.end();
        (i != ie) && (block_split == false);) {
     IntrinsicInst *ii = dyn_cast<IntrinsicInst>(&*i);
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
+    // create a copy of iterator to pass to IRBuilder ctor later
+    BasicBlock::iterator i_ = i;
+#endif
     // increment now since LowerIntrinsic deletion makes iterator invalid.
-    ++i;  
+    ++i;
     if(ii) {
       switch (ii->getIntrinsicID()) {
       case Intrinsic::vastart:
@@ -138,8 +142,12 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
       case Intrinsic::uadd_with_overflow:
       case Intrinsic::usub_with_overflow:
       case Intrinsic::umul_with_overflow: {
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
+        // ctor needs the iterator, but we already increased our one
+        IRBuilder<> builder(ii->getParent(), i_);
+#else
         IRBuilder<> builder(ii->getParent(), ii);
-
+#endif
         Value *op1 = ii->getArgOperand(0);
         Value *op2 = ii->getArgOperand(1);
         

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -46,8 +46,11 @@
 #else
 #include "llvm/IR/CallSite.h"
 #endif
-
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+#include "llvm/IR/LegacyPassManager.h"
+#else
 #include "llvm/PassManager.h"
+#endif
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/raw_os_ostream.h"
@@ -301,7 +304,11 @@ void KModule::prepare(const Interpreter::ModuleOptions &opts,
   // invariant transformations that we will end up doing later so that
   // optimize is seeing what is as close as possible to the final
   // module.
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+  legacy::PassManager pm;
+#else
   PassManager pm;
+#endif
   pm.add(new RaiseAsmPass());
   if (opts.CheckDivZero) pm.add(new DivCheckPass());
   if (opts.CheckOvershift) pm.add(new OvershiftCheckPass());
@@ -369,7 +376,11 @@ void KModule::prepare(const Interpreter::ModuleOptions &opts,
   // linked in something with intrinsics but any external calls are
   // going to be unresolved. We really need to handle the intrinsics
   // directly I think?
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+  legacy::PassManager pm3;
+#else
   PassManager pm3;
+#endif
   pm3.add(createCFGSimplificationPass());
   switch(SwitchType) {
   case eSwitchTypeInternal: break;

--- a/lib/Module/ModuleUtil.cpp
+++ b/lib/Module/ModuleUtil.cpp
@@ -212,15 +212,35 @@ static bool linkBCA(object::Archive* archive, Module* composite, std::string& er
 
   KLEE_DEBUG_WITH_TYPE("klee_linker", dbgs() << "Loading modules\n");
   // Load all bitcode files in to memory so we can examine their symbols
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
+  for (object::Archive::child_iterator AI = archive->child_begin(),
+                                       AE = archive->child_end();
+       AI != AE; ++AI)
+#else
+
   for (object::Archive::child_iterator AI = archive->begin_children(),
-       AE = archive->end_children(); AI != AE; ++AI)
+                                       AE = archive->end_children();
+       AI != AE; ++AI)
+#endif
   {
 
     StringRef memberName;
-    error_code ec = AI->getName(memberName);
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
+    std::error_code ec;
+    ErrorOr<StringRef> errorOr_memberName = AI->getName(); // as per
+    // http://llvm.org/docs/doxygen/html/classllvm_1_1ErrorOr.html#details
+    bool memname_success = true; // maybe a better way but this works to
+                                 // recreate functionality of llvm<3.6
+    if ((ec = errorOr_memberName.getError()))
+      memname_success = false;
+    else
+      memberName = errorOr_memberName.get();
 
-    if ( ec == errc::success )
-    {
+#else
+    error_code ec = AI->getName(memberName);
+    bool memname_success = (ec == errc::success);
+#endif
+    if (memname_success) {
       KLEE_DEBUG_WITH_TYPE("klee_linker", dbgs() << "Loading archive member " << memberName << "\n");
     }
     else
@@ -228,61 +248,82 @@ static bool linkBCA(object::Archive* archive, Module* composite, std::string& er
       errorMessage="Archive member does not have a name!\n";
       return false;
     }
-
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
+    ErrorOr<std::unique_ptr<llvm::object::Binary> > child = AI->getAsBinary();
+    bool getAsBin_success = true;
+    if ((ec = child.getError()))
+      getAsBin_success = false;
+#else
     OwningPtr<object::Binary> child;
     ec = AI->getAsBinary(child);
-    if (ec != object::object_error::success)
-    {
+    bool getAsBin_success = (ec == object::object_error::success);
+#endif
+    if (!getAsBin_success) {
       // If we can't open as a binary object file its hopefully a bitcode file
-
-      OwningPtr<MemoryBuffer> buff; // Once this is destroyed will Module still be valid??
-      Module *Result = 0;
-
-      if (error_code ec = AI->getMemoryBuffer(buff))
-      {
-        SS << "Failed to get MemoryBuffer: " <<ec.message();
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+      ErrorOr<MemoryBufferRef> buff = AI->getMemoryBufferRef();
+      bool getMemBuff_success = true;
+      if ((ec = buff.getError()))
+        getMemBuff_success = false;
+#elif LLVM_VERSION_CODE == LLVM_VERSION(3, 5)
+      ErrorOr<std::unique_ptr<MemoryBuffer> > errorOr_buff =
+          AI->getMemoryBuffer();
+      std::unique_ptr<MemoryBuffer> buff = nullptr;
+      bool getMemBuff_success = true;
+      if ((ec = errorOr_buff.getError()))
+        getMemBuff_success = false;
+      else
+        buff = std::move(errorOr_buff.get());
+#else
+      OwningPtr<MemoryBuffer> buff; // Once this is destroyed will Module still
+                                    // be valid??
+      bool getMemBuff_success = !(ec = AI->getMemoryBuffer(buff));
+#endif
+      if (!getMemBuff_success) {
+        SS << "Failed to get MemoryBuffer: " << ec.message();
         SS.flush();
         return false;
       }
+      if (buff) {
+        Module *Result = 0;
+// FIXME: Maybe load bitcode file lazily? Then if we need to link, materialise
+// the module
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
+        bool parseFile_success = true;
+        ErrorOr<Module *> Result_error =
+            parseBitcodeFile(buff.get(), getGlobalContext());
+        if ((ec = Result_error.getError()))
+          parseFile_success = false;
+        Result = Result_error.get();
+#else
+        Result =
+            ParseBitcodeFile(buff.get(), getGlobalContext(), &errorMessage);
+        bool parseFile_success = (Result);
+#endif
 
-      if (buff)
-      {
-        // FIXME: Maybe load bitcode file lazily? Then if we need to link, materialise the module
-        Result = ParseBitcodeFile(buff.get(), getGlobalContext(), &errorMessage);
-
-        if(!Result)
-        {
+        if (!parseFile_success) {
           SS << "Loading module failed : " << errorMessage << "\n";
           SS.flush();
           return false;
         }
         archiveModules.push_back(Result);
-      }
-      else
-      {
-        errorMessage="Buffer was NULL!";
+      } else {
+        errorMessage = "Buffer was NULL!";
         return false;
       }
-
-    }
-    else if (object::ObjectFile *o = dyn_cast<object::ObjectFile>(child.get()))
-    {
-      SS << "Object file " << o->getFileName().data() <<
-            " in archive is not supported";
+    } else if (child.get()->isObject()) {
+      SS << "Object file " << child.get()->getFileName().data()
+         << " in archive is not supported";
+      SS.flush();
+      return false;
+    } else {
+      SS << "Loading archive child with error " << ec.message();
       SS.flush();
       return false;
     }
-    else
-    {
-      SS << "Loading archive child with error "<< ec.message();
-      SS.flush();
-      return false;
-    }
-
   }
 
   KLEE_DEBUG_WITH_TYPE("klee_linker", dbgs() << "Loaded " << archiveModules.size() << " modules\n");
-
 
   std::set<std::string> previouslyUndefinedSymbols;
 
@@ -315,9 +356,12 @@ static bool linkBCA(object::Archive* archive, Module* composite, std::string& er
 
           KLEE_DEBUG_WITH_TYPE("klee_linker", dbgs() << "Found " << GV->getName() <<
               " in " << M->getModuleIdentifier() << "\n");
-
-
-          if (Linker::LinkModules(composite, M, Linker::DestroySource, &errorMessage))
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+          if (Linker::LinkModules(composite, M))
+#else
+          if (Linker::LinkModules(composite, M, Linker::DestroySource,
+                                  &errorMessage))
+#endif
           {
             // Linking failed
             SS << "Linking archive module with composite failed:" << errorMessage;
@@ -369,11 +413,84 @@ Module *klee::linkWithLibrary(Module *module,
     klee_error("Link with library %s failed. No such file.",
         libraryName.c_str());
   }
-
-  OwningPtr<MemoryBuffer> Buffer;
-  if (error_code ec = MemoryBuffer::getFile(libraryName,Buffer)) {
+#endif
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
+  ErrorOr<std::unique_ptr<MemoryBuffer> > Buffer =
+      MemoryBuffer::getFile(libraryName);
+  std::error_code ec;
+  if ((ec = Buffer.getError())) {
     klee_error("Link with library %s failed: %s", libraryName.c_str(),
-        ec.message().c_str());
+               ec.message().c_str());
+  }
+
+  sys::fs::file_magic magic =
+      sys::fs::identify_magic(Buffer.get()->getBuffer());
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+  MemoryBufferRef buff = Buffer.get()->getMemBufferRef();
+#else
+  MemoryBuffer *buff = Buffer->get();
+#endif
+  LLVMContext &Context = getGlobalContext();
+  std::string ErrorMessage;
+
+  if (magic == sys::fs::file_magic::bitcode) {
+
+    ErrorOr<Module *> Result = parseBitcodeFile(buff, Context);
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+    if ((ec = Buffer.getError()) || Linker::LinkModules(module, Result.get()))
+#else
+    if ((ec = Buffer.getError()) ||
+        Linker::LinkModules(module, Result.get(), Linker::DestroySource,
+                            &ErrorMessage))
+#endif
+      klee_error("Link with library %s failed: %s", libraryName.c_str(),
+                 ec.message().c_str());
+
+    delete Result.get();
+
+  } else if (magic == sys::fs::file_magic::archive) {
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+    ErrorOr<std::unique_ptr<object::Binary> > arch =
+        object::createBinary(buff, &Context);
+#else
+    ErrorOr<object::Binary *> arch =
+        object::createBinary(std::move(Buffer.get()), &Context);
+#endif
+    if ((ec = arch.getError()))
+      klee_error("Link with library %s failed: %s", libraryName.c_str(),
+                 arch.getError().message().c_str());
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+    if (object::Archive *a = dyn_cast<object::Archive>(arch->get())) {
+#else
+    if (object::Archive *a = dyn_cast<object::Archive>(arch.get())) {
+#endif
+      // Handle in helper
+      if (!linkBCA(a, module, ErrorMessage))
+        klee_error("Link with library %s failed: %s", libraryName.c_str(),
+                   ErrorMessage.c_str());
+    } else {
+      klee_error("Link with library %s failed: Cast to archive failed",
+                 libraryName.c_str());
+    }
+
+  } else if (magic.is_object()) {
+    std::unique_ptr<object::Binary> obj;
+    if (object::ObjectFile *o = dyn_cast<object::ObjectFile>(obj.get())) {
+      klee_warning("Link with library: Object file %s in archive %s found. "
+                   "Currently not supported.",
+                   o->getFileName().data(), libraryName.c_str());
+    }
+  } else {
+    klee_error("Link with library %s failed: Unrecognized file type.",
+               libraryName.c_str());
+  }
+  return module;
+#elif LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
+  error_code ec;
+  OwningPtr<MemoryBuffer> Buffer;
+  if (ec = MemoryBuffer::getFile(libraryName, Buffer)) {
+    klee_error("Link with library %s failed: %s", libraryName.c_str(),
+               ec.message().c_str());
   }
 
   sys::fs::file_magic magic = sys::fs::identify_magic(Buffer->getBuffer());
@@ -385,40 +502,39 @@ Module *klee::linkWithLibrary(Module *module,
     Module *Result = 0;
     Result = ParseBitcodeFile(Buffer.get(), Context, &ErrorMessage);
 
-
     if (!Result || Linker::LinkModules(module, Result, Linker::DestroySource,
-        &ErrorMessage))
+                                       &ErrorMessage))
       klee_error("Link with library %s failed: %s", libraryName.c_str(),
-          ErrorMessage.c_str());
+                 ErrorMessage.c_str());
 
     delete Result;
 
   } else if (magic == sys::fs::file_magic::archive) {
     OwningPtr<object::Binary> arch;
-    if (error_code ec = object::createBinary(Buffer.take(), arch))
+    if (ec = object::createBinary(Buffer.take(), arch))
       klee_error("Link with library %s failed: %s", libraryName.c_str(),
-          ec.message().c_str());
+                 ec.message().c_str());
 
     if (object::Archive *a = dyn_cast<object::Archive>(arch.get())) {
       // Handle in helper
       if (!linkBCA(a, module, ErrorMessage))
         klee_error("Link with library %s failed: %s", libraryName.c_str(),
-            ErrorMessage.c_str());
-    }
-    else {
-    	klee_error("Link with library %s failed: Cast to archive failed", libraryName.c_str());
+                   ErrorMessage.c_str());
+    } else {
+      klee_error("Link with library %s failed: Cast to archive failed",
+                 libraryName.c_str());
     }
 
   } else if (magic.is_object()) {
     OwningPtr<object::Binary> obj;
     if (object::ObjectFile *o = dyn_cast<object::ObjectFile>(obj.get())) {
       klee_warning("Link with library: Object file %s in archive %s found. "
-          "Currently not supported.",
-          o->getFileName().data(), libraryName.c_str());
+                   "Currently not supported.",
+                   o->getFileName().data(), libraryName.c_str());
     }
   } else {
     klee_error("Link with library %s failed: Unrecognized file type.",
-        libraryName.c_str());
+               libraryName.c_str());
   }
 
   return module;
@@ -427,11 +543,11 @@ Module *klee::linkWithLibrary(Module *module,
 
   llvm::sys::Path libraryPath(libraryName);
   bool native = false;
-    
+
   if (linker.LinkInFile(libraryPath, native)) {
     klee_error("Linking library %s failed", libraryName.c_str());
   }
-    
+
   return linker.releaseModule();
 #endif
 }

--- a/lib/Module/Optimize.cpp
+++ b/lib/Module/Optimize.cpp
@@ -172,15 +172,20 @@ void Optimize(Module* M) {
   if (VerifyEach)
     Passes.add(createVerifierPass());
 
-#if LLVM_VERSION_CODE <= LLVM_VERSION(3, 1)
-  // Add an appropriate TargetData instance for this module...
-  addPass(Passes, new TargetData(M));
-#elif LLVM_VERSION_CODE < LLVM_VERSION(3, 5)
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+  // Add an appropriate DataLayout instance for this module...
+  DataLayoutPass *dlpass = new DataLayoutPass();
+  dlpass->doInitialization(*M);
+  addPass(Passes, dlpass);
+#elif LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
+  // Add an appropriate DataLayout instance for this module...
+  addPass(Passes, new DataLayoutPass(M));
+#elif LLVM_VERSION_CODE > LLVM_VERSION(3, 1)
   // Add an appropriate DataLayout instance for this module...
   addPass(Passes, new DataLayout(M));
 #else
-  // Add an appropriate DataLayout instance for this module...
-  addPass(Passes, new DataLayoutPass(M));
+  // Add an appropriate TargetData instance for this module...
+  addPass(Passes, new TargetData(M));
 #endif
 
   // DWD - Run the opt standard pass list as well.

--- a/lib/Module/Optimize.cpp
+++ b/lib/Module/Optimize.cpp
@@ -126,7 +126,12 @@ static void AddStandardCompilePasses(PassManager &PM) {
   addPass(PM, createCFGSimplificationPass());    // Clean up after IPCP & DAE
 
   addPass(PM, createPruneEHPass());              // Remove dead EH info
-  addPass(PM, createFunctionAttrsPass());        // Deduce function attrs
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
+  addPass(PM, createPostOrderFunctionAttrsPass());
+  addPass(PM, createReversePostOrderFunctionAttrsPass());
+#else
+  addPass(PM, createFunctionAttrsPass()); // Deduce function attrs
+#endif
 
   if (!DisableInline)
     addPass(PM, createFunctionInliningPass());   // Inline small functions
@@ -257,8 +262,14 @@ void Optimize(Module* M) {
     addPass(Passes, createScalarReplAggregatesPass()); // Break up allocas
 
     // Run a few AA driven optimizations here and now, to cleanup the code.
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
+    addPass(Passes, createPostOrderFunctionAttrsPass());
+    addPass(Passes, createReversePostOrderFunctionAttrsPass());
+    // addPass(Passes, createGlobalsAAWrapperPass());
+#else
     addPass(Passes, createFunctionAttrsPass());      // Add nocapture
     addPass(Passes, createGlobalsModRefPass());      // IP alias analysis
+#endif
 
     addPass(Passes, createLICMPass());               // Hoist loop invariants
     addPass(Passes, createGVNPass());                // Remove redundancies

--- a/lib/Module/RaiseAsm.cpp
+++ b/lib/Module/RaiseAsm.cpp
@@ -96,7 +96,11 @@ bool RaiseAsmPass::runOnModule(Module &M) {
   for (Module::iterator fi = M.begin(), fe = M.end(); fi != fe; ++fi) {
     for (Function::iterator bi = fi->begin(), be = fi->end(); bi != be; ++bi) {
       for (BasicBlock::iterator ii = bi->begin(), ie = bi->end(); ii != ie;) {
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
+        auto i = static_cast<Instruction *>(ii);
+#else
         Instruction *i = ii;
+#endif
         ++ii;  
         changed |= runOnInstruction(M, i);
       }

--- a/lib/Module/RaiseAsm.cpp
+++ b/lib/Module/RaiseAsm.cpp
@@ -75,8 +75,10 @@ bool RaiseAsmPass::runOnModule(Module &M) {
     llvm::errs() << "Warning: unable to select native target: " << Err << "\n";
     TLI = 0;
   } else {
-
-#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+    TM = NativeTarget->createTargetMachine(HostTriple, "", "", TargetOptions());
+    TLI = TM->getSubtargetImpl(*(M.begin()))->getTargetLowering();
+#elif LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
     TM = NativeTarget->createTargetMachine(HostTriple, "", "", TargetOptions());
     TLI = TM->getSubtargetImpl()->getTargetLowering();
 #elif LLVM_VERSION_CODE >= LLVM_VERSION(3, 1)

--- a/lib/Module/RaiseAsm.cpp
+++ b/lib/Module/RaiseAsm.cpp
@@ -20,6 +20,10 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Target/TargetLowering.h"
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Target/TargetSubtargetInfo.h"
+#endif
 #if LLVM_VERSION_CODE < LLVM_VERSION(3, 0)
 #include "llvm/Target/TargetRegistry.h"
 #else
@@ -71,15 +75,20 @@ bool RaiseAsmPass::runOnModule(Module &M) {
     llvm::errs() << "Warning: unable to select native target: " << Err << "\n";
     TLI = 0;
   } else {
-#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 1)
-    TM = NativeTarget->createTargetMachine(HostTriple, "", "",
-                                                          TargetOptions());
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+    TM = NativeTarget->createTargetMachine(HostTriple, "", "", TargetOptions());
+    TLI = TM->getSubtargetImpl()->getTargetLowering();
+#elif LLVM_VERSION_CODE >= LLVM_VERSION(3, 1)
+    TM = NativeTarget->createTargetMachine(HostTriple, "", "", TargetOptions());
+    TLI = TM->getTargetLowering();
 #elif LLVM_VERSION_CODE >= LLVM_VERSION(3, 0)
     TM = NativeTarget->createTargetMachine(HostTriple, "", "");
+    TLI = TM->getTargetLowering();
 #else
     TM = NativeTarget->createTargetMachine(HostTriple, "");
-#endif
     TLI = TM->getTargetLowering();
+#endif
   }
   
   for (Module::iterator fi = M.begin(), fe = M.end(); fi != fe; ++fi) {

--- a/lib/Solver/QueryLoggingSolver.cpp
+++ b/lib/Solver/QueryLoggingSolver.cpp
@@ -26,7 +26,9 @@ QueryLoggingSolver::QueryLoggingSolver(Solver *_solver, std::string path,
                                        const std::string &commentSign,
                                        int queryTimeToLog)
     : solver(_solver),
-#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+      os(path.c_str(), ec, llvm::sys::fs::OpenFlags::F_Text),
+#elif LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
       os(path.c_str(), ErrorInfo, llvm::sys::fs::OpenFlags::F_Text),
 #else
       os(path.c_str(), ErrorInfo),

--- a/lib/Solver/QueryLoggingSolver.h
+++ b/lib/Solver/QueryLoggingSolver.h
@@ -26,6 +26,9 @@ class QueryLoggingSolver : public SolverImpl {
 protected:
   Solver *solver;
   std::string ErrorInfo;
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+  std::error_code ec;
+#endif
   llvm::raw_fd_ostream os;
   // @brief Buffer used by logBuffer
   std::string BufferString;

--- a/test/Concrete/BoolReadWrite.ll
+++ b/test/Concrete/BoolReadWrite.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: not-llvm-3.7, not-llvm-3.8
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i1(i1)

--- a/test/Concrete/BoolReadWrite.llvm37.ll
+++ b/test/Concrete/BoolReadWrite.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: llvm-3.7
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i1(i1)

--- a/test/Concrete/BoolReadWrite.llvm37.ll
+++ b/test/Concrete/BoolReadWrite.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i1(i1)
@@ -6,7 +6,7 @@ declare void @print_i1(i1)
 define i32 @main() {
         %mem = alloca i1
         store i1 1, i1* %mem
-        %v = load i1* %mem
+        %v = load i1, i1* %mem
         br i1 %v, label %ok, label %exit
 ok:
 	call void @print_i1(i1 %v)

--- a/test/Concrete/ConstantExpr.ll
+++ b/test/Concrete/ConstantExpr.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: not-llvm-3.7, not-llvm-3.8
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 ; Most of the test below use the *address* of gInt as part of their computation,

--- a/test/Concrete/ConstantExpr.llvm37.ll
+++ b/test/Concrete/ConstantExpr.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: llvm-3.7
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 ; Most of the test below use the *address* of gInt as part of their computation,

--- a/test/Concrete/ConstantExpr.llvm37.ll
+++ b/test/Concrete/ConstantExpr.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 ; Most of the test below use the *address* of gInt as part of their computation,
@@ -71,7 +71,7 @@ define void @"test_misc"() {
   %t1 = add i32 select(i1 icmp eq (i32* @gInt, i32* inttoptr(i32 100 to i32*)), i32 10, i32 0), 0
   call void @print_i32(i32 %t1)
 
-  %t2 = load i32* getelementptr(%test.struct.type* @test_struct, i32 0, i32 1)
+  %t2 = load i32, i32* getelementptr(%test.struct.type, %test.struct.type* @test_struct, i32 0, i32 1)
   call void @print_i32(i32 %t2)                             
         
   ret void

--- a/test/Concrete/FloatingPointOps.ll
+++ b/test/Concrete/FloatingPointOps.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: not-llvm-3.7, not-llvm-3.8
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 ; casting error messages

--- a/test/Concrete/FloatingPointOps.llvm37.ll
+++ b/test/Concrete/FloatingPointOps.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 ; casting error messages
@@ -76,11 +76,11 @@ entry:
 
 failed:
   ; print the error msg
-  %ret = call i32 (i8*, ...)* @printf( i8* %errMsg )
+  %ret = call i32 (i8*, ...) @printf( i8* %errMsg )
 
   ; add a newline to the ostream
-  %nl = getelementptr [3 x i8]* @.strNL, i32 0, i32 0
-  %ret2 = call i32 (i8*, ...)* @printf( i8* %nl )
+  %nl = getelementptr [3 x i8], [3 x i8]* @.strNL, i32 0, i32 0
+  %ret2 = call i32 (i8*, ...) @printf( i8* %nl )
 
   ; exit with return value 1 to denote that an error occurred
   call void @exit( i32 1 )
@@ -95,10 +95,10 @@ define void @testFPTrunc() {
 entry:
   %d_addr = alloca double, align 8
   store double 8.000000e+00, double* %d_addr
-  %d = load double* %d_addr
+  %d = load double, double* %d_addr
   %f = fptrunc double %d to float
   %matches = fcmp oeq float %f, 8.000000e+00
-  %err_msg = getelementptr [15 x i8]* @.strTrunc, i32 0, i32 0
+  %err_msg = getelementptr [15 x i8], [15 x i8]* @.strTrunc, i32 0, i32 0
   call void @failCheck( i1 %matches, i8* %err_msg )
   ret void
 }
@@ -108,10 +108,10 @@ define void @testFPExt() {
 entry:
   %f_addr = alloca float, align 4
   store float 8.000000e+00, float* %f_addr
-  %f = load float* %f_addr
+  %f = load float, float* %f_addr
   %d = fpext float %f to double
   %matches = fcmp oeq double %d, 8.000000e+00
-  %err_msg = getelementptr [13 x i8]* @.strExt, i32 0, i32 0
+  %err_msg = getelementptr [13 x i8], [13 x i8]* @.strExt, i32 0, i32 0
   call void @failCheck( i1 %matches, i8* %err_msg )
   ret void
 }
@@ -124,18 +124,18 @@ entry:
 
   ; test float to UI
   store float 0x4020333340000000, float* %f_addr; %f = 8.1
-  %f = load float* %f_addr
+  %f = load float, float* %f_addr
   %uf = fptoui float %f to i32
   %matchesf = icmp eq i32 %uf, 8
-  %err_msgf = getelementptr [20 x i8]* @.strFPToUIFlt, i32 0, i32 0
+  %err_msgf = getelementptr [20 x i8], [20 x i8]* @.strFPToUIFlt, i32 0, i32 0
   call void @failCheck( i1 %matchesf, i8* %err_msgf )
 
   ; test double to UI
   store double 8.100000e+00, double* %d_addr
-  %d = load double* %d_addr
+  %d = load double, double* %d_addr
   %ud = fptoui double %d to i32
   %matchesd = icmp eq i32 %ud, 8
-  %err_msgd = getelementptr [21 x i8]* @.strFPToUIDbl, i32 0, i32 0
+  %err_msgd = getelementptr [21 x i8], [21 x i8]* @.strFPToUIDbl, i32 0, i32 0
   call void @failCheck( i1 %matchesd, i8* %err_msgd )
 
   ret void
@@ -149,18 +149,18 @@ entry:
 
   ; test float 8.1 to signed int
   store float 0x4020333340000000, float* %f_addr
-  %f = load float* %f_addr
+  %f = load float, float* %f_addr
   %sf = fptosi float %f to i32
   %matchesf = icmp eq i32 %sf, 8
-  %err_msgf = getelementptr [20 x i8]* @.strFPToSIFlt, i32 0, i32 0
+  %err_msgf = getelementptr [20 x i8], [20 x i8]* @.strFPToSIFlt, i32 0, i32 0
   call void @failCheck( i1 %matchesf, i8* %err_msgf )
 
   ; test double -8.1 to signed int
   store double -8.100000e+00, double* %d_addr
-  %d = load double* %d_addr
+  %d = load double, double* %d_addr
   %sd = fptosi double %d to i32
   %matchesd = icmp eq i32 %sd, -8
-  %err_msgd = getelementptr [21 x i8]* @.strFPToSIDbl, i32 0, i32 0
+  %err_msgd = getelementptr [21 x i8], [21 x i8]* @.strFPToSIDbl, i32 0, i32 0
   call void @failCheck( i1 %matchesd, i8* %err_msgd )
 
   ret void
@@ -172,13 +172,13 @@ entry:
   ; unsigned int to float
   %f = uitofp i32 7 to float
   %matchesf = fcmp oeq float %f, 7.000000e+00
-  %err_msgf = getelementptr [20 x i8]* @.strUIToFPFlt, i32 0, i32 0
+  %err_msgf = getelementptr [20 x i8], [20 x i8]* @.strUIToFPFlt, i32 0, i32 0
   call void @failCheck( i1 %matchesf, i8* %err_msgf )
 
   ; unsigned int to double
   %d = uitofp i32 7 to double
   %matchesd = fcmp oeq double %d, 7.000000e+00
-  %err_msgd = getelementptr [21 x i8]* @.strUIToFPDbl, i32 0, i32 0
+  %err_msgd = getelementptr [21 x i8], [21 x i8]* @.strUIToFPDbl, i32 0, i32 0
   call void @failCheck( i1 %matchesd, i8* %err_msgd )
 
   ret void
@@ -190,13 +190,13 @@ entry:
   ; signed int to float
   %f = sitofp i32 -7 to float
   %matchesf = fcmp oeq float %f, -7.000000e+00
-  %err_msgf = getelementptr [20 x i8]* @.strSIToFPFlt, i32 0, i32 0
+  %err_msgf = getelementptr [20 x i8], [20 x i8]* @.strSIToFPFlt, i32 0, i32 0
   call void @failCheck( i1 %matchesf, i8* %err_msgf )
 
   ; signed int to double
   %d = sitofp i32 -7 to double
   %matchesd = fcmp oeq double %d, -7.000000e+00
-  %err_msgd = getelementptr [21 x i8]* @.strSIToFPDbl, i32 0, i32 0
+  %err_msgd = getelementptr [21 x i8], [21 x i8]* @.strSIToFPDbl, i32 0, i32 0
   call void @failCheck( i1 %matchesd, i8* %err_msgd )
 
   ret void
@@ -213,21 +213,21 @@ entry:
   ; float division
   store float 2.200000e+01, float* %fN_addr
   store float 4.000000e+00, float* %fD_addr
-  %fN = load float* %fN_addr
-  %fD = load float* %fD_addr
+  %fN = load float, float* %fN_addr
+  %fD = load float, float* %fD_addr
   %f = fdiv float %fN, %fD
   %matchesf = fcmp oeq float %f, 5.500000e+00
-  %err_msgf = getelementptr [18 x i8]* @.strDivFlt, i32 0, i32 0
+  %err_msgf = getelementptr [18 x i8], [18 x i8]* @.strDivFlt, i32 0, i32 0
   call void @failCheck( i1 %matchesf, i8* %err_msgf )
 
   ; double division
   store double 2.200000e+01, double* %dN_addr
   store double -4.000000e+00, double* %dD_addr
-  %dN = load double* %dN_addr
-  %dD = load double* %dD_addr
+  %dN = load double, double* %dN_addr
+  %dD = load double, double* %dD_addr
   %d = fdiv double %dN, %dD
   %matchesd = fcmp oeq double %d, -5.500000e+00
-  %err_msgd = getelementptr [19 x i8]* @.strDivDbl, i32 0, i32 0
+  %err_msgd = getelementptr [19 x i8], [19 x i8]* @.strDivDbl, i32 0, i32 0
   call void @failCheck( i1 %matchesd, i8* %err_msgd )
 
   ret void
@@ -244,21 +244,21 @@ entry:
   ; float modoulo
   store float 2.200000e+01, float* %fN_addr
   store float 4.000000e+00, float* %fD_addr
-  %fN = load float* %fN_addr
-  %fD = load float* %fD_addr
+  %fN = load float, float* %fN_addr
+  %fD = load float, float* %fD_addr
   %f = frem float %fN, %fD
   %matchesf = fcmp oeq float %f, 2.000000e+00
-  %err_msgf = getelementptr [18 x i8]* @.strRemFlt, i32 0, i32 0
+  %err_msgf = getelementptr [18 x i8], [18 x i8]* @.strRemFlt, i32 0, i32 0
   call void @failCheck( i1 %matchesf, i8* %err_msgf )
 
   ; double modulo
   store double -2.200000e+01, double* %dN_addr
   store double 4.000000e+00, double* %dD_addr
-  %dN = load double* %dN_addr
-  %dD = load double* %dD_addr
+  %dN = load double, double* %dN_addr
+  %dD = load double, double* %dD_addr
   %d = frem double %dN, %dD
   %matchesd = fcmp oeq double %d, -2.000000e+00
-  %err_msgd = getelementptr [19 x i8]* @.strRemDbl, i32 0, i32 0
+  %err_msgd = getelementptr [19 x i8], [19 x i8]* @.strRemDbl, i32 0, i32 0
   call void @failCheck( i1 %matchesd, i8* %err_msgd )
 
   ret void
@@ -275,27 +275,27 @@ entry:
   ; test integer addition (3 + 4)
   %sumi = add i32 3, 4
   %matchesi = icmp eq i32 %sumi, 7
-  %err_msgi = getelementptr [16 x i8]* @.strAddInt, i32 0, i32 0
+  %err_msgi = getelementptr [16 x i8], [16 x i8]* @.strAddInt, i32 0, i32 0
   call void @failCheck( i1 %matchesi, i8* %err_msgi )
 
   ; test float addition (3.5 + 4.2)
   store float 3.500000e+00, float* %f1_addr
   store float 0x4010CCCCC0000000, float* %f2_addr
-  %f1 = load float* %f1_addr
-  %f2 = load float* %f2_addr
+  %f1 = load float, float* %f1_addr
+  %f2 = load float, float* %f2_addr
   %sumf = fadd float %f1, %f2
   %matchesf = fcmp oeq float %sumf, 0x401ECCCCC0000000
-  %err_msgf = getelementptr [18 x i8]* @.strAddFlt, i32 0, i32 0
+  %err_msgf = getelementptr [18 x i8], [18 x i8]* @.strAddFlt, i32 0, i32 0
   call void @failCheck( i1 %matchesf, i8* %err_msgf )
 
   ; test double addition (3.5 + -4.2)
   store double 3.500000e+00, double* %d1_addr
   store double -4.200000e+00, double* %d2_addr
-  %d1 = load double* %d1_addr
-  %d2 = load double* %d2_addr
+  %d1 = load double, double* %d1_addr
+  %d2 = load double, double* %d2_addr
   %sumd = fadd double %d1, %d2
   %matchesd = fcmp oeq double %sumd, 0xBFE6666666666668
-  %err_msgd = getelementptr [19 x i8]* @.strAddDbl, i32 0, i32 0
+  %err_msgd = getelementptr [19 x i8], [19 x i8]* @.strAddDbl, i32 0, i32 0
   call void @failCheck( i1 %matchesd, i8* %err_msgd )
 
   ret void
@@ -312,27 +312,27 @@ entry:
   ; test integer subtraction (3 - 4)
   %subi = sub i32 3, 4
   %matchesi = icmp eq i32 %subi, -1
-  %err_msgi = getelementptr [16 x i8]* @.strSubInt, i32 0, i32 0
+  %err_msgi = getelementptr [16 x i8], [16 x i8]* @.strSubInt, i32 0, i32 0
   call void @failCheck( i1 %matchesi, i8* %err_msgi )
 
   ; test float subtraction (3.5 - 4.2)
   store float 3.500000e+00, float* %f1_addr
   store float 0x4010CCCCC0000000, float* %f2_addr
-  %f1 = load float* %f1_addr
-  %f2 = load float* %f2_addr
+  %f1 = load float, float* %f1_addr
+  %f2 = load float, float* %f2_addr
   %subf = fsub float %f1, %f2
   %matchesf = fcmp oeq float %subf, 0xBFE6666600000000
-  %err_msgf = getelementptr [18 x i8]* @.strSubFlt, i32 0, i32 0
+  %err_msgf = getelementptr [18 x i8], [18 x i8]* @.strSubFlt, i32 0, i32 0
   call void @failCheck( i1 %matchesf, i8* %err_msgf )
 
   ; test double subtraction (3.5 - -4.2)
   store double 3.500000e+00, double* %d1_addr
   store double -4.200000e+00, double* %d2_addr
-  %d1 = load double* %d1_addr
-  %d2 = load double* %d2_addr
+  %d1 = load double, double* %d1_addr
+  %d2 = load double, double* %d2_addr
   %subd = fsub double %d1, %d2
   %matchesd = fcmp oeq double %subd, 7.700000e+00
-  %err_msgd = getelementptr [19 x i8]* @.strSubDbl, i32 0, i32 0
+  %err_msgd = getelementptr [19 x i8], [19 x i8]* @.strSubDbl, i32 0, i32 0
   call void @failCheck( i1 %matchesd, i8* %err_msgd )
 
   ret void
@@ -349,27 +349,27 @@ entry:
   ; test integer multiplication (3 * 4)
   %muli = mul i32 3, 4
   %matchesi = icmp eq i32 %muli, 12
-  %err_msgi = getelementptr [16 x i8]* @.strMulInt, i32 0, i32 0
+  %err_msgi = getelementptr [16 x i8], [16 x i8]* @.strMulInt, i32 0, i32 0
   call void @failCheck( i1 %matchesi, i8* %err_msgi )
 
   ; test float multiplication (3.5 * 4.2)
   store float 3.500000e+00, float* %f1_addr
   store float 0x4010CCCCC0000000, float* %f2_addr
-  %f1 = load float* %f1_addr
-  %f2 = load float* %f2_addr
+  %f1 = load float, float* %f1_addr
+  %f2 = load float, float* %f2_addr
   %mulf = fmul float %f1, %f2
   %matchesf = fcmp oeq float %mulf, 0x402D666640000000
-  %err_msgf = getelementptr [18 x i8]* @.strMulFlt, i32 0, i32 0
+  %err_msgf = getelementptr [18 x i8], [18 x i8]* @.strMulFlt, i32 0, i32 0
   call void @failCheck( i1 %matchesf, i8* %err_msgf )
 
   ; test double multiplication (3.5 * -4.2)
   store double 3.500000e+00, double* %d1_addr
   store double -4.200000e+00, double* %d2_addr
-  %d1 = load double* %d1_addr
-  %d2 = load double* %d2_addr
+  %d1 = load double, double* %d1_addr
+  %d2 = load double, double* %d2_addr
   %muld = fmul double %d1, %d2
   %matchesd = fcmp oeq double %muld, 0xC02D666666666667
-  %err_msgd = getelementptr [19 x i8]* @.strMulDbl, i32 0, i32 0
+  %err_msgd = getelementptr [19 x i8], [19 x i8]* @.strMulDbl, i32 0, i32 0
   call void @failCheck( i1 %matchesd, i8* %err_msgd )
 
   ret void
@@ -381,55 +381,55 @@ entry:
   ; test fcmp::true -- should always return true
   %cmp_t    = fcmp true float %f1, %f2
   %cmp_t_ok = icmp eq i1 %cmp_t, 1
-  %cmp_t_em = getelementptr [19 x i8]* @.strCmpTrFlt, i32 0, i32 0
+  %cmp_t_em = getelementptr [19 x i8], [19 x i8]* @.strCmpTrFlt, i32 0, i32 0
   call void @failCheck( i1 %cmp_t_ok, i8* %cmp_t_em )
 
   ; test fcmp::false -- should always return false
   %cmp_f    = fcmp false float %f1, %f2
   %cmp_f_ok = icmp eq i1 %cmp_f, 0
-  %cmp_f_em = getelementptr [20 x i8]* @.strCmpFaFlt, i32 0, i32 0
+  %cmp_f_em = getelementptr [20 x i8], [20 x i8]* @.strCmpFaFlt, i32 0, i32 0
   call void @failCheck( i1 %cmp_f_ok, i8* %cmp_f_em )
 
   ; test fcmp::ord -- should return true if neither operand is NaN
   %cmp_o    = fcmp ord float %f1, %f2
   %cmp_o_ok = icmp eq i1 %cmp_o, %ord
-  %cmp_o_em = getelementptr [18 x i8]* @.strCmpOrdFlt, i32 0, i32 0
+  %cmp_o_em = getelementptr [18 x i8], [18 x i8]* @.strCmpOrdFlt, i32 0, i32 0
   call void @failCheck( i1 %cmp_o_ok, i8* %cmp_o_em )
 
   ; test fcmp::oeq -- should return true if neither operand is a NaN and they are equal
   %cmp_eq    = fcmp oeq float %f1, %f2
   %cmp_eq_ok = icmp eq i1 %cmp_eq, %eq
-  %cmp_eq_em = getelementptr [17 x i8]* @.strCmpEqFlt, i32 0, i32 0
+  %cmp_eq_em = getelementptr [17 x i8], [17 x i8]* @.strCmpEqFlt, i32 0, i32 0
   call void @failCheck( i1 %cmp_eq_ok, i8* %cmp_eq_em )
 
   ; test fcmp::oge -- should return true if neither operand is a NaN and the first is greater or equal
   %cmp_ge    = fcmp oge float %f1, %f2
   %cmp_ge_ok = icmp eq i1 %cmp_ge, %ge
-  %cmp_ge_em = getelementptr [17 x i8]* @.strCmpGeFlt, i32 0, i32 0
+  %cmp_ge_em = getelementptr [17 x i8], [17 x i8]* @.strCmpGeFlt, i32 0, i32 0
   call void @failCheck( i1 %cmp_ge_ok, i8* %cmp_ge_em )
 
   ; test fcmp::ogt -- should return true if neither operand is a NaN and the first is greater
   %cmp_gt    = fcmp ogt float %f1, %f2
   %cmp_gt_ok = icmp eq i1 %cmp_gt, %gt
-  %cmp_gt_em = getelementptr [17 x i8]* @.strCmpGtFlt, i32 0, i32 0
+  %cmp_gt_em = getelementptr [17 x i8], [17 x i8]* @.strCmpGtFlt, i32 0, i32 0
   call void @failCheck( i1 %cmp_gt_ok, i8* %cmp_gt_em )
 
   ; test fcmp::ole -- should return true if neither operand is a NaN and the first is less or equal
   %cmp_le    = fcmp ole float %f1, %f2
   %cmp_le_ok = icmp eq i1 %cmp_le, %le
-  %cmp_le_em = getelementptr [17 x i8]* @.strCmpLeFlt, i32 0, i32 0
+  %cmp_le_em = getelementptr [17 x i8], [17 x i8]* @.strCmpLeFlt, i32 0, i32 0
   call void @failCheck( i1 %cmp_le_ok, i8* %cmp_le_em )
 
   ; test fcmp::olt -- should return true if neither operand is a NaN and the first is less
   %cmp_lt    = fcmp olt float %f1, %f2
   %cmp_lt_ok = icmp eq i1 %cmp_lt, %lt
-  %cmp_lt_em = getelementptr [17 x i8]* @.strCmpLtFlt, i32 0, i32 0
+  %cmp_lt_em = getelementptr [17 x i8], [17 x i8]* @.strCmpLtFlt, i32 0, i32 0
   call void @failCheck( i1 %cmp_lt_ok, i8* %cmp_lt_em )
 
   ; test fcmp::one -- should return true if neither operand is a NaN and they are not equal
   %cmp_ne    = fcmp one float %f1, %f2
   %cmp_ne_ok = icmp eq i1 %cmp_ne, %ne
-  %cmp_ne_em = getelementptr [17 x i8]* @.strCmpNeFlt, i32 0, i32 0
+  %cmp_ne_em = getelementptr [17 x i8], [17 x i8]* @.strCmpNeFlt, i32 0, i32 0
   call void @failCheck( i1 %cmp_ne_ok, i8* %cmp_ne_em )
 
   ret void
@@ -441,55 +441,55 @@ entry:
   ; test fcmp::true -- should always return true
   %cmp_t    = fcmp true double %d1, %d2
   %cmp_t_ok = icmp eq i1 %cmp_t, 1
-  %cmp_t_em = getelementptr [19 x i8]* @.strCmpTrDbl, i32 0, i32 0
+  %cmp_t_em = getelementptr [19 x i8], [19 x i8]* @.strCmpTrDbl, i32 0, i32 0
   call void @failCheck( i1 %cmp_t_ok, i8* %cmp_t_em )
 
   ; test fcmp::false -- should always return false
   %cmp_f    = fcmp false double %d1, %d2
   %cmp_f_ok = icmp eq i1 %cmp_f, 0
-  %cmp_f_em = getelementptr [20 x i8]* @.strCmpFaDbl, i32 0, i32 0
+  %cmp_f_em = getelementptr [20 x i8], [20 x i8]* @.strCmpFaDbl, i32 0, i32 0
   call void @failCheck( i1 %cmp_f_ok, i8* %cmp_f_em )
 
   ; test fcmp::ord -- should return true if neither operand is NaN
   %cmp_o    = fcmp ord double %d1, %d2
   %cmp_o_ok = icmp eq i1 %cmp_o, %ord
-  %cmp_o_em = getelementptr [19 x i8]* @.strCmpOrdDbl, i32 0, i32 0
+  %cmp_o_em = getelementptr [19 x i8], [19 x i8]* @.strCmpOrdDbl, i32 0, i32 0
   call void @failCheck( i1 %cmp_o_ok, i8* %cmp_o_em )
 
   ; test fcmp::oeq -- should return true if neither operand is a NaN and they are equal
   %cmp_eq    = fcmp oeq double %d1, %d2
   %cmp_eq_ok = icmp eq i1 %cmp_eq, %eq
-  %cmp_eq_em = getelementptr [18 x i8]* @.strCmpEqDbl, i32 0, i32 0
+  %cmp_eq_em = getelementptr [18 x i8], [18 x i8]* @.strCmpEqDbl, i32 0, i32 0
   call void @failCheck( i1 %cmp_eq_ok, i8* %cmp_eq_em )
 
   ; test fcmp::oge -- should return true if neither operand is a NaN and the first is greater or equal
   %cmp_ge    = fcmp oge double %d1, %d2
   %cmp_ge_ok = icmp eq i1 %cmp_ge, %ge
-  %cmp_ge_em = getelementptr [18 x i8]* @.strCmpGeDbl, i32 0, i32 0
+  %cmp_ge_em = getelementptr [18 x i8], [18 x i8]* @.strCmpGeDbl, i32 0, i32 0
   call void @failCheck( i1 %cmp_ge_ok, i8* %cmp_ge_em )
 
   ; test fcmp::ogt -- should return true if neither operand is a NaN and the first is greater
   %cmp_gt    = fcmp ogt double %d1, %d2
   %cmp_gt_ok = icmp eq i1 %cmp_gt, %gt
-  %cmp_gt_em = getelementptr [18 x i8]* @.strCmpGtDbl, i32 0, i32 0
+  %cmp_gt_em = getelementptr [18 x i8], [18 x i8]* @.strCmpGtDbl, i32 0, i32 0
   call void @failCheck( i1 %cmp_gt_ok, i8* %cmp_gt_em )
 
   ; test fcmp::ole -- should return true if neither operand is a NaN and the first is less or equal
   %cmp_le    = fcmp ole double %d1, %d2
   %cmp_le_ok = icmp eq i1 %cmp_le, %le
-  %cmp_le_em = getelementptr [18 x i8]* @.strCmpLeDbl, i32 0, i32 0
+  %cmp_le_em = getelementptr [18 x i8], [18 x i8]* @.strCmpLeDbl, i32 0, i32 0
   call void @failCheck( i1 %cmp_le_ok, i8* %cmp_le_em )
 
   ; test fcmp::olt -- should return true if neither operand is a NaN and the first is less
   %cmp_lt    = fcmp olt double %d1, %d2
   %cmp_lt_ok = icmp eq i1 %cmp_lt, %lt
-  %cmp_lt_em = getelementptr [18 x i8]* @.strCmpLtDbl, i32 0, i32 0
+  %cmp_lt_em = getelementptr [18 x i8], [18 x i8]* @.strCmpLtDbl, i32 0, i32 0
   call void @failCheck( i1 %cmp_lt_ok, i8* %cmp_lt_em )
 
   ; test fcmp::one -- should return true if neither operand is a NaN and they are not equal
   %cmp_ne    = fcmp one double %d1, %d2
   %cmp_ne_ok = icmp eq i1 %cmp_ne, %ne
-  %cmp_ne_em = getelementptr [18 x i8]* @.strCmpNeDbl, i32 0, i32 0
+  %cmp_ne_em = getelementptr [18 x i8], [18 x i8]* @.strCmpNeDbl, i32 0, i32 0
   call void @failCheck( i1 %cmp_ne_ok, i8* %cmp_ne_em )
 
   ret void
@@ -513,43 +513,43 @@ entry:
   ; test fcmp::uno -- should return true if either operand is NaN
   %cmp_o    = fcmp uno float %f1, %f2
   %cmp_o_ok = icmp eq i1 %cmp_o, %uno
-  %cmp_o_em = getelementptr [20 x i8]* @.strCmpUnoFlt, i32 0, i32 0
+  %cmp_o_em = getelementptr [20 x i8], [20 x i8]* @.strCmpUnoFlt, i32 0, i32 0
   call void @failCheck( i1 %cmp_o_ok, i8* %cmp_o_em )
 
   ; test fcmp::oeq -- should return true if either operand is a NaN and they are equal
   %cmp_eq    = fcmp ueq float %f1, %f2
   %cmp_eq_ok = icmp eq i1 %cmp_eq, %eq
-  %cmp_eq_em = getelementptr [17 x i8]* @.strCmpEqFltU, i32 0, i32 0
+  %cmp_eq_em = getelementptr [17 x i8], [17 x i8]* @.strCmpEqFltU, i32 0, i32 0
   call void @failCheck( i1 %cmp_eq_ok, i8* %cmp_eq_em )
 
   ; test fcmp::oge -- should return true if either operand is a NaN and the first is greater or equal
   %cmp_ge    = fcmp uge float %f1, %f2
   %cmp_ge_ok = icmp eq i1 %cmp_ge, %ge
-  %cmp_ge_em = getelementptr [17 x i8]* @.strCmpGeFltU, i32 0, i32 0
+  %cmp_ge_em = getelementptr [17 x i8], [17 x i8]* @.strCmpGeFltU, i32 0, i32 0
   call void @failCheck( i1 %cmp_ge_ok, i8* %cmp_ge_em )
 
   ; test fcmp::ogt -- should return true if either operand is a NaN and the first is greater
   %cmp_gt    = fcmp ugt float %f1, %f2
   %cmp_gt_ok = icmp eq i1 %cmp_gt, %gt
-  %cmp_gt_em = getelementptr [17 x i8]* @.strCmpGtFltU, i32 0, i32 0
+  %cmp_gt_em = getelementptr [17 x i8], [17 x i8]* @.strCmpGtFltU, i32 0, i32 0
   call void @failCheck( i1 %cmp_gt_ok, i8* %cmp_gt_em )
 
   ; test fcmp::ole -- should return true if either operand is a NaN and the first is less or equal
   %cmp_le    = fcmp ule float %f1, %f2
   %cmp_le_ok = icmp eq i1 %cmp_le, %le
-  %cmp_le_em = getelementptr [17 x i8]* @.strCmpLeFltU, i32 0, i32 0
+  %cmp_le_em = getelementptr [17 x i8], [17 x i8]* @.strCmpLeFltU, i32 0, i32 0
   call void @failCheck( i1 %cmp_le_ok, i8* %cmp_le_em )
 
   ; test fcmp::olt -- should return true if either operand is a NaN and the first is less
   %cmp_lt    = fcmp ult float %f1, %f2
   %cmp_lt_ok = icmp eq i1 %cmp_lt, %lt
-  %cmp_lt_em = getelementptr [17 x i8]* @.strCmpLtFltU, i32 0, i32 0
+  %cmp_lt_em = getelementptr [17 x i8], [17 x i8]* @.strCmpLtFltU, i32 0, i32 0
   call void @failCheck( i1 %cmp_lt_ok, i8* %cmp_lt_em )
 
   ; test fcmp::one -- should return true if either operand is a NaN and they are not equal
   %cmp_ne    = fcmp une float %f1, %f2
   %cmp_ne_ok = icmp eq i1 %cmp_ne, %ne
-  %cmp_ne_em = getelementptr [17 x i8]* @.strCmpNeFltU, i32 0, i32 0
+  %cmp_ne_em = getelementptr [17 x i8], [17 x i8]* @.strCmpNeFltU, i32 0, i32 0
   call void @failCheck( i1 %cmp_ne_ok, i8* %cmp_ne_em )
 
   ret void
@@ -561,43 +561,43 @@ entry:
   ; test fcmp::uno -- should return true if either operand is NaN
   %cmp_o    = fcmp uno double %d1, %d2
   %cmp_o_ok = icmp eq i1 %cmp_o, %uno
-  %cmp_o_em = getelementptr [21 x i8]* @.strCmpUnoDbl, i32 0, i32 0
+  %cmp_o_em = getelementptr [21 x i8], [21 x i8]* @.strCmpUnoDbl, i32 0, i32 0
   call void @failCheck( i1 %cmp_o_ok, i8* %cmp_o_em )
 
   ; test fcmp::ueq -- should return true if either operand is a NaN and they are equal
   %cmp_eq    = fcmp ueq double %d1, %d2
   %cmp_eq_ok = icmp eq i1 %cmp_eq, %eq
-  %cmp_eq_em = getelementptr [18 x i8]* @.strCmpEqDblU, i32 0, i32 0
+  %cmp_eq_em = getelementptr [18 x i8], [18 x i8]* @.strCmpEqDblU, i32 0, i32 0
   call void @failCheck( i1 %cmp_eq_ok, i8* %cmp_eq_em )
 
   ; test fcmp::uge -- should return true if either operand is a NaN and the first is greater or equal
   %cmp_ge    = fcmp uge double %d1, %d2
   %cmp_ge_ok = icmp eq i1 %cmp_ge, %ge
-  %cmp_ge_em = getelementptr [18 x i8]* @.strCmpGeDblU, i32 0, i32 0
+  %cmp_ge_em = getelementptr [18 x i8], [18 x i8]* @.strCmpGeDblU, i32 0, i32 0
   call void @failCheck( i1 %cmp_ge_ok, i8* %cmp_ge_em )
 
   ; test fcmp::ugt -- should return true if either operand is a NaN and the first is greater
   %cmp_gt    = fcmp ugt double %d1, %d2
   %cmp_gt_ok = icmp eq i1 %cmp_gt, %gt
-  %cmp_gt_em = getelementptr [18 x i8]* @.strCmpGtDblU, i32 0, i32 0
+  %cmp_gt_em = getelementptr [18 x i8], [18 x i8]* @.strCmpGtDblU, i32 0, i32 0
   call void @failCheck( i1 %cmp_gt_ok, i8* %cmp_gt_em )
 
   ; test fcmp::ule -- should return true if either operand is a NaN and the first is less or equal
   %cmp_le    = fcmp ule double %d1, %d2
   %cmp_le_ok = icmp eq i1 %cmp_le, %le
-  %cmp_le_em = getelementptr [18 x i8]* @.strCmpLeDblU, i32 0, i32 0
+  %cmp_le_em = getelementptr [18 x i8], [18 x i8]* @.strCmpLeDblU, i32 0, i32 0
   call void @failCheck( i1 %cmp_le_ok, i8* %cmp_le_em )
 
   ; test fcmp::ult -- should return true if either operand is a NaN and the first is less
   %cmp_lt    = fcmp ult double %d1, %d2
   %cmp_lt_ok = icmp eq i1 %cmp_lt, %lt
-  %cmp_lt_em = getelementptr [18 x i8]* @.strCmpLtDblU, i32 0, i32 0
+  %cmp_lt_em = getelementptr [18 x i8], [18 x i8]* @.strCmpLtDblU, i32 0, i32 0
   call void @failCheck( i1 %cmp_lt_ok, i8* %cmp_lt_em )
 
   ; test fcmp::une -- should return true if either operand is a NaN and they are not equal
   %cmp_ne    = fcmp une double %d1, %d2
   %cmp_ne_ok = icmp eq i1 %cmp_ne, %ne
-  %cmp_ne_em = getelementptr [18 x i8]* @.strCmpNeDblU, i32 0, i32 0
+  %cmp_ne_em = getelementptr [18 x i8], [18 x i8]* @.strCmpNeDblU, i32 0, i32 0
   call void @failCheck( i1 %cmp_ne_ok, i8* %cmp_ne_em )
 
   ret void
@@ -640,8 +640,8 @@ entry:
   store i64 -1, i64* %nan_as_i64
 
   ; load two copies of our NaN
-  %nan1 = load double* %nan
-  %nan2 = load double* %nan
+  %nan1 = load double, double* %nan
+  %nan2 = load double, double* %nan
 
   ; Warning: NaN comparisons with normal operators is BROKEN in LLVM JIT v2.0.  Fixed in v2.1.
   ; FIXME: Just check against 2.9 and the Unordered checks work, but the ordered ones do not. Should be investigated.
@@ -673,8 +673,8 @@ entry:
   call void @testFCmp( )
 
   ; everything worked -- print a message saying so
-  %works_msg = getelementptr [20 x i8]* @.strWorks, i32 0, i32 0
-  %ret = call i32 (i8*, ...)* @printf( i8* %works_msg )
+  %works_msg = getelementptr [20 x i8], [20 x i8]* @.strWorks, i32 0, i32 0
+  %ret = call i32 (i8*, ...) @printf( i8* %works_msg )
 
   ret i32 0
 }

--- a/test/Concrete/FloatingPointOps.llvm37.ll
+++ b/test/Concrete/FloatingPointOps.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: llvm-3.7
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 ; casting error messages

--- a/test/Concrete/GlobalInitializers.ll
+++ b/test/Concrete/GlobalInitializers.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: not-llvm-3.7, not-llvm-3.8
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)

--- a/test/Concrete/GlobalInitializers.llvm37.ll
+++ b/test/Concrete/GlobalInitializers.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
@@ -11,25 +11,25 @@ declare void @print_i32(i32)
 
 define i32 @main() {
 entry:
-	%addr0 = getelementptr i32* @gInt, i32 0
-	%addr1 = getelementptr [2 x i32]* @gInts, i32 0, i32 0
-	%addr2 = getelementptr [2 x i32]* @gInts, i32 0, i32 1
-	%addr3 = getelementptr %simple* @gStruct, i32 0, i32 0
-	%addr4 = getelementptr %simple* @gStruct, i32 0, i32 1
-	%addr5 = getelementptr %simple* @gStruct, i32 0, i32 2
-	%addr6 = getelementptr %simple* @gStruct, i32 0, i32 3
-	%addr7 = getelementptr %simple* @gZero, i32 0, i32 2
-	%contents0 = load i32* %addr0
-	%contents1 = load i32* %addr1
-	%contents2 = load i32* %addr2
-	%contents3tmp = load i8* %addr3
+	%addr0 = getelementptr i32, i32* @gInt, i32 0
+	%addr1 = getelementptr [2 x i32], [2 x i32]* @gInts, i32 0, i32 0
+	%addr2 = getelementptr [2 x i32], [2 x i32]* @gInts, i32 0, i32 1
+	%addr3 = getelementptr %simple, %simple* @gStruct, i32 0, i32 0
+	%addr4 = getelementptr %simple, %simple* @gStruct, i32 0, i32 1
+	%addr5 = getelementptr %simple, %simple* @gStruct, i32 0, i32 2
+	%addr6 = getelementptr %simple, %simple* @gStruct, i32 0, i32 3
+	%addr7 = getelementptr %simple, %simple* @gZero, i32 0, i32 2
+	%contents0 = load i32, i32* %addr0
+	%contents1 = load i32, i32* %addr1
+	%contents2 = load i32, i32* %addr2
+	%contents3tmp = load i8, i8* %addr3
 	%contents3 = zext i8 %contents3tmp to i32
-	%contents4tmp = load i16* %addr4
+	%contents4tmp = load i16, i16* %addr4
 	%contents4 = zext i16 %contents4tmp to i32
-	%contents5 = load i32* %addr5
-	%contents6tmp = load i64* %addr6
+	%contents5 = load i32, i32* %addr5
+	%contents6tmp = load i64, i64* %addr6
 	%contents6 = trunc i64 %contents6tmp to i32
-	%contents7 = load i32* %addr7
+	%contents7 = load i32, i32* %addr7
 	%tmp0 = mul i32 %contents0, %contents1
 	%tmp1 = mul i32 %tmp0, %contents2
 	%tmp2 = mul i32 %tmp1, %contents3

--- a/test/Concrete/GlobalInitializers.llvm37.ll
+++ b/test/Concrete/GlobalInitializers.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: llvm-3.7
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)

--- a/test/Concrete/SimpleStoreAndLoad.ll
+++ b/test/Concrete/SimpleStoreAndLoad.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: not-llvm-3.7, not-llvm-3.8
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)

--- a/test/Concrete/SimpleStoreAndLoad.llvm37.ll
+++ b/test/Concrete/SimpleStoreAndLoad.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)
@@ -6,9 +6,9 @@ declare void @print_i32(i32)
 define i32 @main() {
 entry:
 	%a = alloca i32, i32 4
-	%tmp1 = getelementptr i32* %a, i32 0
+	%tmp1 = getelementptr i32, i32* %a, i32 0
 	store i32 0, i32* %tmp1
-	%tmp2 = load i32* %tmp1
+	%tmp2 = load i32, i32* %tmp1
 	%tmp3 = icmp eq i32 %tmp2, 0
 	br i1 %tmp3, label %exitTrue, label %exitFalse
 exitTrue:

--- a/test/Concrete/SimpleStoreAndLoad.llvm37.ll
+++ b/test/Concrete/SimpleStoreAndLoad.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: llvm-3.7
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 declare void @print_i32(i32)

--- a/test/Feature/BitcastAlias.ll
+++ b/test/Feature/BitcastAlias.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: not-llvm-3.7, not-llvm-3.8
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/BitcastAlias.llvm37.ll
+++ b/test/Feature/BitcastAlias.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2
@@ -21,15 +21,15 @@ declare i32 @puts(i8*)
 
 define i32 @main(i32 %argc, i8** nocapture %argv) nounwind readnone {
 entry:
-  %call = call i32 (i64)* bitcast (i32 (i32)* @foo to i32 (i64)*)(i64 52)
+  %call = call i32 (i64) bitcast (i32 (i32)* @foo to i32 (i64)*)(i64 52)
   %r = icmp eq i32 %call, 52
   br i1 %r, label %bbtrue, label %bbfalse
 
 bbtrue:
-  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.passstr, i64 0, i64 0)) nounwind
+  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.passstr, i64 0, i64 0)) nounwind
   ret i32 0
 
 bbfalse:
-  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.failstr, i64 0, i64 0)) nounwind
+  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.failstr, i64 0, i64 0)) nounwind
   ret i32 0
 }

--- a/test/Feature/BitcastAlias.llvm38.ll
+++ b/test/Feature/BitcastAlias.llvm38.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6, not-llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2
@@ -7,34 +7,24 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 target triple = "x86_64-unknown-linux-gnu"
 
-declare {i8, i1} @llvm.umul.with.overflow.i8(i8 %a, i8 %b)
+@foo = alias i32 (i32), i32 (i32)* @__foo
+
+define i32 @__foo(i32 %i) nounwind {
+entry:
+  ret i32 %i
+}
 
 declare i32 @puts(i8*)
 
 @.passstr = private constant [5 x i8] c"PASS\00", align 1
 @.failstr = private constant [5 x i8] c"FAIL\00", align 1
 
-define i32 @main() {
-bb0:
-  %s0 = call {i8, i1} @llvm.umul.with.overflow.i8(i8 1, i8 128)
-  %v0 = extractvalue {i8, i1} %s0, 0
-  %c0 = icmp eq i8 %v0, 128
-  br i1 %c0, label %bb0_1, label %bbfalse
+define i32 @main(i32 %argc, i8** nocapture %argv) nounwind readnone {
+entry:
+  %call = call i32 (i64) bitcast (i32 (i32)* @foo to i32 (i64)*)(i64 52)
+  %r = icmp eq i32 %call, 52
+  br i1 %r, label %bbtrue, label %bbfalse
 
-bb0_1:
-  %o0 = extractvalue {i8, i1} %s0, 1
-  br i1 %o0, label %bbfalse, label %bb1
-
-bb1:
-  %s1 = call {i8, i1} @llvm.umul.with.overflow.i8(i8 2, i8 128)
-  %v1 = extractvalue {i8, i1} %s1, 0
-  %c1 = icmp eq i8 %v1, 0
-  br i1 %c1, label %bb1_1, label %bbfalse
-
-bb1_1:
-  %o1 = extractvalue {i8, i1} %s1, 1
-  br i1 %o1, label %bbtrue, label %bbfalse
-  
 bbtrue:
   %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.passstr, i64 0, i64 0)) nounwind
   ret i32 0

--- a/test/Feature/BitcastAliasMD2U.ll
+++ b/test/Feature/BitcastAliasMD2U.ll
@@ -1,3 +1,4 @@
+; REQUIRES: not-llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt -search=nurs:md2u %t1.bc > %t2

--- a/test/Feature/BitcastAliasMD2U.llvm37.ll
+++ b/test/Feature/BitcastAliasMD2U.llvm37.ll
@@ -1,7 +1,7 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
-; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2
+; RUN: %klee --output-dir=%t.klee-out -disable-opt -search=nurs:md2u %t1.bc > %t2
 ; RUN: grep PASS %t2
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
@@ -21,15 +21,15 @@ declare i32 @puts(i8*)
 
 define i32 @main(i32 %argc, i8** nocapture %argv) nounwind readnone {
 entry:
-  %call = call i32 (i64)* bitcast (i32 (i32)* @foo to i32 (i64)*)(i64 52)
+  %call = call i32 (i64) bitcast (i32 (i32)* @foo to i32 (i64)*)(i64 52)
   %r = icmp eq i32 %call, 52
   br i1 %r, label %bbtrue, label %bbfalse
 
 bbtrue:
-  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.passstr, i64 0, i64 0)) nounwind
+  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.passstr, i64 0, i64 0)) nounwind
   ret i32 0
 
 bbfalse:
-  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.failstr, i64 0, i64 0)) nounwind
+  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.failstr, i64 0, i64 0)) nounwind
   ret i32 0
 }

--- a/test/Feature/BitcastAliasMD2U.llvm38.ll
+++ b/test/Feature/BitcastAliasMD2U.llvm38.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7, not-llvm-3.8
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6, not-llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt -search=nurs:md2u %t1.bc > %t2
@@ -7,7 +7,7 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 target triple = "x86_64-unknown-linux-gnu"
 
-@foo = alias i32 (i32)* @__foo
+@foo = alias i32 (i32), i32 (i32)* @__foo
 
 define i32 @__foo(i32 %i) nounwind {
 entry:
@@ -21,15 +21,15 @@ declare i32 @puts(i8*)
 
 define i32 @main(i32 %argc, i8** nocapture %argv) nounwind readnone {
 entry:
-  %call = call i32 (i64)* bitcast (i32 (i32)* @foo to i32 (i64)*)(i64 52)
+  %call = call i32 (i64) bitcast (i32 (i32)* @foo to i32 (i64)*)(i64 52)
   %r = icmp eq i32 %call, 52
   br i1 %r, label %bbtrue, label %bbfalse
 
 bbtrue:
-  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.passstr, i64 0, i64 0)) nounwind
+  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.passstr, i64 0, i64 0)) nounwind
   ret i32 0
 
 bbfalse:
-  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.failstr, i64 0, i64 0)) nounwind
+  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.failstr, i64 0, i64 0)) nounwind
   ret i32 0
 }

--- a/test/Feature/ConstantStruct.ll
+++ b/test/Feature/ConstantStruct.ll
@@ -1,3 +1,4 @@
+; REQUIRES: not-llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/ConstantStruct.ll
+++ b/test/Feature/ConstantStruct.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: not-llvm-3.7, not-llvm-3.8
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/ConstantStruct.llvm37.ll
+++ b/test/Feature/ConstantStruct.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: llvm-3.7
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/ConstantStruct.llvm37.ll
+++ b/test/Feature/ConstantStruct.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2
@@ -7,29 +7,28 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 target triple = "x86_64-unknown-linux-gnu"
 
-@foo = alias i32 (i32)* @__foo
-
-define i32 @__foo(i32 %i) nounwind {
-entry:
-  ret i32 %i
-}
+%struct.sfoo = type { i32, i64 }
 
 declare i32 @puts(i8*)
+declare i32 @printf(i8*, ...)
 
 @.passstr = private constant [5 x i8] c"PASS\00", align 1
 @.failstr = private constant [5 x i8] c"FAIL\00", align 1
 
 define i32 @main(i32 %argc, i8** nocapture %argv) nounwind readnone {
 entry:
-  %call = call i32 (i64)* bitcast (i32 (i32)* @foo to i32 (i64)*)(i64 52)
-  %r = icmp eq i32 %call, 52
+  %f0 = extractvalue %struct.sfoo { i32 3, i64 1 }, 0
+  %f1 = extractvalue %struct.sfoo { i32 3, i64 1 }, 1
+  %xf0 = zext i32 %f0 to i64
+  %f0mf1 = sub i64 %xf0, %f1
+  %r = icmp eq i64 %f0mf1, 2
   br i1 %r, label %bbtrue, label %bbfalse
 
 bbtrue:
-  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.passstr, i64 0, i64 0)) nounwind
+  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.passstr, i64 0, i64 0)) nounwind
   ret i32 0
 
 bbfalse:
-  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.failstr, i64 0, i64 0)) nounwind
+  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.failstr, i64 0, i64 0)) nounwind
   ret i32 0
 }

--- a/test/Feature/GetElementPtr.ll
+++ b/test/Feature/GetElementPtr.ll
@@ -1,3 +1,4 @@
+; REQUIRES: not-llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/GetElementPtr.ll
+++ b/test/Feature/GetElementPtr.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: not-llvm-3.7, not-llvm-3.8
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/GetElementPtr.llvm37.ll
+++ b/test/Feature/GetElementPtr.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: llvm-3.7
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/GetElementPtr.llvm37.ll
+++ b/test/Feature/GetElementPtr.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2
@@ -7,29 +7,24 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 target triple = "x86_64-unknown-linux-gnu"
 
-@foo = alias i32 (i32)* @__foo
-
-define i32 @__foo(i32 %i) nounwind {
-entry:
-  ret i32 %i
-}
-
 declare i32 @puts(i8*)
 
 @.passstr = private constant [5 x i8] c"PASS\00", align 1
 @.failstr = private constant [5 x i8] c"FAIL\00", align 1
 
-define i32 @main(i32 %argc, i8** nocapture %argv) nounwind readnone {
+define i32 @main() {
 entry:
-  %call = call i32 (i64)* bitcast (i32 (i32)* @foo to i32 (i64)*)(i64 52)
-  %r = icmp eq i32 %call, 52
-  br i1 %r, label %bbtrue, label %bbfalse
+  %addr = alloca i8, align 4
+  %addrp1 = getelementptr i8, i8* %addr, i32 1
+  %addrp1m1 = getelementptr i8, i8* %addrp1, i32 -1
+  %test = icmp eq i8* %addr, %addrp1m1
+  br i1 %test, label %bbtrue, label %bbfalse
 
 bbtrue:
-  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.passstr, i64 0, i64 0)) nounwind
+  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.passstr, i64 0, i64 0)) nounwind
   ret i32 0
 
 bbfalse:
-  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.failstr, i64 0, i64 0)) nounwind
+  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.failstr, i64 0, i64 0)) nounwind
   ret i32 0
 }

--- a/test/Feature/InsertExtractValue.ll
+++ b/test/Feature/InsertExtractValue.ll
@@ -1,3 +1,4 @@
+; REQUIRES: not-llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/InsertExtractValue.ll
+++ b/test/Feature/InsertExtractValue.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: not-llvm-3.7, not-llvm-3.8
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/InsertExtractValue.llvm37.ll
+++ b/test/Feature/InsertExtractValue.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2
@@ -7,12 +7,7 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 target triple = "x86_64-unknown-linux-gnu"
 
-@foo = alias i32 (i32)* @__foo
-
-define i32 @__foo(i32 %i) nounwind {
-entry:
-  ret i32 %i
-}
+%struct.sfoo = type { i32, i32 }
 
 declare i32 @puts(i8*)
 
@@ -21,15 +16,19 @@ declare i32 @puts(i8*)
 
 define i32 @main(i32 %argc, i8** nocapture %argv) nounwind readnone {
 entry:
-  %call = call i32 (i64)* bitcast (i32 (i32)* @foo to i32 (i64)*)(i64 52)
-  %r = icmp eq i32 %call, 52
+  %s0 = insertvalue %struct.sfoo undef, i32 3, 0
+  %s1 = insertvalue %struct.sfoo %s0, i32 1, 1
+  %f0 = extractvalue %struct.sfoo %s1, 0
+  %f1 = extractvalue %struct.sfoo %s1, 1
+  %f0mf1 = sub i32 %f0, %f1
+  %r = icmp eq i32 %f0mf1, 2
   br i1 %r, label %bbtrue, label %bbfalse
 
 bbtrue:
-  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.passstr, i64 0, i64 0)) nounwind
+  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.passstr, i64 0, i64 0)) nounwind
   ret i32 0
 
 bbfalse:
-  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.failstr, i64 0, i64 0)) nounwind
+  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.failstr, i64 0, i64 0)) nounwind
   ret i32 0
 }

--- a/test/Feature/InsertExtractValue.llvm37.ll
+++ b/test/Feature/InsertExtractValue.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: llvm-3.7
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/Overflow.ll
+++ b/test/Feature/Overflow.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: not-llvm-3.7, not-llvm-3.8
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/Overflow.llvm37.ll
+++ b/test/Feature/Overflow.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: llvm-3.7
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/Overflow.llvm37.ll
+++ b/test/Feature/Overflow.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2
@@ -36,10 +36,10 @@ bb1_1:
   br i1 %o1, label %bbtrue, label %bbfalse
   
 bbtrue:
-  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.passstr, i64 0, i64 0)) nounwind
+  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.passstr, i64 0, i64 0)) nounwind
   ret i32 0
 
 bbfalse:
-  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.failstr, i64 0, i64 0)) nounwind
+  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.failstr, i64 0, i64 0)) nounwind
   ret i32 0
 }

--- a/test/Feature/OverflowMul.ll
+++ b/test/Feature/OverflowMul.ll
@@ -1,3 +1,4 @@
+; REQUIRES: not-llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/OverflowMul.ll
+++ b/test/Feature/OverflowMul.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: not-llvm-3.7, not-llvm-3.8
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2

--- a/test/Feature/OverflowMul.llvm37.ll
+++ b/test/Feature/OverflowMul.llvm37.ll
@@ -1,4 +1,4 @@
-; REQUIRES: not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: llvm-as %s -f -o %t1.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc > %t2
@@ -7,7 +7,7 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 target triple = "x86_64-unknown-linux-gnu"
 
-declare {i8, i1} @llvm.uadd.with.overflow.i8(i8 %a, i8 %b)
+declare {i8, i1} @llvm.umul.with.overflow.i8(i8 %a, i8 %b)
 
 declare i32 @puts(i8*)
 
@@ -16,9 +16,9 @@ declare i32 @puts(i8*)
 
 define i32 @main() {
 bb0:
-  %s0 = call {i8, i1} @llvm.uadd.with.overflow.i8(i8 0, i8 -1)
+  %s0 = call {i8, i1} @llvm.umul.with.overflow.i8(i8 1, i8 128)
   %v0 = extractvalue {i8, i1} %s0, 0
-  %c0 = icmp eq i8 %v0, -1
+  %c0 = icmp eq i8 %v0, 128
   br i1 %c0, label %bb0_1, label %bbfalse
 
 bb0_1:
@@ -26,7 +26,7 @@ bb0_1:
   br i1 %o0, label %bbfalse, label %bb1
 
 bb1:
-  %s1 = call {i8, i1} @llvm.uadd.with.overflow.i8(i8 1, i8 -1)
+  %s1 = call {i8, i1} @llvm.umul.with.overflow.i8(i8 2, i8 128)
   %v1 = extractvalue {i8, i1} %s1, 0
   %c1 = icmp eq i8 %v1, 0
   br i1 %c1, label %bb1_1, label %bbfalse
@@ -36,10 +36,10 @@ bb1_1:
   br i1 %o1, label %bbtrue, label %bbfalse
   
 bbtrue:
-  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.passstr, i64 0, i64 0)) nounwind
+  %0 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.passstr, i64 0, i64 0)) nounwind
   ret i32 0
 
 bbfalse:
-  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8]* @.failstr, i64 0, i64 0)) nounwind
+  %1 = call i32 @puts(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.failstr, i64 0, i64 0)) nounwind
   ret i32 0
 }

--- a/test/Feature/Vararg.c
+++ b/test/Feature/Vararg.c
@@ -12,7 +12,7 @@ struct triple {
   int first, second, third;
 };
 
-int test1(int x, ...) {
+void test1(int x, ...) {
   va_list ap;
   va_start(ap, x);
   int i32 = va_arg(ap, int);

--- a/test/Feature/_utils.llvm37._ll
+++ b/test/Feature/_utils.llvm37._ll
@@ -1,0 +1,71 @@
+define i32 @util_make_and_i1(i32 %a, i32 %b) {
+        %a_i1 = icmp ne i32 %a, 0
+        %b_i1 = icmp ne i32 %b, 0
+        %res_i1 = and i1 %a_i1, %b_i1
+        %res = zext i1 %res_i1 to i32
+        ret i32 %res
+}
+
+define i32 @util_make_or_i1(i32 %a, i32 %b) {
+        %a_i1 = icmp ne i32 %a, 0
+        %b_i1 = icmp ne i32 %b, 0
+        %res_i1 = or i1 %a_i1, %b_i1
+        %res = zext i1 %res_i1 to i32
+        ret i32 %res
+}
+
+define i16 @util_make_concat2(i8 %a, i8 %b) {
+        %tmp = alloca i16
+        %tmp8 = bitcast i16* %tmp to i8*
+        %p0 = getelementptr i8, i8* %tmp8, i32 0
+        %p1 = getelementptr i8, i8* %tmp8, i32 1
+        store i8 %b, i8* %p0
+        store i8 %a, i8* %p1
+        %concat = load i16, i16* %tmp
+        ret i16 %concat
+}
+
+define i32 @util_make_concat4(i8 %a, i8 %b, i8 %c, i8 %d) {
+        %tmp = alloca i32
+        %tmp8 = bitcast i32* %tmp to i8*
+        %p0 = getelementptr i8, i8* %tmp8, i32 0
+        %p1 = getelementptr i8, i8* %tmp8, i32 1
+        %p2 = getelementptr i8, i8* %tmp8, i32 2
+        %p3 = getelementptr i8, i8* %tmp8, i32 3
+        store i8 %d, i8* %p0
+        store i8 %c, i8* %p1
+        store i8 %b, i8* %p2
+        store i8 %a, i8* %p3
+        %concat = load i32, i32* %tmp
+        ret i32 %concat
+}
+
+define i64 @util_make_concat8(i8 %a, i8 %b, i8 %c, i8 %d, 
+                              i8 %e, i8 %f, i8 %g, i8 %h) {
+        %tmp = alloca i64
+        %tmp8 = bitcast i64* %tmp to i8*
+        %p0 = getelementptr i8, i8* %tmp8, i32 0
+        %p1 = getelementptr i8, i8* %tmp8, i32 1
+        %p2 = getelementptr i8, i8* %tmp8, i32 2
+        %p3 = getelementptr i8, i8* %tmp8, i32 3
+        %p4 = getelementptr i8, i8* %tmp8, i32 4
+        %p5 = getelementptr i8, i8* %tmp8, i32 5
+        %p6 = getelementptr i8, i8* %tmp8, i32 6
+        %p7 = getelementptr i8, i8* %tmp8, i32 7
+        store i8 %h, i8* %p0
+        store i8 %g, i8* %p1
+        store i8 %f, i8* %p2
+        store i8 %e, i8* %p3
+        store i8 %d, i8* %p4
+        store i8 %c, i8* %p5
+        store i8 %b, i8* %p6
+        store i8 %a, i8* %p7
+        %concat = load i64, i64* %tmp
+        ret i64 %concat
+}
+
+define i32 @util_make_select(i32 %cond, i32 %t, i32 %f) {
+        %cond_i1 = icmp ne i32 %cond, 0
+        %res = select i1 %cond_i1, i32 %t, i32 %f
+        ret i32 %res
+}

--- a/test/Intrinsics/objectsize.ll
+++ b/test/Intrinsics/objectsize.ll
@@ -1,7 +1,7 @@
 ; Unfortunately LLVM 2.9 has a different suffix for the ``llvm.objectsize`` instrinsic
 ; so this LLVM IR fails to verify for that version.
 ;
-; REQUIRES: not-llvm-2.9, not-llvm-3.7
+; REQUIRES: not-llvm-2.9, not-llvm-3.7, not-llvm-3.8
 ; RUN: %llvmas %s -o=%t.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee -exit-on-error --output-dir=%t.klee-out -disable-opt %t.bc

--- a/test/Intrinsics/objectsize.llvm37.ll
+++ b/test/Intrinsics/objectsize.llvm37.ll
@@ -1,7 +1,7 @@
 ; Unfortunately LLVM 2.9 has a different suffix for the ``llvm.objectsize`` instrinsic
 ; so this LLVM IR fails to verify for that version.
 ;
-; REQUIRES: llvm-3.7
+; REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
 ; RUN: %llvmas %s -o=%t.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee -exit-on-error --output-dir=%t.klee-out -disable-opt %t.bc

--- a/test/Intrinsics/objectsize.llvm37.ll
+++ b/test/Intrinsics/objectsize.llvm37.ll
@@ -1,7 +1,7 @@
 ; Unfortunately LLVM 2.9 has a different suffix for the ``llvm.objectsize`` instrinsic
 ; so this LLVM IR fails to verify for that version.
 ;
-; REQUIRES: not-llvm-2.9, not-llvm-3.7
+; REQUIRES: llvm-3.7
 ; RUN: %llvmas %s -o=%t.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee -exit-on-error --output-dir=%t.klee-out -disable-opt %t.bc
@@ -12,13 +12,13 @@ target triple = "x86_64-unknown-linux-gnu"
 define i32 @main() nounwind uwtable {
 entry:
   %a = alloca i8*, align 8
-  %0 = load i8** %a, align 8
+  %0 = load i8*, i8** %a, align 8
   %1 = call i64 @llvm.objectsize.i64.p0i8(i8* %0, i1 true)
   %cmp = icmp ne i64 %1, 0
   br i1 %cmp, label %abort.block, label %continue.block
 
 continue.block:
-  %2 = load i8** %a, align 8
+  %2 = load i8*, i8** %a, align 8
   %3 = call i64 @llvm.objectsize.i64.p0i8(i8* %2, i1 false)
   %cmp1 = icmp ne i64 %3, -1
   br i1 %cmp1, label %abort.block, label %exit.block

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -121,7 +121,7 @@ if int(config.llvm_version_major) == 2:
 
 # Add feature for the LLVM version in use, so it can be tested in REQUIRES and
 # XFAIL checks. We also add "not-XXX" variants, for the same reason.
-known_llvm_versions = set(["2.9", "3.4", "3.5"])
+known_llvm_versions = set(["2.9", "3.4", "3.5","3.6"])
 current_llvm_version = "%s.%s" % (config.llvm_version_major,
                                   config.llvm_version_minor)
 config.available_features.add("llvm-" + current_llvm_version)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -121,7 +121,7 @@ if int(config.llvm_version_major) == 2:
 
 # Add feature for the LLVM version in use, so it can be tested in REQUIRES and
 # XFAIL checks. We also add "not-XXX" variants, for the same reason.
-known_llvm_versions = set(["2.9", "3.4", "3.5","3.6"])
+known_llvm_versions = set(["2.9", "3.4", "3.5", "3.6", "3.7"])
 current_llvm_version = "%s.%s" % (config.llvm_version_major,
                                   config.llvm_version_minor)
 config.available_features.add("llvm-" + current_llvm_version)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -121,7 +121,7 @@ if int(config.llvm_version_major) == 2:
 
 # Add feature for the LLVM version in use, so it can be tested in REQUIRES and
 # XFAIL checks. We also add "not-XXX" variants, for the same reason.
-known_llvm_versions = set(["2.9", "3.4", "3.5", "3.6", "3.7"])
+known_llvm_versions = set(["2.9", "3.4", "3.5", "3.6", "3.7", "3.8"])
 current_llvm_version = "%s.%s" % (config.llvm_version_major,
                                   config.llvm_version_minor)
 config.available_features.add("llvm-" + current_llvm_version)

--- a/test/regression/2007-08-16-invalid-constant-value.c
+++ b/test/regression/2007-08-16-invalid-constant-value.c
@@ -1,4 +1,4 @@
-// REQUIRES: not-llvm-3.7
+// REQUIRES: not-llvm-3.7, not-llvm-3.8
 // RUN: rm -f %t4.out %t4.err %t4.log
 // RUN: %llvmgcc %s -emit-llvm -O2 -c -o %t1.bc
 // RUN: llvm-as -f %p/../Feature/_utils._ll -o %t2.bc

--- a/test/regression/2007-08-16-invalid-constant-value.llvm37.c
+++ b/test/regression/2007-08-16-invalid-constant-value.llvm37.c
@@ -1,4 +1,4 @@
-// REQUIRES: llvm-3.7
+// REQUIRES: not-llvm-2.9, not-llvm-3.4, not-llvm-3.5, not-llvm-3.6
 // RUN: rm -f %t4.out %t4.err %t4.log
 // RUN: %llvmgcc %s -emit-llvm -O2 -c -o %t1.bc
 // RUN: llvm-as -f %p/../Feature/_utils.llvm37._ll -o %t2.bc

--- a/test/regression/2007-08-16-invalid-constant-value.llvm37.c
+++ b/test/regression/2007-08-16-invalid-constant-value.llvm37.c
@@ -1,7 +1,7 @@
-// REQUIRES: not-llvm-3.7
+// REQUIRES: llvm-3.7
 // RUN: rm -f %t4.out %t4.err %t4.log
 // RUN: %llvmgcc %s -emit-llvm -O2 -c -o %t1.bc
-// RUN: llvm-as -f %p/../Feature/_utils._ll -o %t2.bc
+// RUN: llvm-as -f %p/../Feature/_utils.llvm37._ll -o %t2.bc
 // RUN: llvm-link %t1.bc %t2.bc -o %t3.bc
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out %t3.bc
@@ -19,12 +19,12 @@ int main() {
   // value was being created when implied value did not
   // subtract using the proper type (so overflowed into
   // invalid bits)
-  if (util_make_concat2(a+0xCD,0xCD) == 0xABCD) { 
+  if (util_make_concat2(a + 0xCD, 0xCD) == 0xABCD) {
     assert(!klee_is_symbolic(a));
     printf("add constant case: %d\n", a);
   }
 
-  if (util_make_concat2(0x0B-a,0xCD) == 0xABCD) { 
+  if (util_make_concat2(0x0B - a, 0xCD) == 0xABCD) {
     assert(!klee_is_symbolic(a));
     printf("sub constant case: %d\n", a);
   }

--- a/tools/klee/Makefile
+++ b/tools/klee/Makefile
@@ -13,7 +13,13 @@ TOOLNAME = klee
 include $(LEVEL)/Makefile.config
 
 USEDLIBS = kleeCore.a kleeBasic.a kleeModule.a  kleaverSolver.a kleaverExpr.a kleeSupport.a 
-LINK_COMPONENTS = jit bitreader bitwriter ipo linker engine
+LINK_COMPONENTS = bitreader bitwriter ipo linker engine
+
+ifeq ($(shell python -c "print($(LLVM_VERSION_MAJOR).$(LLVM_VERSION_MINOR) >= 3.6)"), True)
+LINK_COMPONENTS += mcjit
+else
+LINK_COMPONENTS += jit
+endif
 
 ifeq ($(shell python -c "print($(LLVM_VERSION_MAJOR).$(LLVM_VERSION_MINOR) >= 3.3)"), True)
 LINK_COMPONENTS += irreader

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -384,7 +384,12 @@ llvm::raw_fd_ostream *KleeHandler::openOutputFile(const std::string &filename) {
   llvm::raw_fd_ostream *f;
   std::string Error;
   std::string path = getOutputFilename(filename);
-#if LLVM_VERSION_CODE >= LLVM_VERSION(3,5)
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+  std::error_code ec;
+  f = new llvm::raw_fd_ostream(path.c_str(), ec, llvm::sys::fs::F_None);
+  if (ec)
+    Error = ec.message();
+#elif LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
   f = new llvm::raw_fd_ostream(path.c_str(), Error, llvm::sys::fs::F_None);
 #elif LLVM_VERSION_CODE >= LLVM_VERSION(3,4)
   f = new llvm::raw_fd_ostream(path.c_str(), Error, llvm::sys::fs::F_Binary);
@@ -640,8 +645,13 @@ static std::string strip(std::string &in) {
 }
 
 static void parseArguments(int argc, char **argv) {
+
   cl::SetVersionPrinter(klee::printVersion);
-#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 2)
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+  cl::ParseCommandLineOptions(argc, (char **)argv, " klee\n"); // removes
+                                                               // warning
+#elif LLVM_VERSION_CODE >= LLVM_VERSION(3, 2)
   // This version always reads response files
   cl::ParseCommandLineOptions(argc, argv, " klee\n");
 #else
@@ -1029,9 +1039,14 @@ static llvm::Module *linkWithUclibc(llvm::Module *mainModule, StringRef libDir) 
   SmallString<128> uclibcBCA(libDir);
   llvm::sys::path::append(uclibcBCA, KLEE_UCLIBC_BCA_NAME);
 
-  bool uclibcExists=false;
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+  Twine uclibcBCA_twine(uclibcBCA.c_str());
+  if (!llvm::sys::fs::exists(uclibcBCA_twine))
+#else
+  bool uclibcExists = false;
   llvm::sys::fs::exists(uclibcBCA.c_str(), uclibcExists);
   if (!uclibcExists)
+#endif
     klee_error("Cannot find klee-uclibc : %s", uclibcBCA.c_str());
 
   Function *f;
@@ -1251,9 +1266,13 @@ int main(int argc, char **argv, char **envp) {
   if (!Buffer)
     klee_error("error loading program '%s': %s", InputFile.c_str(),
                Buffer.getError().message().c_str());
-
-  auto mainModuleOrError = getLazyBitcodeModule(Buffer->get(), getGlobalContext());
-
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+  auto mainModuleOrError =
+      getLazyBitcodeModule(std::move(Buffer.get()), getGlobalContext());
+#else
+  auto mainModuleOrError =
+      getLazyBitcodeModule(Buffer->get(), getGlobalContext());
+#endif
   if (!mainModuleOrError) {
     klee_error("error loading program '%s': %s", InputFile.c_str(),
                mainModuleOrError.getError().message().c_str());

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -58,6 +58,10 @@
 #include "llvm/Support/system_error.h"
 #endif
 
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+#include "llvm/Support/Path.h"
+#endif
+
 #include <dirent.h>
 #include <signal.h>
 #include <unistd.h>
@@ -1282,8 +1286,11 @@ int main(int argc, char **argv, char **envp) {
     // from the std::unique_ptr
     Buffer->release();
   }
-
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+  mainModule = mainModuleOrError->release();
+#else
   mainModule = *mainModuleOrError;
+#endif
   if (auto ec = mainModule->materializeAllPermanently()) {
     klee_error("error loading program '%s': %s", InputFile.c_str(),
                ec.message().c_str());


### PR DESCRIPTION
Hello again,
this is based on #383.
Main changes from LLVM 3.7 to LLVM 3.8:
- ilist pointers and iterators are no longer interchangeable.
  Iterator get be obtained from pointer by `getIterator()` function, but to get pointer back, explicit cast is needed. I went for `static_cast<PtType *>` in my implementation, but simple `&*` would have sufficed, which is little bit less explicit I think. Does anybody see a downside?
- `Archive::Child` is now packed in `ErrorOr<>`, so I added an error check there
- `Linker::linkModules()` arguments are now passed by reference+`unique_ptr` (ownership is passed by latter)
- `createFunctionAttrsPass()` and `createGlobalsModRefPass()` were replaced
- testing tools (lit, FileCheck, ...) are no longer shipped in precompiled binaries and Travis CI would not be happy about compiling LLVM everytime. I didn't find a way to run tests this way.
- Tests: I reworked every `llvm-3.7` in REQUIRES check to `not-llvm-2.9, not-llvm-3.4,
  not-llvm-3.5, not-llvm-3.6` to cover LLVM 3.8+ as well. Is there a more proper way?
- Tests: `alias` now needs explicit type as well, I added versions of 2 tests
