### PR TITLE
Support for musl library

### DIFF
--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -824,9 +824,14 @@ int __fd_getdents(unsigned int fd, struct dirent64 *dirp, unsigned int count) {
     errno = EINVAL;
     return -1;
   } else {
-    // Calculate the maximum size of symbolic entries we need to pad
-    // in between
-    uint64_t sfiles_entry_size = __exe_fs.n_sym_files * sizeof(*dirp);
+    /* Check if the result buffer is too small */
+    if (count < sizeof(*dirp)) {
+      errno = EINVAL;
+      return -1;
+    }
+    /* Calculate the maximum size of symbolic entries we need to pad
+       in between */
+    uint64_t sfiles_entry_size = (__exe_fs.n_sym_files + 1) * sizeof(*dirp);
     if ((unsigned long) f->off < sfiles_entry_size) {
       /* Return our dirents */
       off64_t i, pad, bytes=0;

--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -844,6 +844,10 @@ int __fd_getdents(unsigned int fd, struct dirent64 *dirp, unsigned int count) {
         return -1;
       } 
       for (; i<__exe_fs.n_sym_files; ++i) {
+        /* Check if we still have space for that entry in the buffer */
+        if (bytes + sizeof(*dirp) > count)
+          return bytes;
+
         exe_disk_file_t *df = &__exe_fs.sym_files[i];
         dirp->d_ino = df->stat->st_ino;
         dirp->d_reclen = sizeof(*dirp);
@@ -854,7 +858,10 @@ int __fd_getdents(unsigned int fd, struct dirent64 *dirp, unsigned int count) {
         bytes += dirp->d_reclen;
         ++dirp;
       }
-      
+      /* Check if we still have space for that entry in the buffer */
+      if (bytes + sizeof(*dirp) > count)
+        return bytes;
+
       /* Fake jump to OS records by a "deleted" file. */
       pad = count>=sfiles_entry_size ? sfiles_entry_size : count;
       dirp->d_ino = 0;


### PR DESCRIPTION
Initial support for executing KLEE using musl library.
Similar to uclibc (`--libc=uclib`), use `--libc=musllibc`.

To be able to use it, put a link to the musllibc bc file into your `Release+Asserts/lib` directory.
This will be automated soon.

@mdimjasevic This should get you going. Please try it out.
If you see any issues, let me know.
