### PR TITLE
Fix a bunch of memory bugs

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -458,17 +458,17 @@ void Executor::initializeGlobalObject(ExecutionState &state, ObjectState *os,
 #endif
   if (const ConstantVector *cp = dyn_cast<ConstantVector>(c)) {
     unsigned elementSize =
-      targetData->getTypeStoreSize(cp->getType()->getElementType());
+        targetData->getTypeAllocSize(cp->getType()->getElementType());
     for (unsigned i=0, e=cp->getNumOperands(); i != e; ++i)
-      initializeGlobalObject(state, os, cp->getOperand(i), 
-			     offset + i*elementSize);
+      initializeGlobalObject(state, os, cp->getOperand(i),
+                             offset + (i * elementSize));
   } else if (isa<ConstantAggregateZero>(c)) {
-    unsigned i, size = targetData->getTypeStoreSize(c->getType());
+    unsigned i, size = targetData->getTypeAllocSize(c->getType());
     for (i=0; i<size; i++)
       os->write8(offset+i, (uint8_t) 0);
   } else if (const ConstantArray *ca = dyn_cast<ConstantArray>(c)) {
     unsigned elementSize =
-      targetData->getTypeStoreSize(ca->getType()->getElementType());
+        targetData->getTypeAllocSize(ca->getType()->getElementType());
     for (unsigned i=0, e=ca->getNumOperands(); i != e; ++i)
       initializeGlobalObject(state, os, ca->getOperand(i), 
 			     offset + i*elementSize);
@@ -481,20 +481,18 @@ void Executor::initializeGlobalObject(ExecutionState &state, ObjectState *os,
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 1)
   } else if (const ConstantDataSequential *cds =
                dyn_cast<ConstantDataSequential>(c)) {
-    unsigned elementSize =
-      targetData->getTypeStoreSize(cds->getElementType());
+    unsigned elementSize = targetData->getTypeAllocSize(cds->getElementType());
     for (unsigned i=0, e=cds->getNumElements(); i != e; ++i)
       initializeGlobalObject(state, os, cds->getElementAsConstant(i),
                              offset + i*elementSize);
 #endif
   } else if (!isa<UndefValue>(c)) {
-    unsigned StoreBits = targetData->getTypeStoreSizeInBits(c->getType());
+    unsigned allocBits = targetData->getTypeAllocSizeInBits(c->getType());
     ref<ConstantExpr> C = evalConstant(c);
-
-    // Extend the constant if necessary;
-    assert(StoreBits >= C->getWidth() && "Invalid store size!");
-    if (StoreBits > C->getWidth())
-      C = C->ZExt(StoreBits);
+    // Extend the constant, zero padding if necessary
+    assert(allocBits >= C->getWidth() && "alloc size invalid");
+    if (allocBits > C->getWidth())
+      C = C->ZExt(allocBits);
 
     os->write(offset, C);
   }
@@ -593,10 +591,10 @@ void Executor::initializeGlobals(ExecutionState &state) {
       LLVM_TYPE_Q Type *ty = i->getType()->getElementType();
       uint64_t size = 0;
       if (ty->isSized()) {
-	size = kmodule->targetData->getTypeStoreSize(ty);
+        size = kmodule->targetData->getTypeAllocSize(ty);
       } else {
         klee_warning("Type for %.*s is not sized", (int)i->getName().size(),
-			i->getName().data());
+                     i->getName().data());
       }
 
       // XXX - DWD - hardcode some things until we decide how to fix.
@@ -638,7 +636,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
       }
     } else {
       LLVM_TYPE_Q Type *ty = i->getType()->getElementType();
-      uint64_t size = kmodule->targetData->getTypeStoreSize(ty);
+      uint64_t size = kmodule->targetData->getTypeAllocSize(ty);
       MemoryObject *mo = memory->allocate(size, false, true, &*i);
       if (!mo)
         llvm::report_fatal_error("out of memory");
@@ -2095,8 +2093,8 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     // Memory instructions...
   case Instruction::Alloca: {
     AllocaInst *ai = cast<AllocaInst>(i);
-    unsigned elementSize = 
-      kmodule->targetData->getTypeStoreSize(ai->getAllocatedType());
+    unsigned elementSize =
+        kmodule->targetData->getTypeAllocSize(ai->getAllocatedType());
     ref<Expr> size = Expr::createPointer(elementSize);
     if (ai->isArrayAllocation()) {
       ref<Expr> count = eval(ki, 0, state).value;
@@ -2595,8 +2593,8 @@ void Executor::computeOffsets(KGEPInstruction *kgepi, TypeIt ib, TypeIt ie) {
                                                                Context::get().getPointerWidth()));
     } else {
       const SequentialType *set = cast<SequentialType>(*ii);
-      uint64_t elementSize = 
-        kmodule->targetData->getTypeStoreSize(set->getElementType());
+      uint64_t elementSize =
+          kmodule->targetData->getTypeAllocSize(set->getElementType());
       Value *operand = ii.getOperand();
       if (Constant *c = dyn_cast<Constant>(operand)) {
         ref<ConstantExpr> index = 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -44,6 +44,7 @@
 #include "klee/Internal/Module/KModule.h"
 #include "klee/Internal/Support/ErrorHandling.h"
 #include "klee/Internal/Support/FloatEvaluation.h"
+#include "klee/Internal/Support/ModuleUtil.h"
 #include "klee/Internal/System/Time.h"
 #include "klee/Internal/System/MemoryUsage.h"
 #include "klee/SolverStats.h"
@@ -582,6 +583,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
   for (Module::const_global_iterator i = m->global_begin(),
          e = m->global_end();
        i != e; ++i) {
+    size_t globalObjectAlignment = getAllocationAlignment(i);
     if (i->isDeclaration()) {
       // FIXME: We have no general way of handling unknown external
       // symbols. If we really cared about making external stuff work
@@ -613,7 +615,9 @@ void Executor::initializeGlobals(ExecutionState &state) {
 			(int)i->getName().size(), i->getName().data());
       }
 
-      MemoryObject *mo = memory->allocate(size, false, true, i);
+      MemoryObject *mo = memory->allocate(size, /*isLocal=*/false,
+                                          /*isGlobal=*/true, /*allocSite=*/i,
+                                          /*alignment=*/globalObjectAlignment);
       ObjectState *os = bindObjectInState(state, mo, false);
       globalObjects.insert(std::make_pair(i, mo));
       globalAddresses.insert(std::make_pair(i, mo->getBaseExpr()));
@@ -637,7 +641,9 @@ void Executor::initializeGlobals(ExecutionState &state) {
     } else {
       LLVM_TYPE_Q Type *ty = i->getType()->getElementType();
       uint64_t size = kmodule->targetData->getTypeAllocSize(ty);
-      MemoryObject *mo = memory->allocate(size, false, true, &*i);
+      MemoryObject *mo = memory->allocate(size, /*isLocal=*/false,
+                                          /*isGlobal=*/true, /*allocSite=*/&*i,
+                                          /*alignment=*/globalObjectAlignment);
       if (!mo)
         llvm::report_fatal_error("out of memory");
       ObjectState *os = bindObjectInState(state, mo, false);
@@ -3139,8 +3145,11 @@ void Executor::executeAlloc(ExecutionState &state,
                             const ObjectState *reallocFrom) {
   size = toUnique(state, size);
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(size)) {
-    MemoryObject *mo = memory->allocate(CE->getZExtValue(), isLocal, false, 
-                                        state.prevPC->inst);
+    const llvm::Value *allocSite = state.prevPC->inst;
+    size_t allocationAlignment = getAllocationAlignment(allocSite);
+    MemoryObject *mo =
+        memory->allocate(CE->getZExtValue(), isLocal, /*isGlobal=*/false,
+                         allocSite, allocationAlignment);
     if (!mo) {
       bindLocal(target, state, 
                 ConstantExpr::alloc(0, Context::get().getPointerWidth()));
@@ -3528,10 +3537,11 @@ void Executor::runFunctionAsMain(Function *f,
   Function::arg_iterator ai = f->arg_begin(), ae = f->arg_end();
   if (ai!=ae) {
     arguments.push_back(ConstantExpr::alloc(argc, Expr::Int32));
-
     if (++ai!=ae) {
-      argvMO = memory->allocate((argc+1+envc+1+1) * NumPtrBytes, false, true,
-                                f->begin()->begin());
+      argvMO =
+          memory->allocate((argc + 1 + envc + 1 + 1) * NumPtrBytes,
+                           /*isLocal=*/false, /*isGlobal=*/true,
+                           /*allocSite=*/f->begin()->begin(), /*alignment=*/8);
 
       if (!argvMO)
         klee_error("Could not allocate memory for function arguments");
@@ -3573,8 +3583,10 @@ void Executor::runFunctionAsMain(Function *f,
       } else {
         char *s = i<argc ? argv[i] : envp[i-(argc+1)];
         int j, len = strlen(s);
-        
-        MemoryObject *arg = memory->allocate(len+1, false, true, state->pc->inst);
+
+        MemoryObject *arg =
+            memory->allocate(len + 1, /*isLocal=*/false, /*isGlobal=*/true,
+                             /*allocSite=*/state->pc->inst, /*alignment=*/8);
         if (!arg)
           klee_error("Could not allocate memory for function arguments");
         ObjectState *os = bindObjectInState(*state, arg, false);
@@ -3753,6 +3765,68 @@ Expr::Width Executor::getWidthForLLVMType(LLVM_TYPE_Q llvm::Type *type, bool inc
   return kmodule->targetData->getTypeSizeInBits(type);
 }
 
+size_t Executor::getAllocationAlignment(const llvm::Value *allocSite) const {
+  // FIXME: 8 was the previous default. We shouldn't hard code this
+  // and should fetch the default from elsewhere.
+  const size_t forcedAlignment = 8;
+  size_t alignment = 0;
+  llvm::Type *type = NULL;
+  std::string allocationSiteName("<unknown");
+  if (const GlobalValue *GV = dyn_cast<GlobalValue>(allocSite)) {
+    alignment = GV->getAlignment();
+    allocationSiteName = allocSite->getName().str();
+    if (const GlobalVariable *globalVar = dyn_cast<GlobalVariable>(GV)) {
+      // All GlobalVariables's have pointer type
+      llvm::Type *ptrType = globalVar->getType();
+      assert(isa<llvm::PointerType>(ptrType));
+      type = ptrType->getPointerElementType();
+    } else {
+      type = GV->getType();
+    }
+  } else if (const AllocaInst *AI = dyn_cast<AllocaInst>(allocSite)) {
+    alignment = AI->getAlignment();
+    type = AI->getAllocatedType();
+  } else if (isa<InvokeInst>(allocSite) || isa<CallInst>(allocSite)) {
+    // FIXME: Model the semantics of the call to use the right alignment
+    llvm::Value *allocSiteNonConst = const_cast<llvm::Value *>(allocSite);
+    const CallSite cs = (isa<InvokeInst>(allocSiteNonConst)
+                             ? CallSite(cast<InvokeInst>(allocSiteNonConst))
+                             : CallSite(cast<CallInst>(allocSiteNonConst)));
+    llvm::Function *fn = klee::getDirectCallTarget(cs);
+    if (fn)
+      allocationSiteName = fn->getName().str();
+
+    klee_warning_once(allocSite, "Alignment of memory from call \"%s\" is not "
+                                 "modelled. Using alignment of %zu.",
+                      allocationSiteName.c_str(), forcedAlignment);
+    alignment = forcedAlignment;
+  } else {
+    llvm_unreachable("Unhandled allocation site");
+  }
+
+  if (alignment == 0) {
+    assert(type != NULL);
+    // No specified alignment. Get the alignment for the type.
+    if (type->isSized()) {
+      alignment = kmodule->targetData->getPrefTypeAlignment(type);
+    } else {
+      klee_warning_once(allocSite, "Cannot determine memory alignment for "
+                                   "\"%s\". Using alignment of %zu.",
+                        allocationSiteName.c_str(), forcedAlignment);
+      alignment = forcedAlignment;
+    }
+  }
+
+  // Currently we require alignment be a power of 2
+  if (!bits64::isPowerOfTwo(alignment)) {
+    klee_warning_once(allocSite, "Alignment of %zu requested for %s but this "
+                                 "not supported. Using alignment of %zu",
+                      alignment, allocSite->getName().str().c_str(),
+                      forcedAlignment);
+    alignment = forcedAlignment;
+  }
+  return alignment;
+}
 ///
 
 Interpreter *Interpreter::create(const InterpreterOptions &opts,

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3303,8 +3303,13 @@ void Executor::executeMemoryOperation(ExecutionState &state,
                                       ref<Expr> address,
                                       ref<Expr> value /* undef if read */,
                                       KInstruction *target /* undef if write */) {
-  Expr::Width type = (isWrite ? value->getWidth() : 
-                     getWidthForLLVMType(target->inst->getType()));
+  // FIXME: includePadding should be set to true, however KLEE has implicit
+  // assumptions that the size of a type with/without pading and the size of an
+  // Expr all coincide. Until those implicit assumptions are fixed we can't
+  // support types with padding properly.
+  Expr::Width type = (isWrite ? value->getWidth()
+                              : getWidthForLLVMType(target->inst->getType(),
+                                                    /*includePadding=*/false));
   unsigned bytes = Expr::getMinBytesForWidth(type);
 
   if (SimplifySymIndices) {
@@ -3741,7 +3746,10 @@ void Executor::doImpliedValueConcretization(ExecutionState &state,
   }
 }
 
-Expr::Width Executor::getWidthForLLVMType(LLVM_TYPE_Q llvm::Type *type) const {
+Expr::Width Executor::getWidthForLLVMType(LLVM_TYPE_Q llvm::Type *type, bool includePadding) const {
+  if (includePadding)
+    return kmodule->targetData->getTypeAllocSizeInBits(type);
+
   return kmodule->targetData->getTypeSizeInBits(type);
 }
 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -505,6 +505,7 @@ public:
                                std::map<const std::string*, std::set<unsigned> > &res);
 
   Expr::Width getWidthForLLVMType(LLVM_TYPE_Q llvm::Type *type, bool includePadding=false) const;
+  size_t getAllocationAlignment(const llvm::Value *allocSite) const;
 };
   
 } // End klee namespace

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -504,7 +504,7 @@ public:
   virtual void getCoveredLines(const ExecutionState &state,
                                std::map<const std::string*, std::set<unsigned> > &res);
 
-  Expr::Width getWidthForLLVMType(LLVM_TYPE_Q llvm::Type *type) const;
+  Expr::Width getWidthForLLVMType(LLVM_TYPE_Q llvm::Type *type, bool includePadding=false) const;
 };
   
 } // End klee namespace

--- a/lib/Core/ExecutorUtil.cpp
+++ b/lib/Core/ExecutorUtil.cpp
@@ -106,8 +106,8 @@ namespace klee {
           const SequentialType *set = cast<SequentialType>(*ii);
           ref<ConstantExpr> index = 
             evalConstant(cast<Constant>(ii.getOperand()));
-          unsigned elementSize = 
-            kmodule->targetData->getTypeStoreSize(set->getElementType());
+          unsigned elementSize =
+              kmodule->targetData->getTypeAllocSize(set->getElementType());
 
           index = index->ZExt(Context::get().getPointerWidth());
           addend = index->Mul(ConstantExpr::alloc(elementSize, 

--- a/lib/Core/MemoryManager.h
+++ b/lib/Core/MemoryManager.h
@@ -40,7 +40,7 @@ public:
    * memory.
    */
   MemoryObject *allocate(uint64_t size, bool isLocal, bool isGlobal,
-                         const llvm::Value *allocSite, size_t alignment = 8);
+                         const llvm::Value *allocSite, size_t alignment);
   MemoryObject *allocateFixed(uint64_t address, uint64_t size,
                               const llvm::Value *allocSite);
   void deallocate(const MemoryObject *mo);

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -547,6 +547,7 @@ void SpecialFunctionHandler::handleGetObjSize(ExecutionState &state,
   executor.resolveExact(state, arguments[0], rl, "klee_get_obj_size");
   for (Executor::ExactResolutionList::iterator it = rl.begin(), 
          ie = rl.end(); it != ie; ++it) {
+    // FIXME: Should this be getTypeAllocSizeInBits()?
     executor.bindLocal(
         target, *it->second,
         ConstantExpr::create(it->first.first->size,

--- a/test/regression/2016-12-13-alloca-padded-object.c
+++ b/test/regression/2016-12-13-alloca-padded-object.c
@@ -1,0 +1,78 @@
+// RUN: %llvmgcc %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error %t.bc
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#if defined(__x86_64__)
+typedef long double v4ld __attribute__ ((vector_size(64)));
+#elif defined(__i386__)
+typedef long double v4ld __attribute__ ((vector_size(48)));
+#else
+#error Unsupported platform
+#endif
+
+// FIXME: Come up with a way to test ConstantDataSequential
+// and ConstantAggregateZero with padded data types.
+
+int main() {
+  long double thing = 2.0l;
+
+  // `long double` on x86_64/i386 (x87 fp80) has 10 bytes
+  // of useful data and the rest is padding.
+#if defined(__x86_64__)
+  assert(sizeof(long double) == 16);
+#elif defined(__i386__)
+  assert(sizeof(long double) == 12);
+#else
+#error Unsupported platform
+#endif
+
+  // Older versions of KLEE would report an about of bounds
+  // access during the `memcpy()` because it wouldn't allocate
+  // the right amount of memory for `long double`.
+
+  // Access all bits of the type including the padding.
+  long double thingCopy = 0.0l;
+  memcpy(&thingCopy, &thing, sizeof(long double));
+  assert(thingCopy == 2.0l);
+
+  // Check offset is computed correctly.
+  long double foo[] = { 1.0l, 2.0l, 3.0l };
+  long double* base = foo;
+  printf("base: %zd\n", base);
+
+  // Let KLEE compute the offset
+  long double* secondEl = foo + 1;
+  printf("secondEl: %zd\n", secondEl);
+
+  // Compute what the offset should be
+  size_t secondElExpected = ((size_t) base) + sizeof(long double);
+  // Check they are equal
+  assert(((size_t)secondEl) == secondElExpected);
+
+  // Do the same for the next element
+  long double* thirdEl = foo + 2;
+  printf("thirdEl: %zd\n", thirdEl);
+  size_t thirdElExpected = ((size_t) base) + (2*sizeof(long double));
+  assert(((size_t)thirdEl) == thirdElExpected);
+
+  // Now check values are correct
+  assert(foo[0] == 1.0l);
+  assert(foo[1] == 2.0l);
+  assert(foo[2] == 3.0l);
+
+  // TODO: Enable once we have vector support
+  //v4ld localVector = { 87.5l, -27.75, 1.0l, 9374.25l };
+  //assert(sizeof(localVector) == 4*sizeof(long double));
+  // Now check local vector was correctly initialized
+  // FIXME: KLEE doesn't support vector instructions so examine using
+  // pointer arithmetic.
+  //assert(*(((long double *)&localVector) + /*lane=*/0) == 87.5l);
+  //assert(*(((long double *)&localVector) + /*lane=*/1) == -27.75);
+  //assert(*(((long double *)&localVector) + /*lane=*/2) == 1.0l);
+  //assert(*(((long double *)&localVector) + /*lane=*/3) == 9374.25l);
+  return 0;
+}

--- a/test/regression/2016-12-13-global-padded-object.c
+++ b/test/regression/2016-12-13-global-padded-object.c
@@ -61,7 +61,7 @@ int main() {
   assert(sizeof(globalVector) == 4*sizeof(long double));
   assert(sizeof(globalVector) == sizeof(localVector));
   /* FIXME: The load from globalVector that then gets stored is terribly
-            broken.
+            broken. See FIXME in `Executor::executeMemoryOperation()`
   // Check that the store was done correctly
   for (int index = 0; index < sizeof(globalVector); ++index) {
     uint8_t localByte = *(((uint8_t *)&localVector) + index);

--- a/test/regression/2016-12-13-global-padded-object.c
+++ b/test/regression/2016-12-13-global-padded-object.c
@@ -1,0 +1,98 @@
+// RUN: %llvmgcc %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error %t.bc
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+long double globalThing = 1.0l;
+
+long double globalLongDoubles[] = { 1.0l, 99.0l, -17.0l, 4277.5l };
+
+#if defined(__x86_64__)
+typedef long double v4ld __attribute__ ((vector_size(64)));
+#elif defined(__i386__)
+typedef long double v4ld __attribute__ ((vector_size(48)));
+#else
+#error Unsupported platform
+#endif
+
+v4ld globalVector = { 87.5l, -27.75, 1.0l, 9374.25l };
+
+// FIXME: Come up with a way to test ConstantDataSequential
+// and ConstantAggregateZero with padded data types.
+
+int main() {
+  long double thing = 2.0l;
+
+  // `long double` on x86_64/i386 (x87 fp80) has 10 bytes
+  // of useful data and the rest is padding.
+#if defined(__x86_64__)
+  assert(sizeof(long double) == 16);
+#elif defined(__i386__)
+  assert(sizeof(long double) == 12);
+#else
+#error Unsupported platform
+#endif
+
+  // Older versions of KLEE would report an about of bounds
+  // access during the `memcpy()` because it wouldn't allocate
+  // the right amount of memory for `long double`.
+
+  // Now copy from global
+  memcpy(&thing, &globalThing, sizeof(long double));
+  assert(thing == 1.0l);
+
+  // Now copy from global array
+  long double localLongDoubles[4];
+  assert(sizeof(localLongDoubles) == sizeof(globalLongDoubles));
+  memcpy(localLongDoubles, globalLongDoubles, sizeof(localLongDoubles));
+  // Check that the copy was done correctly
+  for (int index=0; index < sizeof(globalLongDoubles); ++index) {
+    uint8_t localByte = *(((uint8_t*) localLongDoubles) + index);
+    uint8_t globalByte = *(((uint8_t*) globalLongDoubles) + index);
+    assert(localByte == globalByte);
+  }
+
+  // Now copy from global vector
+  v4ld localVector = globalVector;
+  printf("sizeof(globalVector) = %zd\n", sizeof(globalVector));
+  assert(sizeof(globalVector) == 4*sizeof(long double));
+  assert(sizeof(globalVector) == sizeof(localVector));
+  /* FIXME: The load from globalVector that then gets stored is terribly
+            broken.
+  // Check that the store was done correctly
+  for (int index = 0; index < sizeof(globalVector); ++index) {
+    uint8_t localByte = *(((uint8_t *)&localVector) + index);
+    uint8_t globalByte = *(((uint8_t *)&globalVector) + index);
+    printf("Checking byte %d local = %u, global = %u\n", index, localByte,
+           globalByte);
+    assert(localByte == globalByte);
+  }
+  */
+
+  // Check offset is computed correctly for global array.
+  long double* base = globalLongDoubles;
+  printf("base: %zd\n", base);
+  long double* secondEl = globalLongDoubles + 1;
+  printf("secondEl: %zd\n", secondEl);
+  size_t secondElExpected = ((size_t) base) + sizeof(long double);
+  printf("secondElExpected: %zd\n", secondElExpected);
+  assert(((size_t) secondEl) == secondElExpected);
+
+  // Now check global array was correctly initialized
+  assert(globalLongDoubles[0] == 1.0l);
+  assert(globalLongDoubles[1] == 99.0l);
+  assert(globalLongDoubles[2] == -17.0l);
+  assert(globalLongDoubles[3] == 4277.5l);
+
+  // Now check global vector was correctly initialized
+  // FIXME: KLEE doesn't support vector instructions so examine using
+  // pointer arithmetic.
+  assert(*(((long double *)&globalVector) + /*lane=*/0) == 87.5l);
+  assert(*(((long double *)&globalVector) + /*lane=*/1) == -27.75);
+  assert(*(((long double *)&globalVector) + /*lane=*/2) == 1.0l);
+  assert(*(((long double *)&globalVector) + /*lane=*/3) == 9374.25l);
+  return 0;
+}

--- a/test/regression/2016-12-14-alloc-alignment.c
+++ b/test/regression/2016-12-14-alloc-alignment.c
@@ -1,0 +1,21 @@
+// RUN: %llvmgcc %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error %t.bc
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+// Global should be aligned on a 128-byte boundary
+int foo __attribute__((align(128)));
+
+int main() {
+  int bar __attribute__((align(256)));
+
+  // Check alignment of global
+  assert(((size_t)&foo) % 128 == 0);
+
+  // Check alignment of local
+  assert(((size_t)&bar) % 256 == 0);
+  return 0;
+}


### PR DESCRIPTION
This fixes a bunch of memory allocation bugs in KLEE.

There are still problems here but fixing them is going to require careful examination of implicit assumptions made in KLEE regarding the width of types and Expr.