### PR TITLE
Add option to dump statistics every n instructions

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -364,7 +364,7 @@ const Module *Executor::setModule(llvm::Module *module,
   kmodule->prepare(opts, interpreterHandler);
   specialFunctionHandler->bind();
 
-  if (StatsTracker::useStatistics()) {
+  if (StatsTracker::useStatistics() || userSearcherRequiresMD2U()) {
     statsTracker = 
       new StatsTracker(*this,
                        interpreterHandler->getOutputFilename("assembly.ll"),


### PR DESCRIPTION
Use `stats-write-after-instructions` to dump klee statistics after
every n instructions. This is disabled by default
Be aware, `stats-write-interval` is enabled by default.

If both features are enabled, statistics are written every n
instructions and every m seconds to the same file.