### PR TITLE
Improved error reporting if STP fork fails.

### DIFF
--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -230,6 +230,11 @@ runAndGetCexForked(::VC vc, STPBuilder *builder, ::VCExpr q,
   int pid = fork();
   if (pid == -1) {
     fprintf(stderr, "ERROR: fork failed (for STP)");
+    switch(errno) {
+        case EAGAIN: fprintf(stderr, "ERROR: EAGAIN, RLIMIT_NPROC encountered or not enough memory for page tables and task structure."); break;
+        case ENOMEM: fprintf(stderr, "ERROR: ENOMEM, Can not allocate memory.");
+        case ENOSYS: fprintf(stderr, "ERROR: ENOSYS, fork() is not supported on this platform.");
+    }
     if (!IgnoreSolverFailures)
       exit(1);
     return SolverImpl::SOLVER_RUN_STATUS_FORK_FAILED;

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -232,8 +232,8 @@ runAndGetCexForked(::VC vc, STPBuilder *builder, ::VCExpr q,
     fprintf(stderr, "ERROR: fork failed (for STP)");
     switch(errno) {
         case EAGAIN: fprintf(stderr, "ERROR: EAGAIN, RLIMIT_NPROC encountered or not enough memory for page tables and task structure."); break;
-        case ENOMEM: fprintf(stderr, "ERROR: ENOMEM, Can not allocate memory.");
-        case ENOSYS: fprintf(stderr, "ERROR: ENOSYS, fork() is not supported on this platform.");
+        case ENOMEM: fprintf(stderr, "ERROR: ENOMEM, Can not allocate memory."); break;
+        case ENOSYS: fprintf(stderr, "ERROR: ENOSYS, fork() is not supported on this platform."); break;
     }
     if (!IgnoreSolverFailures)
       exit(1);


### PR DESCRIPTION
hey, 

If STP can not fork, the error message is

```
ERROR: fork failed (for STP)
```

troubleshooting the problem required me to use strace in order to obtain

```
clone(child_stack=0, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, childtidptr=0x7fe...) = -1 ENOMEM (Cannot allocate memory)
```

This indicates I do not have enough RAM to fork STP. 

This pull request enables klee to print this information itself, that is, no additional tool (in my case strace) is necessary to diagnose the reason for the failed fork. 
