### PR TITLE
Generate better .path files

### DIFF
--- a/include/klee/Internal/ADT/TreeStream.h
+++ b/include/klee/Internal/ADT/TreeStream.h
@@ -18,6 +18,19 @@ namespace klee {
   typedef unsigned TreeStreamID;
   class TreeOStream;
 
+  struct PathLocation {
+    char branch;
+    std::string file;
+    unsigned int line;
+
+    PathLocation() : branch(0), file(""), line(0) { }
+
+    PathLocation(char branch, std::string file, unsigned int line) :
+            branch(branch), file(file), line(line) { }
+
+    PathLocation(std::ifstream &is, size_t &size);
+  };
+
   class TreeStreamWriter {
     static const unsigned bufferSize = 4*4096;
 
@@ -47,7 +60,7 @@ namespace klee {
 
     // hack, to be replace by proper stream capabilities
     void readStream(TreeStreamID id,
-                    std::vector<unsigned char> &out);
+                    std::vector<PathLocation> &out);
   };
 
   class TreeOStream {

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -785,6 +785,28 @@ void Executor::branch(ExecutionState &state,
       addConstraint(*result[i], conditions[i]);
 }
 
+std::string Executor::getPathInfo(const ExecutionState &state, bool trueBranch)
+{
+  const llvm::BranchInst *branch =
+          dyn_cast<llvm::BranchInst>(state.prevPC->inst);
+  const llvm::Instruction *succ =
+          branch->getSuccessor(trueBranch ? 0 : 1)->getFirstNonPHI();
+
+  const InstructionInfo &ii = kmodule->infos->getInfo(succ);
+  const std::string &file = ii.file;
+  unsigned int fsize = file.size();
+  unsigned int line = ii.line;
+  std::stringstream ss;
+
+  ss << (trueBranch ? '1' : '0');
+
+  ss.write(reinterpret_cast<char*>(&fsize), sizeof(unsigned int));
+  ss << file;
+  ss.write(reinterpret_cast<char*>(&line), sizeof(unsigned int));
+
+  return ss.str();
+}
+
 Executor::StatePair 
 Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
   Solver::Validity res;
@@ -921,7 +943,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
   if (res==Solver::True) {
     if (!isInternal) {
       if (pathWriter) {
-        current.pathOS << "1";
+        current.pathOS << getPathInfo(current, true);
       }
     }
 
@@ -929,7 +951,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
   } else if (res==Solver::False) {
     if (!isInternal) {
       if (pathWriter) {
-        current.pathOS << "0";
+        current.pathOS << getPathInfo(current, false);
       }
     }
 
@@ -988,15 +1010,15 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
       // is used for both falseState and trueState.
       falseState->pathOS = pathWriter->open(current.pathOS);
       if (!isInternal) {
-        trueState->pathOS << "1";
-        falseState->pathOS << "0";
+        trueState->pathOS << getPathInfo(current, true);
+        falseState->pathOS << getPathInfo(current, false);
       }
     }
     if (symPathWriter) {
       falseState->symPathOS = symPathWriter->open(current.symPathOS);
       if (!isInternal) {
-        trueState->symPathOS << "1";
-        falseState->symPathOS << "0";
+        trueState->symPathOS << getPathInfo(current, true);
+        falseState->symPathOS << getPathInfo(current, false);
       }
     }
 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -434,6 +434,8 @@ private:
   void printDebugInstructions(ExecutionState &state);
   void doDumpStates();
 
+  std::string getPathInfo(const ExecutionState &state, bool trueBranch);
+
 public:
   Executor(llvm::LLVMContext &ctx, const InterpreterOptions &opts,
       InterpreterHandler *ie);

--- a/lib/Support/TreeStream.cpp
+++ b/lib/Support/TreeStream.cpp
@@ -25,6 +25,22 @@ using namespace klee;
 
 ///
 
+PathLocation::PathLocation(std::ifstream &is, size_t &size) {
+  this->branch = is.get();
+
+  unsigned fsize, line;
+  is.read(reinterpret_cast<char*>(&fsize), 4);
+  char *file = new char[fsize];
+  is.read(file, fsize);
+  this->file = std::string(file, fsize);
+  delete[] file;
+
+  is.read(reinterpret_cast<char*>(&line), 4);
+  this->line = line;
+
+  size = 1 + 4 + fsize + 4;
+}
+
 TreeStreamWriter::TreeStreamWriter(const std::string &_path) 
   : lastID(0),
     bufferCount(0),
@@ -101,7 +117,7 @@ void TreeStreamWriter::flush() {
 }
 
 void TreeStreamWriter::readStream(TreeStreamID streamID,
-                                  std::vector<unsigned char> &out) {
+                                  std::vector<PathLocation> &out) {
   assert(streamID>0 && streamID<ids);
   flush();
   
@@ -159,7 +175,11 @@ void TreeStreamWriter::readStream(TreeStreamID streamID,
     } else {
       unsigned size = tag;
       if (id==roots.back()) {
-        while (size--) out.push_back(is.get());
+        while (size) {
+          size_t sz;
+          out.push_back(PathLocation(is, sz));
+          size -= sz;
+        }
       } else {
         while (size--) is.get();
       }


### PR DESCRIPTION
We need witnesses for the upcoming SV-COMP. For that purpose we need to know the path through the source file. I.e. sequence of code lines how to get to an erroneous location. I implemented it though the generated .path files. Instead of emitting only a number 0/1 (false branch/true branch), I also put there file name and line number.

I guess this won't be merged as-is. Rather I would like to hear some feedback how you prefer to do it?
