### PR TITLE
Memory leak detection feature

### DIFF
--- a/lib/Core/AddressSpace.cpp
+++ b/lib/Core/AddressSpace.cpp
@@ -285,6 +285,20 @@ bool AddressSpace::resolve(ExecutionState &state,
   return false;
 }
 
+const MemoryObject* AddressSpace::getAnyDynamicObject() {
+  for (MemoryMap::iterator it = objects.begin(), ie = objects.end(); 
+       it != ie; ++it) {
+    const MemoryObject *mo = it->first;
+
+    if (mo->isLocal || mo->isGlobal) {
+      continue;
+    } else {
+      return mo;
+    }
+  }
+  return NULL;
+}
+
 // These two are pretty big hack so we can sort of pass memory back
 // and forth to externals. They work by abusing the concrete cache
 // store inside of the object states, which allows them to

--- a/lib/Core/AddressSpace.h
+++ b/lib/Core/AddressSpace.h
@@ -112,6 +112,8 @@ namespace klee {
     /// \return A writeable ObjectState (\a os or a copy).
     ObjectState *getWriteable(const MemoryObject *mo, const ObjectState *os);
 
+    const MemoryObject* getAnyDynamicObject();
+
     /// Copy the concrete values of all managed ObjectStates into the
     /// actual system memory location they were allocated at.
     void copyOutConcretes();

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1528,6 +1528,16 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     }
     
     if (state.stack.size() <= 1) {
+      const MemoryObject* mo = state.addressSpace.getAnyDynamicObject();
+      if (mo) {
+          std::string alloc_info;
+
+          mo->getAllocInfo(alloc_info);
+          terminateStateOnError(state,
+                        "memory error: memory leak ",
+                        Ptr, NULL, alloc_info);
+          return;
+      }
       assert(!caller && "caller set on initial stack frame");
       terminateStateOnExit(state);
     } else {


### PR DESCRIPTION
I intend to improve memory analysis in KLEE projects. 
So this is the first patch, which allow users to detect memory leaks in programs. The detection is performed at the end of program. If there is any dynamic object (in the end of program), it means that memory leak error exists in program.