### PR TITLE
Fix to #449

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -40,6 +40,7 @@
 #include "llvm/LLVMContext.h"
 #include "llvm/Support/FileSystem.h"
 #endif
+#include "llvm/Support/Errno.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Bitcode/ReaderWriter.h"
 #include "llvm/Support/CommandLine.h"
@@ -1430,10 +1431,8 @@ int main(int argc, char **argv, char **envp) {
     if (RunInDir != "") {
       int res = chdir(RunInDir.c_str());
       if (res < 0) {
-        char info[128];
-        char *str = strerror_r(errno, info, sizeof(info));
         klee_error("Unable to change directory to: %s - %s", RunInDir.c_str(),
-                   str);
+                   sys::StrError(errno).c_str());
       }
     }
 
@@ -1495,10 +1494,8 @@ int main(int argc, char **argv, char **envp) {
     if (RunInDir != "") {
       int res = chdir(RunInDir.c_str());
       if (res < 0) {
-        char info[128];
-        char *str = strerror_r(errno, info, sizeof(info));
         klee_error("Unable to change directory to: %s - %s", RunInDir.c_str(),
-                   str);
+                   sys::StrError(errno).c_str());
       }
     }
     interpreter->runFunctionAsMain(mainFn, pArgc, pArgv, pEnvp);


### PR DESCRIPTION
Use LLVM-based functions to print errno. Compiles on both LLVM 3.4 and LLVM 2.9.
Thanks to @MartinNowack 