### PR TITLE
[CMake] Add missing dependencies reported in #507.

### DIFF
--- a/cmake/find_llvm.cmake
+++ b/cmake/find_llvm.cmake
@@ -149,7 +149,14 @@ else()
     string_to_list("${_llvm_libs}" _llvm_libs_list)
 
     # Now find the system libs that are needed.
-    _run_llvm_config(_system_libs "--ldflags")
+    if (${LLVM_PACKAGE_VERSION} VERSION_LESS "3.5")
+      # For LLVM 3.4 and older system libraries
+      # appeared in the output of `--ldflags`.
+      _run_llvm_config(_system_libs "--ldflags")
+      # TODO: Filter out `-L<path>` flag.
+    else()
+      _run_llvm_config(_system_libs "--system-libs")
+    endif()
     string_to_list("${_system_libs}" _system_libs_list)
 
     # Create an imported target for each LLVM library

--- a/lib/Module/CMakeLists.txt
+++ b/lib/Module/CMakeLists.txt
@@ -22,6 +22,7 @@ klee_add_component(kleeModule
 set(LLVM_COMPONENTS
   bitreader
   bitwriter
+  codegen
   ipo
   linker
   support

--- a/lib/Module/CMakeLists.txt
+++ b/lib/Module/CMakeLists.txt
@@ -33,3 +33,11 @@ if ("${LLVM_PACKAGE_VERSION}" VERSION_EQUAL "3.3" OR
 endif()
 klee_get_llvm_libs(LLVM_LIBS ${LLVM_COMPONENTS})
 target_link_libraries(kleeModule PUBLIC ${LLVM_LIBS})
+target_link_libraries(kleeModule PRIVATE
+  kleeSupport
+  # FIXME:
+  # There is a circular dependency between `kleeModule` and `kleeCore`.
+  # `ModuleUtil.cpp` uses `klee::SpecialFunctionHandler` (in `kleeCore`) but
+  # `kleeCore` uses `kleeModule`.
+  kleeCore
+)


### PR DESCRIPTION
This has shown that there is another circular dependency
(added by me! sigh...) between `kleeCore` and `kleeModule`.