### PR TITLE
[cmake] add PATH_SUFFIXES needed to find z3 on Fedora

### DIFF
--- a/cmake/modules/FindZ3.cmake
+++ b/cmake/modules/FindZ3.cmake
@@ -20,6 +20,9 @@ endif()
 # Try to find headers
 find_path(Z3_INCLUDE_DIRS
   NAMES z3.h
+  # For distributions that keep the header files in a `z3` folder,
+  # for example Fedora's `z3-devel` package at `/usr/include/z3/z3.h`
+  PATH_SUFFIXES z3
   DOC "Z3 C header"
 )
 if (Z3_INCLUDE_DIRS)


### PR DESCRIPTION
On Fedora 25 the `z3.h` file from the `z3-devel` package is located at `/usr/include/z3`.
The `FindZ3.cmake ` script need a little hint to be able to find that location.