### PR TITLE
Dockerfile: link binaries to /usr/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,3 +132,8 @@ USER klee
 
 # Add KLEE binary directory to PATH
 RUN echo 'export PATH=$PATH:'${BUILD_DIR}'/klee/Release+Asserts/bin' >> /home/klee/.bashrc
+
+# Link klee to /usr/bin so that it can be used by docker run
+USER root
+RUN for exec in ${BUILD_DIR}/klee/Release+Asserts/bin/* ; do ln -s ${exec} /usr/bin/`basename ${exec}`; done
+USER klee


### PR DESCRIPTION
This fixes an issue related to the PATH used by docker run, that is different than the one used by bash.
This allows to run docker run klee/klee klee FILE.o directly.