### PR TITLE
Fix assertion failure when klee::getDirectCallTarget() is used on call to bitcasted weak alias

### DIFF
--- a/include/klee/Internal/Support/ModuleUtil.h
+++ b/include/klee/Internal/Support/ModuleUtil.h
@@ -29,7 +29,11 @@ namespace klee {
   /// null if it cannot be determined (should be only for indirect
   /// calls, although complicated constant expressions might be
   /// another possibility).
-  llvm::Function *getDirectCallTarget(llvm::CallSite);
+  ///
+  /// If `moduleIsFullyLinked` is set to true it will be assumed that the
+  //  module containing the `llvm::CallSite` is fully linked. This assumption
+  //  allows resolution of functions that are marked as overridable.
+  llvm::Function *getDirectCallTarget(llvm::CallSite, bool moduleIsFullyLinked);
 
   /// Return true iff the given Function value is used in something
   /// other than a direct call (or a constant expression that

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -167,7 +167,8 @@ static bool instructionIsCoverable(Instruction *i) {
     } else {
       Instruction *prev = --it;
       if (isa<CallInst>(prev) || isa<InvokeInst>(prev)) {
-        Function *target = getDirectCallTarget(prev);
+        Function *target =
+            getDirectCallTarget(prev, /*moduleIsFullyLinked=*/true);
         if (target && target->doesNotReturn())
           return false;
       }
@@ -690,7 +691,8 @@ void StatsTracker::computeReachableUncovered() {
               // (which should be correct anyhow).
               callTargets.insert(std::make_pair(it,
                                                 std::vector<Function*>()));
-            } else if (Function *target = getDirectCallTarget(cs)) {
+            } else if (Function *target = getDirectCallTarget(
+                           cs, /*moduleIsFullyLinked=*/true)) {
               callTargets[it].push_back(target);
             } else {
               callTargets[it] = 

--- a/test/regression/2016-11-24-bitcast-weak-alias.c
+++ b/test/regression/2016-11-24-bitcast-weak-alias.c
@@ -1,0 +1,43 @@
+// RUN: %llvmgcc %s -Wall -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out -exit-on-error -search=nurs:covnew %t.bc DUMMY_ARG >%t1.log 2>&1
+// RUN: FileCheck -input-file=%t1.log %s
+
+// This test case is designed to cover code in `klee::getDirectCallTarget(CallSite)`.
+// In particular it designed to test the case where a bitcasted function call, calls
+// a weak alias.
+struct v1 {
+  int c;
+  int d;
+};
+
+int __real_function(struct v1 *unused, struct v1 *unused2, int unused3) {
+  return 0;
+}
+
+struct v2 {
+  int e;
+  int f;
+};
+
+int alias_function(struct v1 *, struct v1 *, int)
+    __attribute__((weak, alias("__real_function")));
+
+int main(int argc, char** argv) {
+  struct v2 local = { .e= 0, .f=0 };
+  int choice = (argc == 1);
+  int number = 0;
+
+  // FIXME: Drop the guard when llvm 2.9 is dropped.
+  // Prevent actually making the call at runtime due to llvm-gcc
+  // injecting an abort if the call is made. The call is guarded
+  // in such a way that the compiler cannot remove the call.
+  if (choice) {
+    // Call via a bitcasted alias.
+    number = ((int (*)(struct v2 *, struct v2 *, int))alias_function)(
+        &local, &local, 0);
+  }
+  return number % 255;
+}
+
+// CHECK: KLEE: done: completed paths = 1


### PR DESCRIPTION
Fix assertion failure when klee::getDirectCallTarget() is used on call to bitcasted weak alias.

Test case is included.