### PR TITLE
[Klee Web] Link libkleeRuntest library to fix coverage report

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,4 +136,7 @@ RUN echo 'export PATH=$PATH:'${BUILD_DIR}'/klee/Release+Asserts/bin' >> /home/kl
 # Link klee to /usr/bin so that it can be used by docker run
 USER root
 RUN for exec in ${BUILD_DIR}/klee/Release+Asserts/bin/* ; do ln -s ${exec} /usr/bin/`basename ${exec}`; done
+
+# Link klee to the libkleeRuntest library needed by docker run
+RUN ln -s ${BUILD_DIR}/klee/Release+Asserts/lib/libkleeRuntest.so /usr/lib/libkleeRuntest.so.1.0
 USER klee


### PR DESCRIPTION
This is a suggested fix to #461 in order to let Klee Web run the coverage report.