### PR TITLE
Try to unbreak the TravisCI and Docker builds.

### DIFF
--- a/.travis/testing-utils.sh
+++ b/.travis/testing-utils.sh
@@ -4,9 +4,9 @@ set -e
 
 if [ "${LLVM_VERSION}" != "2.9" ]; then
     # Using LLVM3.4 all we need is vanilla GoogleTest :)
-    wget https://googletest.googlecode.com/files/gtest-1.7.0.zip
-    unzip gtest-1.7.0.zip
-    cd gtest-1.7.0/
+    wget https://github.com/google/googletest/archive/release-1.7.0.zip
+    unzip release-1.7.0.zip
+    cd googletest-release-1.7.0/
     cmake .
     make
     # Normally I wouldn't do something like this but hey we're running on a temporary virtual machine, so who cares?


### PR DESCRIPTION
GTest has moved from googlecode to GitHub so update URL and directory
name used in source archive as appropriate.