### PR TITLE
Added string for -run-in directory errors

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1426,7 +1426,10 @@ int main(int argc, char **argv, char **envp) {
     if (RunInDir != "") {
       int res = chdir(RunInDir.c_str());
       if (res < 0) {
-        klee_error("Unable to change directory to: %s", RunInDir.c_str());
+        char info[128];
+        char *str = strerror_r(errno, info, sizeof(info));
+        klee_error("Unable to change directory to: %s - %s", RunInDir.c_str(),
+                   str);
       }
     }
 
@@ -1488,7 +1491,10 @@ int main(int argc, char **argv, char **envp) {
     if (RunInDir != "") {
       int res = chdir(RunInDir.c_str());
       if (res < 0) {
-        klee_error("Unable to change directory to: %s", RunInDir.c_str());
+        char info[128];
+        char *str = strerror_r(errno, info, sizeof(info));
+        klee_error("Unable to change directory to: %s - %s", RunInDir.c_str(),
+                   str);
       }
     }
     interpreter->runFunctionAsMain(mainFn, pArgc, pArgv, pEnvp);


### PR DESCRIPTION
A very small refactoring to improve the error string with -run-in option.
It helped me a lot to understand what kind of error I was encountering.