### PR TITLE
Allow relocation of installed klee tree

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -606,11 +606,15 @@ std::string KleeHandler::getRunTimeLibraryPath(const char *argv0) {
 
   SmallString<128> libDir;
 
-  if ( strcmp(toolRoot.c_str(), KLEE_INSTALL_BIN_DIR ) == 0)
+  if (strlen( KLEE_INSTALL_BIN_DIR ) != 0 &&
+      strlen( KLEE_INSTALL_RUNTIME_DIR ) != 0 &&
+      toolRoot.str().endswith( KLEE_INSTALL_BIN_DIR ))
   {
     KLEE_DEBUG_WITH_TYPE("klee_runtime", llvm::dbgs() <<
                          "Using installed KLEE library runtime: ");
-    libDir = KLEE_INSTALL_RUNTIME_DIR ;
+    libDir = toolRoot.str().substr(0, 
+               toolRoot.str().size() - strlen( KLEE_INSTALL_BIN_DIR ));
+    llvm::sys::path::append(libDir, KLEE_INSTALL_RUNTIME_DIR);
   }
   else
   {


### PR DESCRIPTION
This trivial change allows relocation of an  installed klee tree.

For example, if klee is configured with bindir /usr/bin, and with runtime dir /usr/lib/klee/runtime,
but klee is called from, for example, /home/user/klee/usr/bin/klee, it will find and use runtime in /home/user/klee/usr/lib/klee/runtime, instead of global /usr/lib/klee/runtime.

It will use global runtime directory only when installed to global binary directory.

Inspired by relocation code in gcc.