### PR TITLE
Change operator<< to work and return ostream

### DIFF
--- a/include/klee/Expr.h
+++ b/include/klee/Expr.h
@@ -310,7 +310,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Expr::Kind kin
 }
 #endif
 
-inline std::stringstream &operator<<(std::stringstream &os, const Expr &e) {
+inline std::ostream &operator<<(std::ostream &os, const Expr &e) {
   std::string str;
   llvm::raw_string_ostream TmpStr(str);
   e.print(TmpStr);
@@ -318,7 +318,7 @@ inline std::stringstream &operator<<(std::stringstream &os, const Expr &e) {
   return os;
 }
 
-inline std::stringstream &operator<<(std::stringstream &os, const Expr::Kind kind) {
+inline std::ostream &operator<<(std::ostream &os, const Expr::Kind kind) {
   std::string str;
   llvm::raw_string_ostream TmpStr(str);
   Expr::printKind(TmpStr, kind);

--- a/include/klee/util/Ref.h
+++ b/include/klee/util/Ref.h
@@ -117,7 +117,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const ref<T> &e) {
 }
 
 template<class T>
-inline std::stringstream &operator<<(std::stringstream &os, const ref<T> &e) {
+inline std::ostream &operator<<(std::ostream &os, const ref<T> &e) {
   os << *e;
   return os;
 }


### PR DESCRIPTION
The sandard C++ library's << operators are implemented over ostream, and
return ostream. Therefore, the following code fails:

std::stringstream ss;
klee::ref<klee::Expr> expr;
ss << "Hello " << expr << " World";

By changing the operator to work on and return ostream, the above code
succeeds and works as expected.