### PR TITLE
[CMake] Fix typo in the output of the `debugs_vars` rule in the Makefile

### DIFF
--- a/runtime/Makefile.cmake.bitcode.rules
+++ b/runtime/Makefile.cmake.bitcode.rules
@@ -154,7 +154,7 @@ debug_vars:
 	@echo "IS_RELEASE := $(IS_RELEASE)"
 	@echo "LOCAL_BUILD_DIR := $(LOCAL_BUILD_DIR)"
 	@echo "LLVMCC := $(LLVMCC)"
-	@echo "LLVMCC.Flag := $(LLVMCC.Flags)"
+	@echo "LLVMCC.Flags := $(LLVMCC.Flags)"
 	@echo "LLVMCC.Warnings := $(LLVMCC.Warnings)"
 	@echo "MODULE_FILE := $(MODULE_FILE)"
 	@echo "ROOT_OBJ := $(ROOT_OBJ)"


### PR DESCRIPTION
Fix typo in the output of the `debugs_vars` rule in the Makefile bitcode build system used by the CMake build system.