### PR TITLE
Bug fix for TreeStreamWriter.

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -971,6 +971,16 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
         falseState->symPathOS << "0";
       }
     }
+    else{
+    	// Need to update the pathOS.id field of falseState, otherwise the same id is used
+    	// for both falseState and trueState.
+    	if (pathWriter) {
+		falseState->pathOS = pathWriter->open(current.pathOS);
+	  }
+	  if (symPathWriter) {
+		falseState->symPathOS = symPathWriter->open(current.symPathOS);
+	  }
+    }
 
     addConstraint(*trueState, condition);
     addConstraint(*falseState, Expr::createIsZero(condition));

--- a/lib/Support/TreeStream.cpp
+++ b/lib/Support/TreeStream.cpp
@@ -77,7 +77,7 @@ void TreeStreamWriter::write(TreeOStream &os, const char *s, unsigned size) {
   } else {
     output->write(reinterpret_cast<const char*>(&os.id), 4);
     output->write(reinterpret_cast<const char*>(&size), 4);
-    output->write(buffer, size);
+    output->write(s, size);//need to write s directly
   }
 #else
   output->write(reinterpret_cast<const char*>(&os.id), 4);


### PR DESCRIPTION
Bug fixes for pathOS.id and tree stream writer.

For pathOS.id, it is not updated when there is an internal fork. Causing both trueState and falseState to have the same pathOS.id. 

I only fixed the fork function in Executor.cpp. The branch function might also need a patch.

For tree stream writer, the bug is always writing the empty 'buffer' instead of the real string, when the buffer is empty and the string is longer than the size of buffer.
