### PR TITLE
Modified -debug-print-instructions to write directly on log file.

### DIFF
--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -21,6 +21,7 @@
 #include "klee/Internal/Module/KInstruction.h"
 #include "klee/Internal/Module/KModule.h"
 #include "klee/util/ArrayCache.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include "llvm/ADT/Twine.h"
 
@@ -183,12 +184,22 @@ private:
   /// Assumes ownership of the created array objects
   ArrayCache arrayCache;
 
+  /// File to print executed instructions to
+  llvm::raw_ostream *debugInstFile;
+
+  // @brief Buffer used by logBuffer
+  std::string debugBufferString;
+
+  // @brief buffer to store logs before flushing to file
+  llvm::raw_string_ostream debugLogBuffer;
+
   llvm::Function* getTargetFunction(llvm::Value *calledVal,
                                     ExecutionState &state);
   
   void executeInstruction(ExecutionState &state, KInstruction *ki);
 
-  void printFileLine(ExecutionState &state, KInstruction *ki);
+  void printFileLine(ExecutionState &state, KInstruction *ki,
+                     llvm::raw_ostream &file);
 
   void run(ExecutionState &initialState);
 
@@ -400,6 +411,7 @@ private:
   void processTimers(ExecutionState *current,
                      double maxInstTime);
   void checkMemoryUsage();
+  void printDebugInstructions(ExecutionState &state);
 
 public:
   Executor(const InterpreterOptions &opts, InterpreterHandler *ie);

--- a/test/Feature/LoggingInstructions.c
+++ b/test/Feature/LoggingInstructions.c
@@ -1,0 +1,47 @@
+// RUN: %llvmgcc %s -emit-llvm -g -c -o %t2.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error --debug-print-instructions=all:stderr %t2.bc 2>%t3.txt
+// RUN: FileCheck -input-file=%t3.txt -check-prefix=CHECK-FILE-SRC %s
+// RUN: FileCheck -input-file=%t3.txt -check-prefix=CHECK-FILE-DBG %s
+// RUN: not test -f %t.klee-out/instructions.txt
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error --debug-print-instructions=all:file %t2.bc
+// RUN: FileCheck -input-file=%t.klee-out/instructions.txt -check-prefix=CHECK-FILE-DBG %s
+// RUN: FileCheck -input-file=%t.klee-out/instructions.txt -check-prefix=CHECK-FILE-SRC %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error --debug-print-instructions=src:file %t2.bc
+// RUN: FileCheck -input-file=%t.klee-out/instructions.txt -check-prefix=CHECK-FILE-SRC %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error --debug-print-instructions=compact:file %t2.bc
+// RUN: FileCheck -input-file=%t.klee-out/instructions.txt -check-prefix=CHECK-FILE-COMPACT %s
+//
+#include "klee/klee.h"
+#include <assert.h>
+#include <stdio.h>
+
+char array[5] = { 1, 2, 3, -4, 5 };
+
+int main() {
+  unsigned k;
+
+  klee_make_symbolic(&k, sizeof(k), "k");
+  klee_assume(k < 5);
+
+  if (array[k] == -4)
+    printf("Yes\n");
+
+  // CHECK-FILE-SRC: LoggingInstructions.c:27
+  // CHECK-FILE-SRC: LoggingInstructions.c:28
+  // CHECK-FILE-SRC: LoggingInstructions.c:30
+  // CHECK-FILE-SRC: LoggingInstructions.c:31
+
+  // CHECK-FILE-DBG: call void @klee_make_symbolic
+  // CHECK-FILE-DBG: load
+
+  // CHECK-FILE-COMPACT-NOT: LoggingInstructions.c:21
+  // CHECK-FILE-COMPACT-NOT: LoggingInstructions.c:22
+  // CHECK-FILE-COMPACT-NOT: LoggingInstructions.c:24
+  // CHECK-FILE-COMPACT-NOT: LoggingInstructions.c:25
+
+  return 0;
+}


### PR DESCRIPTION
-debug-print-instructions can now be invoked with 4 different values:
1) all:stderr,   which logs all instructions to stderr;
2) all:file,     which logs all instructions to file in format [src, inst_cntr, inst_id, llvm_inst];
3) src:file,     which logs all instructions to file in format [src, inst_cntr, inst_id];
4) compact:file, which logs all instructions to file in format [inst_cntr, inst_id];
Writing to file gives a speedup of ~50x.

Changes made mainly by @MartinNowack.