### PR TITLE
[CMake] Fix legacy build system files in source tree interfering with CMake build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,39 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 endif()
 
 ################################################################################
+# Sanity Check: Check for in source build of the old build system.
+# Some build files from the old build system could interfere with our build.
+################################################################################
+set(KLEE_OLD_BUILD_SYSTEM_FILES
+  "include/klee/Config/config.h"
+  "test/lit.site.cfg"
+)
+foreach (legacy_file ${KLEE_OLD_BUILD_SYSTEM_FILES})
+  if (EXISTS "${CMAKE_SOURCE_DIR}/${legacy_file}")
+    if (EXISTS "${CMAKE_SOURCE_DIR}/.git")
+      set(CLEAN_SRC_DIR_INSTRUCTIONS
+        "The KLEE source tree apears to be a git repository so you can run"
+        " \"git clean -dxn\" to see what files aren't part of the repo and then"
+        " run \"git clean -fdx\" to remove them."
+      )
+    else()
+      # This is the only reliable way to fix this.
+      set(CLEAN_SRC_DIR_INSTRUCTIONS
+        "The KLEE source tree doesn't appear to be a git repository so you will"
+        " need to download a fresh copy of KLEE's source code."
+      )
+    endif()
+    message(FATAL_ERROR "\"${CMAKE_SOURCE_DIR}/${legacy_file}\""
+      " exists in KLEE's source tree. It is likely that the Autoconf/Makefile"
+      " build system was configured to do an in-source build in KLEE's source"
+      " tree. This could cause problems with the CMake build. "
+      ${CLEAN_SRC_DIR_INSTRUCTIONS}
+      " You can then run cmake again."
+    )
+  endif()
+endforeach()
+
+################################################################################
 # Build type
 ################################################################################
 message(STATUS "CMake generator: ${CMAKE_GENERATOR}")
@@ -605,8 +638,8 @@ configure_file(${CMAKE_SOURCE_DIR}/include/klee/Config/CompileTimeInfo.h.cmin
 ################################################################################
 # Global include directories
 ################################################################################
-include_directories("${CMAKE_SOURCE_DIR}/include")
 include_directories("${CMAKE_BINARY_DIR}/include")
+include_directories("${CMAKE_SOURCE_DIR}/include")
 
 ################################################################################
 # Set default location for targets in the build directory


### PR DESCRIPTION
[CMake] Fix legacy build system files in source tree interfering
with CMake build.

We now raise a fatal error if we detect certain files in the source
tree. This is a heuristic but it's good enough for now.

The order of includes has also been changed so that the build tree
include directory has priority over the source tree include directory so
that even if the added check was missing the right header file (i.e.
`${CMAKE_BINARY_DIR}/include/klee/Config/config.h` would be picked up at
build time.
