### PR TITLE
ReadExpr::create() was missing an opportunity to constant fold

### DIFF
--- a/test/Feature/RewriteEqualities.c
+++ b/test/Feature/RewriteEqualities.c
@@ -5,7 +5,7 @@
 // RUN: grep "N0)" %t.klee-out/test000003.kquery
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --search=dfs --write-kqueries --rewrite-equalities %t.bc
-// RUN: grep "(Read w8 8 const_arr1)" %t.klee-out/test000003.kquery
+// RUN: FileCheck -input-file=%t.klee-out/test000003.kquery %s
 
 #include <stdio.h>
 #include <klee/klee.h>
@@ -19,6 +19,8 @@ int run(unsigned char * x, unsigned char * y) {
 
   if(y[x[2]] < 11){
     if(x[2] == 8){
+      // CHECK:      (query [(Eq 8 (Read w8 2 x))]
+      // CHECK-NEXT: false)
       return 2;
     } else{
       return 3;


### PR DESCRIPTION
`ReadExpr::create()` was missing an opportunity to constant fold when handling constant arrays.

@andreamattavelli This a sketch of a potential optimization we have been discussing.