### PR TITLE
[CMake] Fix bug with enabling and then disabling TCMalloc support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,8 @@ if (ENABLE_TCMALLOC)
     message(FATAL_ERROR "Can't find \"${TCMALLOC_HEADER}\"")
   endif()
 else()
+  unset(HAVE_GPERFTOOLS_MALLOC_EXTENSION_H)
+  unset(HAVE_GPERFTOOLS_MALLOC_EXTENSION_H CACHE)
   message(STATUS "TCMalloc support disabled")
 endif()
 


### PR DESCRIPTION
[CMake] Fix bug where if KLEE was built with `ENABLE_TCMALLOC`
and then re-configured with `ENABLE_TCMALLOC` set to OFF then
`klee/Config/config.h` was not correctly re-generated.