### PR TITLE
Executor: do not crash on non-sized globals

### DIFF
--- a/test/Feature/NonSizedGlobals.c
+++ b/test/Feature/NonSizedGlobals.c
@@ -1,0 +1,12 @@
+// RUN: %llvmgcc %s -emit-llvm -g -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error %t1.bc
+
+struct X;
+extern struct X Y;
+void *ptr = &Y;
+
+int main()
+{
+	return 0;
+}


### PR DESCRIPTION
Sometimes, globals are not sized and ->getTypeStoreSize on such type
crashes inside the LLVM. Check whether type is sized prior to calling
the function above.

A minimalistic example of Y being unsized with no effect on the actual
code is put to tests.

Signed-off-by: Jiri Slaby <jslaby@suse.cz>