### PR TITLE
[CMake] Remove unneeded dependency declarations for the unit tests.

### DIFF
--- a/unittests/Assignment/CMakeLists.txt
+++ b/unittests/Assignment/CMakeLists.txt
@@ -1,4 +1,3 @@
 add_klee_unit_test(AssignmentTest
   AssignmentTest.cpp)
-klee_get_llvm_libs(LLVM_LIBS Support)
-target_link_libraries(AssignmentTest PRIVATE kleaverExpr ${LLVM_LIBS})
+target_link_libraries(AssignmentTest PRIVATE kleaverExpr)

--- a/unittests/Expr/CMakeLists.txt
+++ b/unittests/Expr/CMakeLists.txt
@@ -1,6 +1,3 @@
 add_klee_unit_test(ExprTest
   ExprTest.cpp)
-# FIXME: KLEE's libraries should just declare what libraries
-# they depend on so we don't need to manually link.
-klee_get_llvm_libs(LLVM_LIBS Support)
-target_link_libraries(ExprTest PRIVATE kleaverExpr ${LLVM_LIBS})
+target_link_libraries(ExprTest PRIVATE kleaverExpr)

--- a/unittests/Ref/CMakeLists.txt
+++ b/unittests/Ref/CMakeLists.txt
@@ -1,6 +1,3 @@
 add_klee_unit_test(RefTest
   RefTest.cpp)
-# FIXME: KLEE's libraries should just declare what libraries
-# they depend on so we don't need to manually link.
-klee_get_llvm_libs(LLVM_LIBS Support)
-target_link_libraries(RefTest PRIVATE kleaverExpr ${LLVM_LIBS})
+target_link_libraries(RefTest PRIVATE kleaverExpr)

--- a/unittests/Solver/CMakeLists.txt
+++ b/unittests/Solver/CMakeLists.txt
@@ -1,12 +1,3 @@
 add_klee_unit_test(SolverTest
   SolverTest.cpp)
-# FIXME: KLEE's libraries should just declare what libraries
-# they depend on so we don't need to manually link.
-klee_get_llvm_libs(LLVM_LIBS Support)
-target_link_libraries(SolverTest
-  PRIVATE
-  kleaverSolver
-  kleaverExpr
-  kleeSupport
-  kleeBasic
-  ${LLVM_LIBS})
+target_link_libraries(SolverTest PRIVATE kleaverSolver)


### PR DESCRIPTION
Remove unneeded dependency declarations for the unit tests.

These were changes that I forgot to make in
dda296e09ee53ed85ccf1c3f08e7e809adce612e .