### PR TITLE
Remove option --randomize-fork.  If someone needs this, the right way…

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -119,12 +119,7 @@ namespace {
   DumpStatesOnHalt("dump-states-on-halt",
                    cl::init(true),
 		   cl::desc("Dump test cases for all active states on exit (default=on)"));
- 
-  cl::opt<bool>
-  RandomizeFork("randomize-fork",
-                cl::init(false),
-		cl::desc("Randomly swap the true and false states on a fork (default=off)"));
- 
+  
   cl::opt<bool>
   AllowExternalSymCalls("allow-external-sym-calls",
                         cl::init(false),
@@ -922,9 +917,6 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
 
     falseState = trueState->branch();
     addedStates.push_back(falseState);
-
-    if (RandomizeFork && theRNG.getBool())
-      std::swap(trueState, falseState);
 
     if (it != seedMap.end()) {
       std::vector<SeedInfo> seeds = it->second;


### PR DESCRIPTION
… is to implement it in the solver.  This was discussed in https://github.com/klee/klee/pull/214
