### PR TITLE
CMake: Fixed the LLVM version regex

### DIFF
--- a/cmake/find_llvm.cmake
+++ b/cmake/find_llvm.cmake
@@ -65,7 +65,7 @@ else()
   # Get LLVM version
   _run_llvm_config(LLVM_PACKAGE_VERSION "--version")
   # Try x.y.z patern
-  set(_llvm_version_regex "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
+  set(_llvm_version_regex "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(svn)?$")
   if ("${LLVM_PACKAGE_VERSION}" MATCHES "${_llvm_version_regex}")
     string(REGEX REPLACE
       "${_llvm_version_regex}"


### PR DESCRIPTION
When trying to KLEE with a version of LLVM (specifically, 3.5) built from Github (https://github.com/llvm-mirror/llvm/tree/release_35) the regex in find_llvm.cmake failed to match the LLVM version string because it was suffixed with "svn" - i.e. "3.5.2svn".

I added the optional "svn" suffix to the CMake regex to fix this. I would have prefered to use a non-capturing group, however when I used `(?:svn)?` the regex failed to compile for some reason (anyone know why?). Alternatively, you could just remove the `$` from the end of the regex (i.e. `^([0-9]+)\\.([0-9]+)\\.([0-9]+)`). Let me know what you guys would prefer!