### PR TITLE
[CMake] Fix the build when `-DBUILD_SHARED_LIBS=ON` is passed.

### DIFF
--- a/cmake/klee_add_component.cmake
+++ b/cmake/klee_add_component.cmake
@@ -8,7 +8,9 @@
 #===------------------------------------------------------------------------===#
 
 function(klee_add_component target_name)
-  add_library(${target_name} ${ARGN})
+  # Components are explicitly STATIC because we don't support building them
+  # as shared libraries.
+  add_library(${target_name} STATIC ${ARGN})
   # Use of `PUBLIC` means these will propagate to targets that use this component.
   if (("${CMAKE_VERSION}" VERSION_EQUAL "3.3") OR ("${CMAKE_VERSION}" VERSION_GREATER "3.3"))
     # In newer CMakes we can make sure that the flags are only used when compiling C++


### PR DESCRIPTION
This fixes issue #507.

We can't build the components as shared libraries right now due
to cyclic dependencies (see #502 for a fix) and there are a few
other patches needed too (see #507).

Building the components as shared libraries isn't really desirable
anyway because it would require us to ship KLEE's libraries which
don't have a stable API.