### PR TITLE
[cmake] Build with newer JIT (for LLVM >= 3.6)

### DIFF
--- a/tools/klee/CMakeLists.txt
+++ b/tools/klee/CMakeLists.txt
@@ -15,12 +15,17 @@ add_executable(klee
 set(LLVM_COMPONENTS
 	bitreader
 	bitwriter
-	engine
 	ipo
-	jit
 	linker
 	support
 )
+
+if ("${LLVM_PACKAGE_VERSION}" VERSION_EQUAL "3.6" OR
+    "${LLVM_PACKAGE_VERSION}" VERSION_GREATER "3.6")
+  list(APPEND LLVM_COMPONENTS mcjit executionengine native)
+else()
+  list(APPEND LLVM_COMPONENTS jit engine)
+endif()
 
 if ("${LLVM_PACKAGE_VERSION}" VERSION_EQUAL "3.3" OR
     "${LLVM_PACKAGE_VERSION}" VERSION_GREATER "3.3")


### PR DESCRIPTION
Links in the correct LLVM libraries when using the MCJIT. This has no effect for LLVM versions less than 3.6. This is mean to make the work done by @rtrembecky in PR #385 compatible with the new CMake build system.