### PR TITLE
Fix to PTree pointer use-after-delete

### DIFF
--- a/lib/Core/PTree.cpp
+++ b/lib/Core/PTree.cpp
@@ -37,7 +37,6 @@ void PTree::remove(Node *n) {
   assert(!n->left && !n->right);
   do {
     Node *p = n->parent;
-    delete n;
     if (p) {
       if (n == p->left) {
         p->left = 0;
@@ -46,6 +45,7 @@ void PTree::remove(Node *n) {
         p->right = 0;
       }
     }
+    delete n;
     n = p;
   } while (n && !n->left && !n->right);
 }


### PR DESCRIPTION
In PTree::remove we delete the memory pointed by `n` at line 40 but then we use the same pointer inside the `if` at lines 41 and 45. As far as I know this is undefined behavior.