### PR TITLE
Fixes and testing for libkleeRuntest

### DIFF
--- a/runtime/Runtest/Makefile
+++ b/runtime/Runtest/Makefile
@@ -59,3 +59,14 @@ ifeq ($(HOST_OS), $(filter $(HOST_OS), Linux GNU GNU/kFreeBSD))
     # Don't allow unresolved symbols.
     LLVMLibsOptions += -Wl,--no-undefined
 endif
+
+ifeq ($(HOST_OS), Linux)
+	# HACK: Setup symlinks that `ldconfig` would set up
+	# so that libkleeRuntest can be used from the build directory.
+	# This is needed to run tests.
+	sym_link_name := $(SharedLibDir)/$(SharedPrefix)$(LIBRARYNAME)$(SHLIBEXT).$(SHARED_VERSION)
+
+all:: $(LibName.SO)
+	$(Verb) [ ! -e "$(sym_link_name)" ] && ln -s $(LibName.SO) "$(sym_link_name)" || echo ""
+
+endif

--- a/runtime/Runtest/intrinsics.c
+++ b/runtime/Runtest/intrinsics.c
@@ -10,8 +10,9 @@
 /* Straight C for linking simplicity */
 
 #include <assert.h>
-#include <stdlib.h>
+#include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/time.h>
@@ -29,6 +30,23 @@ static unsigned char rand_byte(void) {
   x ^= x>>16;
   x ^= x>>8;
   return x & 0xFF;
+}
+
+static void report_internal_error(const char *msg, ...)
+    __attribute__((format(printf, 1, 2)));
+static void report_internal_error(const char *msg, ...) {
+  fprintf(stderr, "KLEE_RUN_TEST_ERROR: ");
+  va_list ap;
+  va_start(ap, msg);
+  vfprintf(stderr, msg, ap);
+  va_end(ap);
+  fprintf(stderr, "\n");
+  char *testErrorsNonFatal = getenv("KLEE_RUN_TEST_ERRORS_NON_FATAL");
+  if (testErrorsNonFatal) {
+    fprintf(stderr, "KLEE_RUN_TEST_ERROR: Forcing execution to continue\n");
+  } else {
+    exit(1);
+  }
 }
 
 void klee_make_symbolic(void *array, size_t nbytes, const char *name) {
@@ -82,7 +100,7 @@ void klee_make_symbolic(void *array, size_t nbytes, const char *name) {
 
   for (;; ++testPosition) {
     if (testPosition >= testData->numObjects) {
-      fprintf(stderr, "ERROR: out of inputs, using zero\n");
+      report_internal_error("out of inputs. Will use zero if continuing.");
       memset(array, 0, nbytes);
       break;
     } else {
@@ -95,13 +113,14 @@ void klee_make_symbolic(void *array, size_t nbytes, const char *name) {
         continue;
       }
       if (strcmp(name, o->name) != 0) {
-        fprintf(stderr, "ERROR: object name mismatch. Requesting \"%s\" but "
-                        "returning \"%s\"",
-                name, o->name);
+        report_internal_error(
+            "object name mismatch. Requesting \"%s\" but returning \"%s\"",
+            name, o->name);
       }
       memcpy(array, o->bytes, nbytes < o->numBytes ? nbytes : o->numBytes);
       if (nbytes != o->numBytes) {
-        fprintf(stderr, "ERROR: object sizes differ\n");
+        report_internal_error("object sizes differ. Expected %zu but got %u",
+                              nbytes, o->numBytes);
         if (o->numBytes < nbytes)
           memset((char *)array + o->numBytes, 0, nbytes - o->numBytes);
       }
@@ -119,14 +138,13 @@ uintptr_t klee_choose(uintptr_t n) {
   uintptr_t x;
   klee_make_symbolic(&x, sizeof x, "klee_choose");
   if(x >= n)
-    fprintf(stderr, "ERROR: max = %ld, got = %ld\n", n, x);
-  assert(x < n);
+    report_internal_error("klee_choose failure. max = %ld, got = %ld\n", n, x);
   return x;
 }
 
 void klee_assume(uintptr_t x) {
   if (!x) {
-    fprintf(stderr, "ERROR: invalid klee_assume\n");
+    report_internal_error("invalid klee_assume");
   }
 }
 
@@ -148,10 +166,8 @@ int klee_range(int begin, int end, const char* name) {
   int x;
   klee_make_symbolic(&x, sizeof x, name);
   if (x<begin || x>=end) {
-    fprintf(stderr, 
-            "KLEE: ERROR: invalid klee_range(%u,%u,%s) value, got: %u\n", 
-            begin, end, name, x);
-    abort();
+    report_internal_error("invalid klee_range(%u,%u,%s) value, got: %u\n",
+                          begin, end, name, x);
   }
   return x;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,8 @@ set(LLVM_TOOLS_DIR "${LLVM_TOOLS_BINARY_DIR}")
 # is shared by both build systems.
 set(LLVMCC "${LLVMCC} -I${CMAKE_SOURCE_DIR}/include")
 set(LLVMCXX "${LLVMCXX} -I${CMAKE_SOURCE_DIR}/include")
+set(NATIVE_CC "${CMAKE_C_COMPILER} -I ${CMAKE_SOURCE_DIR}/include")
+set(NATIVE_CXX "${CMAKE_CXX_COMPILER} -I ${CMAKE_SOURCE_DIR}/include")
 set(TARGET_TRIPLE "${TARGET_TRIPLE}")
 if (ENABLE_KLEE_UCLIBC)
   set(ENABLE_UCLIBC 1)
@@ -105,6 +107,20 @@ add_subdirectory(Concrete)
 ###############################################################################
 # Configure lit test suite
 ###############################################################################
+
+# Find path to libkleeRuntest target for `lit.site.cfg`.
+# FIXME: This is not the right way to get the location of the target we have to
+# set CMP0026 to old.
+# This will likely break if using a multi-configuration generator.
+if (POLICY CMP0026)
+  # HACK: Allow reading `LOCATION` property.
+  cmake_policy(SET CMP0026 OLD)
+endif()
+get_property(LIB_KLEE_RUN_TEST_PATH
+  TARGET kleeRuntest
+  PROPERTY LOCATION
+)
+
 configure_file(lit.site.cfg.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
   @ONLY
@@ -112,7 +128,7 @@ configure_file(lit.site.cfg.in
 
 add_custom_target(integrationtests
   COMMAND "${LIT_TOOL}" ${LIT_ARGS} "${CMAKE_CURRENT_BINARY_DIR}"
-  DEPENDS klee kleaver
+  DEPENDS klee kleaver kleeRuntest
   COMMENT "Running integration tests"
   ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}
 )

--- a/test/Makefile
+++ b/test/Makefile
@@ -84,4 +84,7 @@ lit.site.cfg: lit.site.cfg.in
 	     -e "s#@HAVE_SELINUX@#$(HAVE_SELINUX)#g" \
 	     -e "s#@ENABLE_STP@#$(ENABLE_STP)#g" \
 	     -e "s#@ENABLE_Z3@#$(ENABLE_Z3)#g" \
+	     -e "s#@NATIVE_CC@#$(CC) -I$(PROJ_SRC_ROOT)/include#g" \
+	     -e "s#@NATIVE_CXX@#$(CXX) -I$(PROJ_SRC_ROOT)/include#g" \
+	     -e "s#@LIB_KLEE_RUN_TEST_PATH@#$(SharedLibDir)/$(SharedPrefix)kleeRuntest$(SHLIBEXT)#g" \
 	     $(PROJ_SRC_DIR)/lit.site.cfg.in > $@

--- a/test/Replay/libkleeruntest/replay_invalid_klee_assume.c
+++ b/test/Replay/libkleeruntest/replay_invalid_klee_assume.c
@@ -1,0 +1,44 @@
+// RUN: %llvmgcc -DASSUME_VALUE=1 %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --search=dfs %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: test ! -f %t.klee-out/test000002.ktest
+
+// Now try to replay with libkleeRuntest but build the binary to use a different
+// value for the `klee_assume()` call.
+// RUN: %cc -DASSUME_VALUE=32 -DPRINT_VALUE %s %libkleeruntest -Wl,-rpath=%libkleeruntestdir -o %t_runner
+
+// Check that the default is to exit with an error
+// RUN: not env KTEST_FILE=%t.klee-out/test000001.ktest %t_runner 2>&1 | FileCheck -check-prefix=CHECK_FATAL %s
+
+// Check that setting `KLEE_RUN_TEST_ERRORS_NON_FATAL` will not exit with an error
+// and will continue executing.
+// RUN: env KTEST_FILE=%t.klee-out/test000001.ktest KLEE_RUN_TEST_ERRORS_NON_FATAL=1 %t_runner 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+#include <stdint.h>
+#include <stdio.h>
+
+#ifndef ASSUME_VALUE
+#error ASSUME_VALUE must be defined
+#endif
+
+
+int main(int argc, char** argv) {
+  int x = 54;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_assume(x == ASSUME_VALUE);
+
+#ifdef PRINT_VALUE
+  printf("x=%d\n", x);
+#endif
+
+  return 0;
+}
+// CHECK: KLEE_RUN_TEST_ERROR: invalid klee_assume
+// CHECK: KLEE_RUN_TEST_ERROR: Forcing execution to continue
+// CHECK: x=1
+
+// CHECK_FATAL: KLEE_RUN_TEST_ERROR: invalid klee_assume
+// CHECK_FATAL-NOT: x=1
+

--- a/test/Replay/libkleeruntest/replay_invalid_klee_choose.c
+++ b/test/Replay/libkleeruntest/replay_invalid_klee_choose.c
@@ -1,0 +1,45 @@
+// RUN: %llvmgcc -DBOUND_VALUE=32 -DFORCE_VALUE=20 %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --libc=klee --search=dfs %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: test ! -f %t.klee-out/test000002.ktest
+
+// Now try to replay with libkleeRuntest but build the binary to use a different
+// bound for `klee_choose()`.
+// RUN: %cc -DBOUND_VALUE=2 -DPRINT_VALUE %s %libkleeruntest -Wl,-rpath=%libkleeruntestdir -o %t_runner
+
+// Check that the default is to exit with an error
+// RUN: not env KTEST_FILE=%t.klee-out/test000001.ktest %t_runner 2>&1 | FileCheck -check-prefix=CHECK_FATAL %s
+
+// Check that setting `KLEE_RUN_TEST_ERRORS_NON_FATAL` will not exit with an error
+// and will continue executing.
+// RUN: env KTEST_FILE=%t.klee-out/test000001.ktest KLEE_RUN_TEST_ERRORS_NON_FATAL=1 %t_runner 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+#include <stdint.h>
+#include <stdio.h>
+
+#ifndef BOUND_VALUE
+#error BOUND_VALUE must be defined
+#endif
+
+
+int main(int argc, char** argv) {
+  int x = klee_choose(BOUND_VALUE);
+#ifdef FORCE_VALUE
+  klee_assume(x == FORCE_VALUE);
+#endif
+
+#ifdef PRINT_VALUE
+  printf("x=%d\n", x);
+#endif
+
+  return 0;
+}
+// CHECK: KLEE_RUN_TEST_ERROR: klee_choose failure. max = 2, got = 20
+// CHECK: KLEE_RUN_TEST_ERROR: Forcing execution to continue
+// CHECK: x=20
+
+// CHECK_FATAL: KLEE_RUN_TEST_ERROR: klee_choose failure. max = 2, got = 20
+// CHECK_FATAL-NOT: x=20
+

--- a/test/Replay/libkleeruntest/replay_invalid_klee_range.c
+++ b/test/Replay/libkleeruntest/replay_invalid_klee_range.c
@@ -1,0 +1,45 @@
+// RUN: %llvmgcc -DBOUND_VALUE=32 -DFORCE_VALUE=20 %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --libc=klee --search=dfs %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: test ! -f %t.klee-out/test000002.ktest
+
+// Now try to replay with libkleeRuntest but build the binary to use a different
+// bound for `klee_range()`.
+// RUN: %cc -DBOUND_VALUE=2 -DPRINT_VALUE %s %libkleeruntest -Wl,-rpath=%libkleeruntestdir -o %t_runner
+
+// Check that the default is to exit with an error
+// RUN: not env KTEST_FILE=%t.klee-out/test000001.ktest %t_runner 2>&1 | FileCheck -check-prefix=CHECK_FATAL %s
+
+// Check that setting `KLEE_RUN_TEST_ERRORS_NON_FATAL` will not exit with an error
+// and will continue executing.
+// RUN: env KTEST_FILE=%t.klee-out/test000001.ktest KLEE_RUN_TEST_ERRORS_NON_FATAL=1 %t_runner 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+#include <stdint.h>
+#include <stdio.h>
+
+#ifndef BOUND_VALUE
+#error BOUND_VALUE must be defined
+#endif
+
+
+int main(int argc, char** argv) {
+  int x = klee_range(0, BOUND_VALUE, "x");
+#ifdef FORCE_VALUE
+  klee_assume(x == FORCE_VALUE);
+#endif
+
+#ifdef PRINT_VALUE
+  printf("x=%d\n", x);
+#endif
+
+  return 0;
+}
+// CHECK: KLEE_RUN_TEST_ERROR: invalid klee_range(0,2,x) value, got: 20
+// CHECK: KLEE_RUN_TEST_ERROR: Forcing execution to continue
+// CHECK: x=20
+
+// CHECK_FATAL: KLEE_RUN_TEST_ERROR: invalid klee_range(0,2,x) value, got: 20
+// CHECK_FATAL-NOT: x=20
+

--- a/test/Replay/libkleeruntest/replay_invalid_num_objects.c
+++ b/test/Replay/libkleeruntest/replay_invalid_num_objects.c
@@ -1,0 +1,39 @@
+// Compile program that only makes one klee_make_symbolic() call
+// RUN: %llvmgcc %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --search=dfs %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+
+// Now try to replay with libkleeRuntest but build the binary so it
+// makes two calls to klee_make_symbolic.
+// RUN: %cc -DEXTRA_MAKE_SYMBOLIC %s %libkleeruntest -Wl,-rpath=%libkleeruntestdir -o %t_runner
+
+// Check that the default is to exit with an error
+// RUN: not env KTEST_FILE=%t.klee-out/test000001.ktest %t_runner 2>&1 | FileCheck -check-prefix=CHECK_FATAL %s
+
+// Check that setting `KLEE_RUN_TEST_ERRORS_NON_FATAL` will not exit with an error
+// and will continue executing.
+// RUN: env KTEST_FILE=%t.klee-out/test000001.ktest KLEE_RUN_TEST_ERRORS_NON_FATAL=1 %t_runner 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+  int x = 0;
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+#ifdef EXTRA_MAKE_SYMBOLIC
+  int y = 1;
+  klee_make_symbolic(&y, sizeof(y), "x");
+  klee_assume(y == 0);
+  fprintf(stderr, "y is \"%d\"\n", y);
+#endif
+  return 0;
+}
+// CHECK: KLEE_RUN_TEST_ERROR: out of inputs
+// CHECK: KLEE_RUN_TEST_ERROR: Forcing execution to continue
+// CHECK: y is "0"
+
+// CHECK_FATAL: KLEE_RUN_TEST_ERROR: out of inputs
+// CHECK_FATAL-NOT: y is "0"
+

--- a/test/Replay/libkleeruntest/replay_invalid_object_names.c
+++ b/test/Replay/libkleeruntest/replay_invalid_object_names.c
@@ -1,0 +1,45 @@
+// RUN: %llvmgcc -DOBJ_NAME=simple_name %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --search=dfs %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+
+// Now try to replay with libkleeRuntest but build the binary to use a different
+// object name
+// RUN: %cc -DOBJ_NAME=wrong_name -DPRINT_VALUE %s %libkleeruntest -Wl,-rpath=%libkleeruntestdir -o %t_runner
+
+// Check that the default is to exit with an error
+// RUN: not env KTEST_FILE=%t.klee-out/test000001.ktest %t_runner 2>&1 | FileCheck -check-prefix=CHECK_FATAL %s
+
+// Check that setting `KLEE_RUN_TEST_ERRORS_NON_FATAL` will not exit with an error
+// and will continue executing.
+// RUN: env KTEST_FILE=%t.klee-out/test000001.ktest KLEE_RUN_TEST_ERRORS_NON_FATAL=1 %t_runner 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+#include <stdio.h>
+
+#ifndef OBJ_NAME
+#error OBJ_NAME must be defined
+#endif
+
+#define STRINGIFY(X) #X
+#define XSTRINGIFY(X) STRINGIFY(X)
+
+
+int main(int argc, char** argv) {
+  int x = 1;
+  klee_make_symbolic(&x, sizeof(x), XSTRINGIFY(OBJ_NAME));
+  klee_assume(x == 0);
+
+#ifdef PRINT_VALUE
+  printf("x=%d\n", x);
+#endif
+
+  return 0;
+}
+// CHECK: KLEE_RUN_TEST_ERROR: object name mismatch. Requesting "wrong_name" but returning "simple_name"
+// CHECK: KLEE_RUN_TEST_ERROR: Forcing execution to continue
+// CHECK: x=0
+
+// CHECK_FATAL: KLEE_RUN_TEST_ERROR: object name mismatch. Requesting "wrong_name" but returning "simple_name"
+// CHECK_FATAL-NOT: x=0
+

--- a/test/Replay/libkleeruntest/replay_invalid_object_size.c
+++ b/test/Replay/libkleeruntest/replay_invalid_object_size.c
@@ -1,0 +1,43 @@
+// RUN: %llvmgcc -DINT_TYPE=uint8_t %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --search=dfs %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: test ! -f %t.klee-out/test000002.ktest
+
+// Now try to replay with libkleeRuntest but build the binary to use a different
+// size for variable `x`.
+// RUN: %cc -DINT_TYPE=uint32_t -DPRINT_VALUE %s %libkleeruntest -Wl,-rpath=%libkleeruntestdir -o %t_runner
+
+// Check that the default is to exit with an error
+// RUN: not env KTEST_FILE=%t.klee-out/test000001.ktest %t_runner 2>&1 | FileCheck -check-prefix=CHECK_FATAL %s
+
+// Check that setting `KLEE_RUN_TEST_ERRORS_NON_FATAL` will not exit with an error
+// and will continue executing.
+// RUN: env KTEST_FILE=%t.klee-out/test000001.ktest KLEE_RUN_TEST_ERRORS_NON_FATAL=1 %t_runner 2>&1 | FileCheck %s
+#include "klee/klee.h"
+#include <stdint.h>
+#include <stdio.h>
+
+#ifndef INT_TYPE
+#error INT_TYPE must be defined
+#endif
+
+
+int main(int argc, char** argv) {
+  INT_TYPE x = 1;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_assume(x == 0);
+
+#ifdef PRINT_VALUE
+  printf("x=%d\n", x);
+#endif
+
+  return 0;
+}
+// CHECK: KLEE_RUN_TEST_ERROR: object sizes differ. Expected 4 but got 1
+// CHECK: KLEE_RUN_TEST_ERROR: Forcing execution to continue
+// CHECK: x=0
+
+// CHECK_FATAL: KLEE_RUN_TEST_ERROR: object sizes differ. Expected 4 but got 1
+// CHECK_FATAL-NOT: x=0
+

--- a/test/Replay/libkleeruntest/replay_posix_runtime.c
+++ b/test/Replay/libkleeruntest/replay_posix_runtime.c
@@ -1,6 +1,5 @@
 // REQUIRES: posix-runtime
 // FIXME: We need to fix a bug in libkleeRuntest
-// XFAIL: *
 // RUN: %llvmgcc %s -emit-llvm -g -O0 -c -o %t.bc
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --posix-runtime --search=dfs %t.bc

--- a/test/Replay/libkleeruntest/replay_posix_runtime.c
+++ b/test/Replay/libkleeruntest/replay_posix_runtime.c
@@ -1,0 +1,36 @@
+// REQUIRES: posix-runtime
+// FIXME: We need to fix a bug in libkleeRuntest
+// XFAIL: *
+// RUN: %llvmgcc %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --posix-runtime --search=dfs %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: test -f %t.klee-out/test000002.ktest
+
+// Now try to replay with libkleeRuntest
+// RUN: %cc %s %libkleeruntest -Wl,-rpath=%libkleeruntestdir -o %t_runner
+// RUN: %ktest-tool %t.klee-out/test000001.ktest | FileCheck -check-prefix=CHECKMODEL %s
+// RUN: env KTEST_FILE=%t.klee-out/test000001.ktest %t_runner | FileCheck -check-prefix=TESTONE %s
+// RUN: env KTEST_FILE=%t.klee-out/test000002.ktest %t_runner | FileCheck -check-prefix=TESTTWO %s
+
+#include "klee/klee.h"
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+  int x = 0;
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+  if (x == 0) {
+    printf("x is 0\n");
+  } else {
+    printf("x is not 0\n");
+  }
+  return 0;
+}
+
+// CHECKMODEL: num objects: 2
+// CHECKMODEL: object 0: name: {{b*}}'model_version'
+// CHECKMODEL: object 1: name: {{b*}}'x'
+
+// TESTONE: x is not 0
+// TESTTWO: x is 0

--- a/test/Replay/libkleeruntest/replay_simple.c
+++ b/test/Replay/libkleeruntest/replay_simple.c
@@ -1,0 +1,28 @@
+// RUN: %llvmgcc %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --search=dfs %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: test -f %t.klee-out/test000002.ktest
+
+// Now try to replay with libkleeRuntest
+// RUN: %cc %s %libkleeruntest -Wl,-rpath=%libkleeruntestdir -o %t_runner
+// RUN: env KTEST_FILE=%t.klee-out/test000001.ktest %t_runner | FileCheck -check-prefix=TESTONE %s
+// RUN: env KTEST_FILE=%t.klee-out/test000002.ktest %t_runner | FileCheck -check-prefix=TESTTWO %s
+
+#include "klee/klee.h"
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+  int x = 0;
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+  if (x == 0) {
+    printf("x is 0\n");
+  } else {
+    printf("x is not 0\n");
+  }
+  return 0;
+}
+
+// TESTONE: x is not 0
+// TESTTWO: x is 0

--- a/test/Replay/libkleeruntest/replay_two_objects.c
+++ b/test/Replay/libkleeruntest/replay_two_objects.c
@@ -1,0 +1,33 @@
+// RUN: %llvmgcc %s -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --search=dfs %t.bc 2>&1 | FileCheck %s
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: test ! -f %t.klee-out/test000002.ktest
+
+// Now try to replay with libkleeRuntest
+// RUN: %cc -DPRINT_VALUES %s %libkleeruntest -Wl,-rpath=%libkleeruntestdir -o %t_runner
+// RUN: env KTEST_FILE=%t.klee-out/test000001.ktest %t_runner | FileCheck -check-prefix=TESTONE %s
+
+#include "klee/klee.h"
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+  int x = 0;
+  int y = 0;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_make_symbolic(&y, sizeof(x), "y");
+
+  klee_assume(x == 1);
+  klee_assume(y == 128);
+
+#ifdef PRINT_VALUES
+  printf("x=%d\n", x);
+  printf("y=%d\n", y);
+#endif
+
+  return 0;
+}
+// CHECK: KLEE: done: completed paths = 1
+
+// TESTONE: x=1
+// TESTONE: y=128

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -76,7 +76,7 @@ if config.test_exec_root is None:
 
 
 # Add substitutions from lit.site.cfg
-subs = [ 'llvmgcc', 'llvmgxx']
+subs = [ 'llvmgcc', 'llvmgxx', 'cc', 'cxx']
 for name in subs:
     value = getattr(config, name, None)
     if value == None:
@@ -89,6 +89,10 @@ config.substitutions.append( ('%lli', os.path.join(llvm_tools_dir, 'lli')) )
 config.substitutions.append( ('%llvmas', os.path.join(llvm_tools_dir, 'llvm-as')) )
 # Add a substitution for llvm-ar
 config.substitutions.append( ('%llvmar', os.path.join(llvm_tools_dir, 'llvm-ar')) )
+
+# Add a substition for libkleeruntest
+config.substitutions.append( ('%libkleeruntestdir', os.path.dirname(config.libkleeruntest)) )
+config.substitutions.append( ('%libkleeruntest', config.libkleeruntest) )
 
 # Get KLEE and Kleaver specific parameters passed on llvm-lit cmd line
 # e.g. llvm-lit --param klee_opts=--help
@@ -107,7 +111,10 @@ if len(kleaver_extra_params) != 0:
     print("Passing extra Kleaver command line args: {0}".format(kleaver_extra_params))
 
 # Set absolute paths and extra cmdline args for KLEE's tools
-subs = [ ('%kleaver', 'kleaver', kleaver_extra_params), ('%klee','klee', klee_extra_params) ]
+subs = [ ('%kleaver', 'kleaver', kleaver_extra_params),
+  ('%klee','klee', klee_extra_params),
+  ('%ktest-tool', 'ktest-tool', '')
+]
 for s,basename,extra_args in subs:
     config.substitutions.append( ( s,
                                    "{0} {1}".format( os.path.join(klee_tools_dir, basename), extra_args ).strip()
@@ -140,3 +147,7 @@ if config.enable_z3:
   config.available_features.add('z3')
 else:
   config.available_features.add('not-z3')
+
+# POSIX runtime feature
+if config.enable_posix_runtime:
+  config.available_features.add('posix-runtime')

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -14,6 +14,9 @@ config.llvm_version_minor = "@LLVM_VERSION_MINOR@"
 config.llvmgcc = "@LLVMCC@"
 config.llvmgxx = "@LLVMCXX@"
 
+config.cc = "@NATIVE_CC@"
+config.cxx = "@NATIVE_CXX@"
+
 # Features
 config.enable_uclibc = True if @ENABLE_UCLIBC@ == 1 else False
 config.enable_posix_runtime = True if @ENABLE_POSIX_RUNTIME@ == 1 else False
@@ -23,6 +26,9 @@ config.enable_z3 = True if @ENABLE_Z3@ == 1 else False
 
 # Current target
 config.target_triple = "@TARGET_TRIPLE@"
+
+# Path to libkleeRuntest
+config.libkleeruntest = "@LIB_KLEE_RUN_TEST_PATH@"
 
 # Let the main config do the real work.
 try:


### PR DESCRIPTION
This contains fixes and enhancements for libkleeRuntest that I previously discussed with @danielschemmel.

The main changes are

* Add actual tests!
* Fix a bug when replaying test cases created when KLEE ran using the POSIX runtime
* Fix how errors are handled inside libkleeRuntest so by default it exits when errors occur instead of the old behaviour which just carried on executing (which seems a pretty silly default).

@danielschemmel could you review this?