### PR TITLE
MemoryUsage: handle ill-designed mallinfo

### DIFF
--- a/lib/Support/MemoryUsage.cpp
+++ b/lib/Support/MemoryUsage.cpp
@@ -26,7 +26,7 @@ using namespace klee;
 
 size_t util::GetTotalMallocUsage() {
 #ifdef HAVE_GPERFTOOLS_MALLOC_EXTENSION_H
-  uint64_t value;
+  size_t value = 0;
   MallocExtension::instance()->GetNumericProperty(
       "generic.current_allocated_bytes", &value);
   return value;
@@ -36,9 +36,9 @@ size_t util::GetTotalMallocUsage() {
   // does not include mmap()'ed memory in mi.uordblks
   // but other implementations (e.g. tcmalloc) do.
 #if defined(__GLIBC__)
-  return mi.uordblks + mi.hblkhd;
+  return (size_t)(unsigned)mi.uordblks + (unsigned)mi.hblkhd;
 #else
-  return mi.uordblks;
+  return (unsigned)mi.uordblks;
 #endif
 
 #elif defined(HAVE_MALLOC_ZONE_STATISTICS) && defined(HAVE_MALLOC_MALLOC_H)


### PR DESCRIPTION
The mallinfo() interface is ill-designed. It returns 'int' as occupied
memory. This means at most 2G. This causes troubles when capping the
memory to 3G by -max-memory=3000 for example.

We cannot fix the interface, but we can at least extend the space to
4G. So cast those 'int's to 'unsigned int's to avoid sign extension.
Then do the addition on 'size_t' to count on 64bit values (on 64 bit).

Apart from that, the original 'int' + 'int' lead to overflow which is
undefined on 'signed int's in C.

Signed-off-by: Jiri Slaby <jslaby@suse.cz>