### PR TITLE
Teach KLEE to respect the requested memory alignment of allocated memory

### DIFF
--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -505,6 +505,7 @@ public:
                                std::map<const std::string*, std::set<unsigned> > &res);
 
   Expr::Width getWidthForLLVMType(LLVM_TYPE_Q llvm::Type *type) const;
+  size_t getAllocationAlignment(const llvm::Value *allocSite) const;
 };
   
 } // End klee namespace

--- a/lib/Core/MemoryManager.h
+++ b/lib/Core/MemoryManager.h
@@ -40,7 +40,7 @@ public:
    * memory.
    */
   MemoryObject *allocate(uint64_t size, bool isLocal, bool isGlobal,
-                         const llvm::Value *allocSite, size_t alignment = 8);
+                         const llvm::Value *allocSite, size_t alignment);
   MemoryObject *allocateFixed(uint64_t address, uint64_t size,
                               const llvm::Value *allocSite);
   void deallocate(const MemoryObject *mo);

--- a/test/regression/2016-12-14-alloc-alignment.c
+++ b/test/regression/2016-12-14-alloc-alignment.c
@@ -1,0 +1,21 @@
+// RUN: %llvmgcc %s -Wall -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error %t.bc
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+// Global should be aligned on a 128-byte boundary
+int foo __attribute__((aligned(128)));
+
+int main() {
+  int bar __attribute__((aligned(256)));
+
+  // Check alignment of global
+  assert(((size_t)&foo) % 128 == 0);
+
+  // Check alignment of local
+  assert(((size_t)&bar) % 256 == 0);
+  return 0;
+}


### PR DESCRIPTION
Teach KLEE to respect the requested memory alignment of globals and stack variables when possible.

Previously an alignment 8 was always used which did not faithfully
emulate what was either explicitly requested in the LLVM IR or what
the default alignment was for the target.