### PR TITLE
test: fix broken Vararg test

### DIFF
--- a/test/Feature/Vararg.c
+++ b/test/Feature/Vararg.c
@@ -12,7 +12,7 @@ struct triple {
   int first, second, third;
 };
 
-int test1(int x, ...) {
+void test1(int x, ...) {
   va_list ap;
   va_start(ap, x);
   int i32 = va_arg(ap, int);


### PR DESCRIPTION
The helper function had int return type, while no value was being
returned.
