### PR TITLE
Makefile: use proper shared libs

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -919,14 +919,14 @@ $(LLVM_CONFIG):
 $(ToolDir)/$(strip $(TOOLNAME))$(EXEEXT): $(LLVM_CONFIG)
 
 ifeq ($(ENABLE_SHARED), 1)
+LLVMLibsOptions += -L $(LLVMSharedLibDir)
+
 # We can take the "auto-import" feature to get rid of using dllimport.
 ifeq ($(HOST_OS), $(filter $(HOST_OS), Cygwin MingW))
 LLVMLibsOptions += -Wl,--enable-auto-import,--enable-runtime-pseudo-reloc \
                    -L $(SharedLibDir)
 endif
-LLVMLibsOptions += -lLLVM-$(LLVMVersion)
-LLVMLibsPaths += $(LLVMSharedLibDir)/$(SharedPrefix)LLVM-$(LLVMVersion)$(SHLIBEXT)
-else
+endif
 
 ifndef NO_LLVM_CONFIG
 LLVMConfigLibs := $(shell $(LLVM_CONFIG) --libs $(LINK_COMPONENTS) || echo Error)
@@ -941,7 +941,6 @@ endif
 LLVMLibsPaths += $(LLVM_CONFIG) $(LLVMConfigLibfiles)
 endif
 
-endif
 endif
 endif
 


### PR DESCRIPTION
There is nothing like libLLVM-<version>.so in current LLVM versions.
So the build fails with:
make[2]: **\* No rule to make target '/opt/llvm-3.4.2/klee/build/RelWithDebInfo/lib/libLLVM-3.4.2.so', needed by '/home/abuild/rpmbuild/BUILD/klee-20160926/Release+Asserts/bin/kleaver'.
Stop.

To fix this, use the same library names as in the static libs case.

Signed-off-by: Jiri Slaby jslaby@suse.cz
