### PR TITLE
Silenced warning: comparison of integers of different signs ('const i…

### DIFF
--- a/unittests/Expr/ExprTest.cpp
+++ b/unittests/Expr/ExprTest.cpp
@@ -182,7 +182,7 @@ TEST(ExprTest, ReadExprFoldingConstantUpdate) {
   // Check that constant folding worked
   EXPECT_EQ(Expr::Constant, read.get()->getKind());
   ConstantExpr *c = static_cast<ConstantExpr *>(read.get());
-  EXPECT_EQ(32, c->getZExtValue());
+  EXPECT_EQ(UINT64_C(32), c->getZExtValue());
 }
 
 TEST(ExprTest, ReadExprFoldingConstantMultipleUpdate) {
@@ -209,7 +209,7 @@ TEST(ExprTest, ReadExprFoldingConstantMultipleUpdate) {
   // Check that constant folding worked
   EXPECT_EQ(Expr::Constant, read.get()->getKind());
   ConstantExpr *c = static_cast<ConstantExpr *>(read.get());
-  EXPECT_EQ(64, c->getZExtValue());
+  EXPECT_EQ(UINT64_C(64), c->getZExtValue());
 }
 
 TEST(ExprTest, ReadExprFoldingSymbolicValueUpdate) {


### PR DESCRIPTION
…nt' and 'const unsigned long long')