### PR TITLE
Fix Travis CI build - use alternative ppa for LLVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,18 +65,16 @@ before_install:
     # Set up the locations to get various packages from
     # We assume the Travis image uses Ubuntu 12.04 LTS
     ###########################################################################
-    - sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.4 main" >> /etc/apt/sources.list.d/llvm.list'
-    - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.4 main" >> /etc/apt/sources.list.d/llvm.list'
-    - sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main" >> /etc/apt/sources.list.d/llvm.list'
-    - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main" >> /etc/apt/sources.list.d/llvm.list'
-    - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/delcypher:/z3/xUbuntu_12.04/ /' >> /etc/apt/sources.list.d/z3.list"
     # Needed for CMake
-    - sudo add-apt-repository -y ppa:ubuntu-sdk-team/ppa
     - sudo add-apt-repository -y ppa:kalakris/cmake
+    # Needed for LLVM
+    - sudo add-apt-repository -y ppa:h-rayflood/llvm
     # Needed for new libstdc++ and gcc4.8
     - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test/
-    - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
+    # Needed for Z3
+    - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/delcypher:/z3/xUbuntu_12.04/ /' >> /etc/apt/sources.list.d/z3.list"
     - wget -O - http://download.opensuse.org/repositories/home:delcypher:z3/xUbuntu_12.04/Release.key | sudo apt-key add -
+    # Update package information
     - sudo apt-get update
     ###########################################################################
     # Set up out of source build directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,10 +93,6 @@ before_install:
     # Make gcc4.8 the default gcc version
     - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 20
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 20
-    # Make Clang3.4 the default clang version
-    - sudo apt-get install clang-3.4
-    - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.4 20
-    - sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.4 20
     # Install LLVM and the LLVM bitcode compiler we require to build KLEE
     - ${KLEE_SRC}/.travis/install-llvm-and-runtime-compiler.sh
     - ${KLEE_SRC}/.travis/install-tcmalloc.sh

--- a/.travis/install-llvm-and-runtime-compiler.sh
+++ b/.travis/install-llvm-and-runtime-compiler.sh
@@ -5,6 +5,8 @@ sudo apt-get install -y llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev
 
 if [ "${LLVM_VERSION}" != "2.9" ]; then
     sudo apt-get install -y llvm-${LLVM_VERSION}-tools clang-${LLVM_VERSION}
+    sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 20
+    sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 20
 else
     # Get llvm-gcc. We don't bother installing it
     wget http://llvm.org/releases/2.9/llvm-gcc4.2-2.9-x86_64-linux.tar.bz2


### PR DESCRIPTION
Use alternativ PPA for LLVM packages which are build using the debian package description.
