### PR TITLE
add nicer error messages for --use-merge and add explanation why it currently cannot be used with random-path

### DIFF
--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -402,6 +402,8 @@ Instruction *MergingSearcher::getMergePoint(ExecutionState &es) {
 }
 
 ExecutionState &MergingSearcher::selectState() {
+  // FIXME: this loop is endless if baseSearcher includes RandomPathSearcher.
+  // The reason is that RandomPathSearcher::removeState() does nothing...
   while (!baseSearcher->empty()) {
     ExecutionState &es = baseSearcher->selectState();
     if (getMergePoint(es)) {

--- a/lib/Core/UserSearcher.cpp
+++ b/lib/Core/UserSearcher.cpp
@@ -117,8 +117,12 @@ Searcher *klee::constructUserSearcher(Executor &executor) {
 
   // merge support is experimental
   if (UseMerge) {
-    assert(!UseBumpMerge);
-    assert(std::find(CoreSearch.begin(), CoreSearch.end(), Searcher::RandomPath) == CoreSearch.end()); // XXX: needs further debugging: test/Features/Searchers.c fails with this searcher
+    if (UseBumpMerge)
+      klee_error("use-merge and use-bump-merge cannot be used together");
+    // RandomPathSearcher cannot be used in conjunction with MergingSearcher,
+    // see MergingSearcher::selectState() for explanation.
+    if (std::find(CoreSearch.begin(), CoreSearch.end(), Searcher::RandomPath) != CoreSearch.end())
+      klee_error("use-merge currently does not support random-path, please use another search strategy");
     searcher = new MergingSearcher(executor, searcher);
   } else if (UseBumpMerge) {
     searcher = new BumpMergingSearcher(executor, searcher);


### PR DESCRIPTION
This prevents `klee --use-merge` to crash on an assertion (https://github.com/klee/klee/blob/e853f0bceeb7099acc3df16e52a3cfd1dabad422/lib/Core/UserSearcher.cpp#L121). The PR also adds an explanation why RandomPathSearcher does not work with MergingSearcher.