### PR TITLE
Added `klee_posix_prefer_cex` among the external calls that we model

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -757,6 +757,7 @@ static const char *modelledExternals[] = {
   "klee_mark_global",
   "klee_merge",
   "klee_prefer_cex",
+  "klee_posix_prefer_cex",
   "klee_print_expr",
   "klee_print_range",
   "klee_report_error",


### PR DESCRIPTION
As far as I understood, `klee_posix_prefer_cex` should also be present in the `modelledExternals` array inside KLEE main file (`tools/klee/main.cpp:757`).