### PR TITLE
Fix to potential overflow in POSIX/fd.c

### DIFF
--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -466,8 +466,8 @@ ssize_t write(int fd, const void *buf, size_t count) {
     if (f->dfile == __exe_fs.sym_stdout)
       __exe_fs.stdout_writes += actual_count;
 
-    f->off += count;
-    return count;
+    f->off += actual_count;
+    return actual_count;
   }
 }
 


### PR DESCRIPTION
Fixed a potential overflow in the write() method in fd.c as specified by http://linux.die.net/man/2/write

> On success, the number of bytes written is returned (zero indicates nothing was written). 