### PR TITLE
Increased the type size for the stop-after-n-instructions option to a…

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -290,7 +290,7 @@ namespace {
 		    clEnumValEnd),
 		  cl::ZeroOrMore);
 
-  cl::opt<unsigned int>
+  cl::opt<unsigned long long>
   StopAfterNInstructions("stop-after-n-instructions",
                          cl::desc("Stop execution after specified number of instructions (default=0 (off))"),
                          cl::init(0));


### PR DESCRIPTION
…void too strict limitations

This PR fixes issues for executing KLEE on binutils (e.g., AR and AS where the instruction limit is around 9 billion).