### PR TITLE
llvm: stop using global context

### DIFF
--- a/include/klee/Interpreter.h
+++ b/include/klee/Interpreter.h
@@ -18,6 +18,7 @@ struct KTest;
 
 namespace llvm {
 class Function;
+class LLVMContext;
 class Module;
 class raw_ostream;
 class raw_fd_ostream;
@@ -93,7 +94,8 @@ protected:
 public:
   virtual ~Interpreter() {}
 
-  static Interpreter *create(const InterpreterOptions &_interpreterOpts,
+  static Interpreter *create(llvm::LLVMContext &ctx,
+                             const InterpreterOptions &_interpreterOpts,
                              InterpreterHandler *ih);
 
   /// Register the module to be executed.  

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -343,9 +343,10 @@ const char *Executor::TerminateReasonNames[] = {
   [ Unhandled ] = "xxx",
 };
 
-Executor::Executor(const InterpreterOptions &opts, InterpreterHandler *ih)
+Executor::Executor(LLVMContext &ctx, const InterpreterOptions &opts,
+    InterpreterHandler *ih)
     : Interpreter(opts), kmodule(0), interpreterHandler(ih), searcher(0),
-      externalDispatcher(new ExternalDispatcher()), statsTracker(0),
+      externalDispatcher(new ExternalDispatcher(ctx)), statsTracker(0),
       pathWriter(0), symPathWriter(0), specialFunctionHandler(0),
       processTree(0), replayKTest(0), replayPath(0), usingSeeds(0),
       atMemoryLimit(false), inhibitForking(false), haltExecution(false),
@@ -1552,7 +1553,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
       if (!isVoidReturn) {
         LLVM_TYPE_Q Type *t = caller->getType();
-        if (t != Type::getVoidTy(getGlobalContext())) {
+        if (t != Type::getVoidTy(i->getContext())) {
           // may need to do coercion due to bitcasts
           Expr::Width from = result->getWidth();
           Expr::Width to = getWidthForLLVMType(t);
@@ -3087,7 +3088,7 @@ void Executor::callExternalFunction(ExecutionState &state,
   }
 
   LLVM_TYPE_Q Type *resultType = target->inst->getType();
-  if (resultType != Type::getVoidTy(getGlobalContext())) {
+  if (resultType != Type::getVoidTy(function->getContext())) {
     ref<Expr> e = ConstantExpr::fromMemory((void*) args, 
                                            getWidthForLLVMType(resultType));
     bindLocal(target, state, e);
@@ -3756,7 +3757,7 @@ Expr::Width Executor::getWidthForLLVMType(LLVM_TYPE_Q llvm::Type *type) const {
 
 ///
 
-Interpreter *Interpreter::create(const InterpreterOptions &opts,
+Interpreter *Interpreter::create(LLVMContext &ctx, const InterpreterOptions &opts,
                                  InterpreterHandler *ih) {
-  return new Executor(opts, ih);
+  return new Executor(ctx, opts, ih);
 }

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -41,6 +41,7 @@ namespace llvm {
   class Function;
   class GlobalValue;
   class Instruction;
+  class LLVMContext;
 #if LLVM_VERSION_CODE <= LLVM_VERSION(3, 1)
   class TargetData;
 #else
@@ -434,7 +435,8 @@ private:
   void doDumpStates();
 
 public:
-  Executor(const InterpreterOptions &opts, InterpreterHandler *ie);
+  Executor(llvm::LLVMContext &ctx, const InterpreterOptions &opts,
+      InterpreterHandler *ie);
   virtual ~Executor();
 
   const InterpreterHandler& getHandler() {

--- a/lib/Core/ExternalDispatcher.cpp
+++ b/lib/Core/ExternalDispatcher.cpp
@@ -85,8 +85,8 @@ void *ExternalDispatcher::resolveSymbol(const std::string &name) {
   return addr;
 }
 
-ExternalDispatcher::ExternalDispatcher() {
-  dispatchModule = new Module("ExternalDispatcher", getGlobalContext());
+ExternalDispatcher::ExternalDispatcher(LLVMContext &ctx) {
+  dispatchModule = new Module("ExternalDispatcher", ctx);
 
   std::string error;
   executionEngine = ExecutionEngine::createJIT(dispatchModule, &error);
@@ -195,6 +195,7 @@ Function *ExternalDispatcher::createDispatcher(Function *target, Instruction *in
   if (!resolveSymbol(target->getName()))
     return 0;
 
+  LLVMContext &ctx = target->getContext();
   CallSite cs;
   if (inst->getOpcode()==Instruction::Call) {
     cs = CallSite(cast<CallInst>(inst));
@@ -206,20 +207,20 @@ Function *ExternalDispatcher::createDispatcher(Function *target, Instruction *in
 
   std::vector<LLVM_TYPE_Q Type*> nullary;
   
-  Function *dispatcher = Function::Create(FunctionType::get(Type::getVoidTy(getGlobalContext()), 
+  Function *dispatcher = Function::Create(FunctionType::get(Type::getVoidTy(ctx),
 							    nullary, false),
 					  GlobalVariable::ExternalLinkage, 
 					  "",
 					  dispatchModule);
 
 
-  BasicBlock *dBB = BasicBlock::Create(getGlobalContext(), "entry", dispatcher);
+  BasicBlock *dBB = BasicBlock::Create(ctx, "entry", dispatcher);
 
   // Get a Value* for &gTheArgsP, as an i64**.
   Instruction *argI64sp = 
-    new IntToPtrInst(ConstantInt::get(Type::getInt64Ty(getGlobalContext()), 
+    new IntToPtrInst(ConstantInt::get(Type::getInt64Ty(ctx),
                                       (uintptr_t) (void*) &gTheArgsP),
-                     PointerType::getUnqual(PointerType::getUnqual(Type::getInt64Ty(getGlobalContext()))),
+                     PointerType::getUnqual(PointerType::getUnqual(Type::getInt64Ty(ctx))),
                      "argsp", dBB);
   Instruction *argI64s = new LoadInst(argI64sp, "args", dBB); 
   
@@ -238,8 +239,7 @@ Function *ExternalDispatcher::createDispatcher(Function *target, Instruction *in
                                (*ai)->getType());
     Instruction *argI64p = 
       GetElementPtrInst::Create(argI64s, 
-                                ConstantInt::get(Type::getInt32Ty(getGlobalContext()), 
-                                                 idx), 
+                                ConstantInt::get(Type::getInt32Ty(ctx), idx),
                                 "", dBB);
 
     Instruction *argp = new BitCastInst(argI64p, PointerType::getUnqual(argTy),
@@ -260,14 +260,14 @@ Function *ExternalDispatcher::createDispatcher(Function *target, Instruction *in
 #else
   Instruction *result = CallInst::Create(dispatchTarget, args, args+i, "", dBB);
 #endif
-  if (result->getType() != Type::getVoidTy(getGlobalContext())) {
+  if (result->getType() != Type::getVoidTy(ctx)) {
     Instruction *resp = 
       new BitCastInst(argI64s, PointerType::getUnqual(result->getType()), 
                       "", dBB);
     new StoreInst(result, resp, dBB);
   }
 
-  ReturnInst::Create(getGlobalContext(), dBB);
+  ReturnInst::Create(ctx, dBB);
 
   delete[] args;
 

--- a/lib/Core/ExternalDispatcher.h
+++ b/lib/Core/ExternalDispatcher.h
@@ -17,6 +17,7 @@
 namespace llvm {
   class ExecutionEngine;
   class Instruction;
+  class LLVMContext;
   class Function;
   class FunctionType;
   class Module;
@@ -35,7 +36,7 @@ namespace klee {
     bool runProtectedCall(llvm::Function *f, uint64_t *args);
     
   public:
-    ExternalDispatcher();
+    ExternalDispatcher(llvm::LLVMContext &ctx);
     ~ExternalDispatcher();
 
     /* Call the given function using the parameter passing convention of

--- a/lib/Module/Checks.cpp
+++ b/lib/Module/Checks.cpp
@@ -53,6 +53,7 @@ char DivCheckPass::ID;
 
 bool DivCheckPass::runOnModule(Module &M) { 
   Function *divZeroCheckFunction = 0;
+  LLVMContext &ctx = M.getContext();
 
   bool moduleChanged = false;
   
@@ -67,7 +68,7 @@ bool DivCheckPass::runOnModule(Module &M) {
             
             CastInst *denominator =
               CastInst::CreateIntegerCast(i->getOperand(1),
-                                          Type::getInt64Ty(getGlobalContext()),
+                                          Type::getInt64Ty(ctx),
                                           false,  /* sign doesn't matter */
                                           "int_cast_to_i64",
                                           i);
@@ -75,8 +76,8 @@ bool DivCheckPass::runOnModule(Module &M) {
             // Lazily bind the function to avoid always importing it.
             if (!divZeroCheckFunction) {
               Constant *fc = M.getOrInsertFunction("klee_div_zero_check", 
-                                                   Type::getVoidTy(getGlobalContext()), 
-                                                   Type::getInt64Ty(getGlobalContext()), 
+                                                   Type::getVoidTy(ctx),
+                                                   Type::getInt64Ty(ctx),
                                                    NULL);
               divZeroCheckFunction = cast<Function>(fc);
             }
@@ -100,6 +101,7 @@ char OvershiftCheckPass::ID;
 
 bool OvershiftCheckPass::runOnModule(Module &M) {
   Function *overshiftCheckFunction = 0;
+  LLVMContext &ctx = M.getContext();
 
   bool moduleChanged = false;
 
@@ -118,12 +120,13 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
             // Determine bit width of first operand
             uint64_t bitWidth=i->getOperand(0)->getType()->getScalarSizeInBits();
 
-            ConstantInt *bitWidthC = ConstantInt::get(Type::getInt64Ty(getGlobalContext()),bitWidth,false);
+            ConstantInt *bitWidthC = ConstantInt::get(Type::getInt64Ty(ctx),
+		bitWidth, false);
             args.push_back(bitWidthC);
 
             CastInst *shift =
               CastInst::CreateIntegerCast(i->getOperand(1),
-                                          Type::getInt64Ty(getGlobalContext()),
+                                          Type::getInt64Ty(ctx),
                                           false,  /* sign doesn't matter */
                                           "int_cast_to_i64",
                                           i);
@@ -133,9 +136,9 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
             // Lazily bind the function to avoid always importing it.
             if (!overshiftCheckFunction) {
               Constant *fc = M.getOrInsertFunction("klee_overshift_check",
-                                                   Type::getVoidTy(getGlobalContext()),
-                                                   Type::getInt64Ty(getGlobalContext()),
-                                                   Type::getInt64Ty(getGlobalContext()),
+                                                   Type::getVoidTy(ctx),
+                                                   Type::getInt64Ty(ctx),
+                                                   Type::getInt64Ty(ctx),
                                                    NULL);
               overshiftCheckFunction = cast<Function>(fc);
             }

--- a/lib/Module/LowerSwitch.cpp
+++ b/lib/Module/LowerSwitch.cpp
@@ -66,7 +66,7 @@ void LowerSwitchPass::switchConvert(CaseItr begin, CaseItr end,
   
   // iterate through all the cases, creating a new BasicBlock for each
   for (CaseItr it = begin; it < end; ++it) {
-    BasicBlock *newBlock = BasicBlock::Create(getGlobalContext(), "NodeBlock");
+    BasicBlock *newBlock = BasicBlock::Create(F->getContext(), "NodeBlock");
     Function::iterator FI = origBlock;
     F->getBasicBlockList().insert(++FI, newBlock);
     
@@ -102,7 +102,7 @@ void LowerSwitchPass::processSwitchInst(SwitchInst *SI) {
 
   // Create a new, empty default block so that the new hierarchy of
   // if-then statements go to this and the PHI nodes are happy.
-  BasicBlock* newDefault = BasicBlock::Create(getGlobalContext(), "newDefault");
+  BasicBlock* newDefault = BasicBlock::Create(F->getContext(), "newDefault");
 
   F->getBasicBlockList().insert(defaultBlock, newDefault);
   BranchInst::Create(defaultBlock, newDefault);

--- a/lib/Module/ModuleUtil.cpp
+++ b/lib/Module/ModuleUtil.cpp
@@ -248,7 +248,8 @@ static bool linkBCA(object::Archive* archive, Module* composite, std::string& er
       if (buff)
       {
         // FIXME: Maybe load bitcode file lazily? Then if we need to link, materialise the module
-        Result = ParseBitcodeFile(buff.get(), getGlobalContext(), &errorMessage);
+        Result = ParseBitcodeFile(buff.get(), composite->getContext(),
+	    &errorMessage);
 
         if(!Result)
         {
@@ -378,7 +379,7 @@ Module *klee::linkWithLibrary(Module *module,
 
   sys::fs::file_magic magic = sys::fs::identify_magic(Buffer->getBuffer());
 
-  LLVMContext &Context = getGlobalContext();
+  LLVMContext &Context = module->getContext();
   std::string ErrorMessage;
 
   if (magic == sys::fs::file_magic::bitcode) {


### PR DESCRIPTION
It was marked as deprecated long time ago and finally removed in LLVM
3.9. Remove all uses of getGlobalContext and create our own context.
Propagate it all over the code then.