### PR TITLE
Silenced two "control may reach end of non-void function [-Wreturn-ty…

### DIFF
--- a/include/klee/Internal/ADT/DiscretePDF.inc
+++ b/include/klee/Internal/ADT/DiscretePDF.inc
@@ -162,32 +162,32 @@ void DiscretePDF<T>::update(T item, weight_type weight) {
 
 template <class T>
 T DiscretePDF<T>::choose(double p) {
-  if (p<0.0 || p>=1.0) {
+  if ((p < 0.0) || (p >= 1.0))
     assert(0 && "choose: argument(p) outside valid range");
-  } else if (!m_root) {
+
+  if (!m_root)
     assert(0 && "choose: choose() called on empty tree");
-  } else {
-    weight_type w = (weight_type) (m_root->sumWeights * p);
-    Node *n = m_root;
 
-    while (1) {
-      if (n->left) {
-        if (w<n->left->sumWeights) {
-          n = n->left;
-          continue;
-        } else {
-          w -= n->left->sumWeights;
-        }
+  weight_type w = (weight_type) (m_root->sumWeights * p);
+  Node *n = m_root;
+
+  while (1) {
+    if (n->left) {
+      if (w<n->left->sumWeights) {
+	n = n->left;
+	continue;
+      } else {
+	w -= n->left->sumWeights;
       }
-      if (w<n->weight || !n->right) {
-        break; // !n->right condition shouldn't be necessary, just sanity check
-      }
-      w -= n->weight;
-      n = n->right;
     }
-
-    return n->key;
+    if (w<n->weight || !n->right) {
+      break; // !n->right condition shouldn't be necessary, just sanity check
+    }
+    w -= n->weight;
+    n = n->right;
   }
+
+  return n->key;
 }
 
 template <class T>

--- a/lib/Core/ExecutorUtil.cpp
+++ b/lib/Core/ExecutorUtil.cpp
@@ -153,6 +153,11 @@ namespace klee {
     case Instruction::FCmp:
       assert(0 && "floating point ConstantExprs unsupported");
     }
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 1)
+    llvm_unreachable("Unsupported expression in evalConstantExpr");
+#else
+    assert(0 && "Unsupported expression in evalConstantExpr");
+#endif
+    return op1;
   }
-
 }


### PR DESCRIPTION
…pe]" warnings emitted by Clang 7.3.0, one by adding an assert, and the other by refactoring the choose() function.