### PR TITLE
Handle null pointer case for klee_get_obj_size()

### DIFF
--- a/lib/Core/AddressSpace.cpp
+++ b/lib/Core/AddressSpace.cpp
@@ -54,6 +54,7 @@ ObjectState *AddressSpace::getWriteable(const MemoryObject *mo,
 bool AddressSpace::resolveOne(const ref<ConstantExpr> &addr, 
                               ObjectPair &result) {
   uint64_t address = addr->getZExtValue();
+  assert(address && "Cannot resolve null address to object.");
   MemoryObject hack(address);
 
   if (const MemoryMap::value_type *res = objects.lookup_previous(&hack)) {


### PR DESCRIPTION
Return 0 in case a null pointer is provided as an argument for
klee_get_obj_size().
