### PR TITLE
Makefile: change -std-compile-opts to -O3

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1622,12 +1622,12 @@ $(ObjDir)/%.s: %.m $(ObjDir)/.dir $(BUILT_SOURCES)
 ifdef DEBUG_RUNTIME
 $(ObjectsBC): $(ObjDir)/%.bc: $(ObjDir)/%.ll $(LLVMAS) $(LOPT)
 	$(Echo) "Compiling $*.ll to $*.bc for $(BuildMode) build (bytecode)"
-	$(Verb) $(LLVMAS) $< -o - | $(LOPT) -std-compile-opts -o $@
+	$(Verb) $(LLVMAS) $< -o - | $(LOPT) -O3 -o $@
 else
 $(ObjectsBC): $(ObjDir)/%.bc: $(ObjDir)/%.ll $(LLVMAS) $(LOPT)
 	$(Echo) "Compiling $*.ll to $*.bc for $(BuildMode) build (bytecode)"
 	$(Verb) $(LLVMAS) $< -o - | \
-	   $(LOPT) -std-compile-opts -strip-debug -o $@
+	   $(LOPT) -O3 -strip-debug -o $@
 endif
 
 


### PR DESCRIPTION
As per:
http://llvm.org/releases/3.6.0/docs/ReleaseNotes.html#the-opt-option-std-compile-opts-was-removed
the -std-compile-opts was effectively an alias of -O3. And since it was
removed in later LLVM versions, stop relying on that.