### PR TITLE
[CMake] Rename "integrationtests" to "systemtests", removed some undocumented targets and other build changes

### DIFF
--- a/.travis/klee.sh
+++ b/.travis/klee.sh
@@ -191,7 +191,7 @@ fi
 # lit tests
 ###############################################################################
 if [ "X${USE_CMAKE}" == "X1" ]; then
-  make integrationtests
+  make systemtests
 else
   # Note can't use ``make check`` because llvm-lit is not available
   cd test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,11 @@ if (POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW)
 endif()
 
+if (POLICY CMP0037)
+  # Disallow reserved target names
+  cmake_policy(SET CMP0037 NEW)
+endif()
+
 # This overrides the default flags for the different CMAKE_BUILD_TYPEs
 set(CMAKE_USER_MAKE_RULES_OVERRIDE_C
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/c_flags_override.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,10 +699,16 @@ if ((NOT LIT_TOOL) OR (NOT EXISTS "${LIT_TOOL}"))
     message(STATUS "Using lit: ${LIT_TOOL}")
   endif()
 
+  # Add global test target
+  add_custom_target(check
+    COMMENT "Running tests"
+  )
+
   option(ENABLE_UNIT_TESTS "Enable unit tests" ON)
   if (ENABLE_UNIT_TESTS)
     message(STATUS "Unit tests enabled")
     add_subdirectory(unittests)
+    add_dependencies(check unittests)
   else()
     message(STATUS "Unit tests disabled")
   endif()
@@ -710,15 +716,11 @@ if ((NOT LIT_TOOL) OR (NOT EXISTS "${LIT_TOOL}"))
   if (ENABLE_SYSTEM_TESTS)
     message(STATUS "System tests enabled")
     add_subdirectory(test)
+    add_dependencies(check systemtests)
   else()
     message(STATUS "System tests disabled")
   endif()
 
-  # Add global test target
-  add_custom_target(check
-    DEPENDS unittests systemtests
-    COMMENT "Running tests"
-  )
 else()
   message(STATUS "Testing disabled")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,24 +699,24 @@ if ((NOT LIT_TOOL) OR (NOT EXISTS "${LIT_TOOL}"))
     message(STATUS "Using lit: ${LIT_TOOL}")
   endif()
 
-  option(ENABLE_UNIT_TESTS "Enable unittests" ON)
+  option(ENABLE_UNIT_TESTS "Enable unit tests" ON)
   if (ENABLE_UNIT_TESTS)
     message(STATUS "Unit tests enabled")
     add_subdirectory(unittests)
   else()
     message(STATUS "Unit tests disabled")
   endif()
-  option(ENABLE_INTEGRATION_TESTS "Enable integration tests" ON)
-  if (ENABLE_INTEGRATION_TESTS)
-    message(STATUS "Integration tests enabled")
+  option(ENABLE_SYSTEM_TESTS "Enable system tests" ON)
+  if (ENABLE_SYSTEM_TESTS)
+    message(STATUS "System tests enabled")
     add_subdirectory(test)
   else()
-    message(STATUS "Integration tests disabled")
+    message(STATUS "System tests disabled")
   endif()
 
   # Add global test target
   add_custom_target(check
-    DEPENDS unittests integrationtests
+    DEPENDS unittests systemtests
     COMMENT "Running tests"
   )
 else()

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1877,32 +1877,6 @@ systemtests::
 	  $(EchoCmd) No test directory ; \
 	fi
 
-check-lit:: check
-
-check-dg::
-	$(Verb) if test -d "$(PROJ_OBJ_ROOT)/test" ; then \
-	  if test -f "$(PROJ_OBJ_ROOT)/test/Makefile" ; then \
-	    $(EchoCmd) Running test suite ; \
-	    $(MAKE) -C $(PROJ_OBJ_ROOT)/test check-local-dg ; \
-	  else \
-	    $(EchoCmd) No Makefile in test directory ; \
-	  fi ; \
-	else \
-	  $(EchoCmd) No test directory ; \
-	fi
-
-check-all::
-	$(Verb) if test -d "$(PROJ_OBJ_ROOT)/test" ; then \
-	  if test -f "$(PROJ_OBJ_ROOT)/test/Makefile" ; then \
-	    $(EchoCmd) Running test suite ; \
-	    $(MAKE) -C $(PROJ_OBJ_ROOT)/test check-local-all ; \
-	  else \
-	    $(EchoCmd) No Makefile in test directory ; \
-	  fi ; \
-	else \
-	  $(EchoCmd) No test directory ; \
-	fi
-
 ###############################################################################
 # UNITTESTS: Running the unittests test suite
 ###############################################################################

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -21,10 +21,10 @@
 #--------------------------------------------------------------------
 RecursiveTargets := all clean clean-all install uninstall install-bytecode \
                     unitcheck
-LocalTargets     := all-local clean-local clean-all-local check-local \
+LocalTargets     := all-local clean-local clean-all-local systemtests-local \
                     install-local printvars uninstall-local \
 		    install-bytecode-local
-TopLevelTargets  := check dist dist-check dist-clean dist-gzip dist-bzip2 \
+TopLevelTargets  := check systemtests dist dist-check dist-clean dist-gzip dist-bzip2 \
                     dist-zip unittests
 UserTargets      := $(RecursiveTargets) $(LocalTargets) $(TopLevelTargets)
 InternalTargets  := preconditions distdir dist-hook
@@ -1856,14 +1856,19 @@ endif
 endif
 
 ###############################################################################
+# Global target to run all tests
+###############################################################################
+check:: systemtests unittests
+
+###############################################################################
 # CHECK: Running the test suite
 ###############################################################################
 
-check::
+systemtests::
 	$(Verb) if test -d "$(PROJ_OBJ_ROOT)/test" ; then \
 	  if test -f "$(PROJ_OBJ_ROOT)/test/Makefile" ; then \
 	    $(EchoCmd) Running test suite ; \
-	    $(MAKE) -C $(PROJ_OBJ_ROOT)/test check-local \
+	    $(MAKE) -C $(PROJ_OBJ_ROOT)/test systemtests-local \
 	      TESTSUITE=$(TESTSUITE) ; \
 	  else \
 	    $(EchoCmd) No Makefile in test directory ; \
@@ -2001,7 +2006,7 @@ dist-check:: $(DistTarGZip)
 	  ../$(DistName)/configure --prefix="$(DistCheckDir)/install" \
 	    --srcdir=../$(DistName) $(DIST_CHECK_CONFIG_OPTIONS) && \
 	  $(MAKE) all && \
-	  $(MAKE) check && \
+	  $(MAKE) systemtests && \
 	  $(MAKE) unittests && \
 	  $(MAKE) install && \
 	  $(MAKE) uninstall && \

--- a/README-CMake.md
+++ b/README-CMake.md
@@ -10,7 +10,7 @@ its autoconf/Makefile based build system.
 * `docs` - Build documentation
 * `edit_cache` - Show cmake/ccmake/cmake-gui interface for chaning configure options.
 * `help` - Show list of top level targets
-* `integrationtests` - Run integration tests
+* `systemtests` - Run system tests
 * `unittests` - Build and run unittests
 
 ## Useful CMake variables
@@ -36,7 +36,7 @@ cmake -DCMAKE_BUILD_TYPE=Release /path/to/klee/src
 
 * `ENABLE_DOXYGEN` (BOOLEAN) - Enable building doxygen documentation.
 
-* `ENABLE_INTEGRATION_TESTS` (BOOLEAN) - Enable KLEE integration tests.
+* `ENABLE_SYSTEM_TESTS` (BOOLEAN) - Enable KLEE system tests.
 
 * `ENABLE_KLEE_ASSERTS` (BOOLEAN) - Enable assertions when building KLEE.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -126,10 +126,10 @@ configure_file(lit.site.cfg.in
   @ONLY
 )
 
-add_custom_target(integrationtests
+add_custom_target(systemtests
   COMMAND "${LIT_TOOL}" ${LIT_ARGS} "${CMAKE_CURRENT_BINARY_DIR}"
   DEPENDS klee kleaver kleeRuntest
-  COMMENT "Running integration tests"
+  COMMENT "Running system tests"
   ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}
 )
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,7 @@ DIRS   =
 #
 # Make llvm-lit the default for testing
 #
-all:: check-local
+all:: systemtests-local
 
 # Include other test rules
 include Makefile.tests
@@ -55,7 +55,7 @@ check-local:: lit.site.cfg
 	  exit 1; \
 	fi
 
-check-local-all:: lit.site.cfg
+systemtests-local:: lit.site.cfg
 	$(Verb) ( $(ULIMIT) \
 	          $(PYTHON) $(LLVM_SRC_ROOT)/utils/lit/lit.py $(LIT_ARGS) $(LIT_ALL_TESTSUITES) )
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -45,16 +45,6 @@ endif
 # Potential support in the future for multiple test suites
 LIT_ALL_TESTSUITES := $(LIT_TESTSUITE)
 
-check-local:: lit.site.cfg
-	$(Verb) $(MAKE) -s clean
-	$(Verb) ( $(ULIMIT) \
-	          $(PYTHON) $(LLVM_SRC_ROOT)/utils/lit/lit.py $(LIT_ARGS) $(LIT_TESTSUITE) )
-	$(Verb) klee_last_path=$$(find . -name klee-last | head -1); \
-	 if [ ! -z "$$klee_last_path" ]; then \
-	  echo "error: one of the tests failed to use --output-dir, found: $$klee_last_path"; \
-	  exit 1; \
-	fi
-
 systemtests-local:: lit.site.cfg
 	$(Verb) ( $(ULIMIT) \
 	          $(PYTHON) $(LLVM_SRC_ROOT)/utils/lit/lit.py $(LIT_ARGS) $(LIT_ALL_TESTSUITES) )

--- a/tools/klee-stats/CMakeLists.txt
+++ b/tools/klee-stats/CMakeLists.txt
@@ -9,5 +9,5 @@
 install(PROGRAMS klee-stats DESTINATION bin)
 
 # Copy into the build directory's binary directory
-# so integration tests can find it
+# so system tests can find it
 configure_file(klee-stats "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/klee-stats" COPYONLY)

--- a/tools/ktest-tool/CMakeLists.txt
+++ b/tools/ktest-tool/CMakeLists.txt
@@ -9,5 +9,5 @@
 install(PROGRAMS ktest-tool DESTINATION bin)
 
 # Copy into the build directory's binary directory
-# so integration tests can find it
+# so system tests can find it
 configure_file(ktest-tool "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ktest-tool" COPYONLY)


### PR DESCRIPTION
This was a proposal from #500.

@andreamattavelli pointed out that the lit tests are really
system tests rather than integration tests so this commit fixes
the inappropriate naming that I chose.