### PR TITLE
[CMake] Implement install of the kleeRuntest target.

### DIFF
--- a/runtime/Runtest/CMakeLists.txt
+++ b/runtime/Runtest/CMakeLists.txt
@@ -20,3 +20,6 @@ set_target_properties(kleeRuntest
     VERSION ${KLEE_RUNTEST_VERSION}
     SOVERSION ${KLEE_RUNTEST_VERSION}
 )
+
+install(TARGETS kleeRuntest
+  DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")


### PR DESCRIPTION
[CMake] Implement install of the kleeRuntest target.

Required to fix #480 