### PR TITLE
Fix BFS searcher

### DIFF
--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -141,6 +141,9 @@ public:
   /// @brief Set of used array names for this state.  Used to avoid collisions.
   std::set<std::string> arrayNames;
 
+  /// @brief Flag if constraints were added recently
+  bool constraintsAdded;
+
   std::string getFnAlias(std::string fn);
   void addFnAlias(std::string old_fn, std::string new_fn);
   void removeFnAlias(std::string fn);
@@ -165,7 +168,10 @@ public:
   void popFrame();
 
   void addSymbolic(const MemoryObject *mo, const Array *array);
-  void addConstraint(ref<Expr> e) { constraints.addConstraint(e); }
+  void addConstraint(ref<Expr> e) {
+    constraints.addConstraint(e);
+    constraintsAdded = true;
+  }
 
   bool merge(const ExecutionState &b);
   void dumpStack(llvm::raw_ostream &out) const;

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -66,18 +66,13 @@ StackFrame::~StackFrame() {
 
 /***/
 
-ExecutionState::ExecutionState(KFunction *kf) :
-    pc(kf->instructions),
-    prevPC(pc),
+ExecutionState::ExecutionState(KFunction *kf)
+    : pc(kf->instructions), prevPC(pc),
 
-    queryCost(0.), 
-    weight(1),
-    depth(0),
+      queryCost(0.), weight(1), depth(0),
 
-    instsSinceCovNew(0),
-    coveredNew(false),
-    forkDisabled(false),
-    ptreeNode(0) {
+      instsSinceCovNew(0), coveredNew(false), forkDisabled(false), ptreeNode(0),
+      constraintsAdded(false) {
   pushFrame(0, kf);
 }
 
@@ -97,31 +92,20 @@ ExecutionState::~ExecutionState() {
   while (!stack.empty()) popFrame();
 }
 
-ExecutionState::ExecutionState(const ExecutionState& state):
-    fnAliases(state.fnAliases),
-    pc(state.pc),
-    prevPC(state.prevPC),
-    stack(state.stack),
-    incomingBBIndex(state.incomingBBIndex),
+ExecutionState::ExecutionState(const ExecutionState &state)
+    : fnAliases(state.fnAliases), pc(state.pc), prevPC(state.prevPC),
+      stack(state.stack), incomingBBIndex(state.incomingBBIndex),
 
-    addressSpace(state.addressSpace),
-    constraints(state.constraints),
+      addressSpace(state.addressSpace), constraints(state.constraints),
 
-    queryCost(state.queryCost),
-    weight(state.weight),
-    depth(state.depth),
+      queryCost(state.queryCost), weight(state.weight), depth(state.depth),
 
-    pathOS(state.pathOS),
-    symPathOS(state.symPathOS),
+      pathOS(state.pathOS), symPathOS(state.symPathOS),
 
-    instsSinceCovNew(state.instsSinceCovNew),
-    coveredNew(state.coveredNew),
-    forkDisabled(state.forkDisabled),
-    coveredLines(state.coveredLines),
-    ptreeNode(state.ptreeNode),
-    symbolics(state.symbolics),
-    arrayNames(state.arrayNames)
-{
+      instsSinceCovNew(state.instsSinceCovNew), coveredNew(state.coveredNew),
+      forkDisabled(state.forkDisabled), coveredLines(state.coveredLines),
+      ptreeNode(state.ptreeNode), symbolics(state.symbolics),
+      arrayNames(state.arrayNames), constraintsAdded(state.constraintsAdded) {
   for (unsigned int i=0; i<symbolics.size(); i++)
     symbolics[i].first->refCount++;
 }

--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -104,6 +104,22 @@ ExecutionState &BFSSearcher::selectState() {
 void BFSSearcher::update(ExecutionState *current,
                          const std::vector<ExecutionState *> &addedStates,
                          const std::vector<ExecutionState *> &removedStates) {
+  // If constraints were added to the current state, it evolved.
+  // Therefore, add this state to the end if it should not be deleted.
+  if (current && current->constraintsAdded &&
+      std::find(removedStates.begin(), removedStates.end(), current) ==
+          removedStates.end()) {
+    assert(states.front() == current);
+    states.pop_front();
+    states.push_back(current);
+    current->constraintsAdded = false;
+  }
+
+  for (std::vector<ExecutionState *>::const_iterator it = addedStates.begin(),
+                                                     itE = addedStates.end();
+       it != itE; ++it)
+    (*it)->constraintsAdded = false;
+
   states.insert(states.end(),
                 addedStates.begin(),
                 addedStates.end());

--- a/test/Feature/BFSSearcher.c
+++ b/test/Feature/BFSSearcher.c
@@ -1,0 +1,22 @@
+// RUN: %llvmgcc %s -emit-llvm -g -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --stop-after-n-instructions=500 --search=bfs %t1.bc 2>%t2.log
+// RUN: FileCheck -input-file=%t2.log %s
+#include "assert.h"
+#include "klee/klee.h"
+
+int nd() {
+  int r;
+  klee_make_symbolic(&r, sizeof(r), "r");
+  return r;
+}
+
+int main() {
+  int x = 1;
+  while (nd() != 0) {
+    x *= 2;
+  }
+  // CHECK: ASSERTION FAIL
+  klee_assert(0);
+  return x;
+}

--- a/test/Feature/BFSSearcher2.c
+++ b/test/Feature/BFSSearcher2.c
@@ -1,0 +1,26 @@
+// RUN: %llvmgcc %s -emit-llvm -g -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --stop-after-n-instructions=500 --search=bfs %t1.bc 2>%t2.log
+// RUN: FileCheck -input-file=%t2.log %s
+#include "klee/klee.h"
+unsigned int nd() {
+  unsigned int r;
+  klee_make_symbolic(&r, sizeof(r), "r");
+  return r;
+}
+
+int main() {
+  unsigned int x = 1;
+  unsigned int y = nd();
+  klee_assume(y > 0);
+  while (x < y) {
+    if (x < y / x) {
+      x *= x;
+    } else {
+      x++;
+    }
+  }
+  // CHECK: ASSERTION FAIL
+  klee_assert(x != y);
+  return x;
+}


### PR DESCRIPTION
For performance reasons, if KLEE branches, one state is reused
and it is progressed by adding new constraints.
Make sure both new states end up at the end of the BFS searcher queue.

Fixes #486 