### PR TITLE
tests: Added lit substitution for llvm-ar

### DIFF
--- a/test/Feature/LinkLLVMLib.c
+++ b/test/Feature/LinkLLVMLib.c
@@ -1,5 +1,5 @@
 // RUN: %llvmgcc %s -g -emit-llvm -O0 -c -o %t1.bc -DLINK_LLVM_LIB_TEST_LIB
-// RUN: llvm-ar r %t1.a %t1.bc
+// RUN: %llvmar r %t1.a %t1.bc
 //
 // RUN: %llvmgcc %s -g -emit-llvm -O0 -c -o %t2.bc -DLINK_LLVM_LIB_TEST_EXEC
 // RUN: rm -rf %t.klee-out

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -87,6 +87,8 @@ for name in subs:
 config.substitutions.append( ('%lli', os.path.join(llvm_tools_dir, 'lli')) )
 # Add a substitution for llvm-as
 config.substitutions.append( ('%llvmas', os.path.join(llvm_tools_dir, 'llvm-as')) )
+# Add a substitution for llvm-ar
+config.substitutions.append( ('%llvmar', os.path.join(llvm_tools_dir, 'llvm-ar')) )
 
 # Get KLEE and Kleaver specific parameters passed on llvm-lit cmd line
 # e.g. llvm-lit --param klee_opts=--help


### PR DESCRIPTION
Brings llvm-ar into line with llvm-as and lli, removing the assumption that llvm-ar is installed system-wide.