### PR TITLE
Solver: QueryLoggingSolver, make ErrorInfo local

### DIFF
--- a/lib/Solver/QueryLoggingSolver.cpp
+++ b/lib/Solver/QueryLoggingSolver.cpp
@@ -39,6 +39,7 @@ QueryLoggingSolver::QueryLoggingSolver(Solver *_solver, std::string path,
     : solver(_solver), os(0), BufferString(""), logBuffer(BufferString),
       queryCount(0), minQueryTimeToLog(queryTimeToLog), startTime(0.0f),
       lastQueryTime(0.0f), queryCommentSign(commentSign) {
+  std::string ErrorInfo;
 #ifdef HAVE_ZLIB_H
   if (!CreateCompressedQueryLog) {
 #endif

--- a/lib/Solver/QueryLoggingSolver.h
+++ b/lib/Solver/QueryLoggingSolver.h
@@ -25,7 +25,6 @@ class QueryLoggingSolver : public SolverImpl {
 
 protected:
   Solver *solver;
-  std::string ErrorInfo;
   llvm::raw_ostream *os;
   // @brief Buffer used by logBuffer
   std::string BufferString;


### PR DESCRIPTION
ErrorInfo is not used anywhere outside of QueryLoggingSolver
constructor. No need to preserve it in the class, so let's have it only
in the constructor.