### PR TITLE
configure: add option to disable timestamping

### DIFF
--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -382,6 +382,19 @@ AC_SUBST(KLEE_BITCODE_C_COMPILER,$klee_llvm_bc_c_compiler)
 AC_SUBST(KLEE_BITCODE_CXX_COMPILER,$klee_llvm_bc_cxx_compiler)
 
 dnl **************************************************************************
+dnl User option to disable timestamping.
+
+AC_ARG_ENABLE([timestamp],AS_HELP_STRING([--enable-timestamp],
+	[Enable timestamping the source code while building. (default=disabled)]))
+
+if test "x${enable_timestamp}" = "xyes" ; then
+  AC_DEFINE(KLEE_ENABLE_TIMESTAMP,[1],[Enable time stamping the sources])
+  AC_MSG_NOTICE([Source timestamping enabled.])
+else
+  AC_MSG_NOTICE([Source timestamping disabled.])
+fi
+
+dnl **************************************************************************
 dnl User option to enable uClibc support.
 
 AC_ARG_WITH(uclibc,

--- a/configure
+++ b/configure
@@ -735,6 +735,7 @@ enable_cxx11
 with_llvm_build_mode
 with_llvmcc
 with_llvmcxx
+enable_timestamp
 with_uclibc
 enable_posix_runtime
 with_runtime
@@ -1373,6 +1374,8 @@ Optional Features:
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-cxx11          Build using C++11
+  --enable-timestamp      Enable timestamping the source code while building.
+                          (default=disabled)
   --enable-posix-runtime  Enable the POSIX runtime
 
 Optional Packages:
@@ -3994,6 +3997,24 @@ KLEE_BITCODE_C_COMPILER=$klee_llvm_bc_c_compiler
 
 KLEE_BITCODE_CXX_COMPILER=$klee_llvm_bc_cxx_compiler
 
+
+
+# Check whether --enable-timestamp was given.
+if test "${enable_timestamp+set}" = set; then :
+  enableval=$enable_timestamp;
+fi
+
+
+if test "x${enable_timestamp}" = "xyes" ; then
+
+$as_echo "#define KLEE_ENABLE_TIMESTAMP 1" >>confdefs.h
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: Source timestamping enabled." >&5
+$as_echo "$as_me: Source timestamping enabled." >&6;}
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: Source timestamping disabled." >&5
+$as_echo "$as_me: Source timestamping disabled." >&6;}
+fi
 
 
 

--- a/include/klee/Config/config.h.in
+++ b/include/klee/Config/config.h.in
@@ -72,6 +72,9 @@
 /* Define to 1 if you have the <zlib.h> header file. */
 #undef HAVE_ZLIB_H
 
+/* Enable time stamping the sources */
+#undef KLEE_ENABLE_TIMESTAMP
+
 /* Define to empty or 'const' depending on how SELinux qualifies its security
    context parameters. */
 #undef KLEE_SELINUX_CTX_CONST

--- a/lib/Support/PrintVersion.cpp
+++ b/lib/Support/PrintVersion.cpp
@@ -17,7 +17,9 @@
 void klee::printVersion()
 {
   llvm::outs() << PACKAGE_STRING " (" PACKAGE_URL ")\n";
+#ifdef KLEE_ENABLE_TIMESTAMP
   llvm::outs() << "  Built " __DATE__ " (" __TIME__ ")\n";
+#endif
   llvm::outs() << "  Build mode: " << KLEE_BUILD_MODE "\n";
   llvm::outs() << "  Build revision: ";
 #ifdef KLEE_BUILD_REVISION


### PR DESCRIPTION
    It is pain for build systems to see __DATE__ or __TIME__ in sources as
    the build is not reproducible. So add an option to disable time
    stamping the sources.