### PR TITLE
CommandLine: do not copy list in optionIsSet

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -70,8 +70,7 @@ extern llvm::cl::opt<klee::MetaSMTBackendType> MetaSMTBackend;
 
 //A bit of ugliness so we can use cl::list<> like cl::bits<>, see queryLoggingOptions
 template <typename T>
-static bool optionIsSet(llvm::cl::list<T> list, T option)
-{
+static bool optionIsSet(llvm::cl::list<T> &list, T option) {
     return std::find(list.begin(), list.end(), option) != list.end();
 }
 


### PR DESCRIPTION
Pass the list as reference. Otherwise we can get errors with newer LLVM
like:
```
lib/Basic/ConstructSolverChain.cpp:26:19: error: call to deleted constructor of 'llvm::cl::list<QueryLoggingSolverType>'
  if (optionIsSet(queryLoggingOptions, SOLVER_KQUERY)) {
                  ^~~~~~~~~~~~~~~~~~~
llvm/Support/CommandLine.h:1466:3: note: 'list' has been explicitly marked deleted here
  list(const list &) = delete;
  ^
```