### PR TITLE
convert iterators using static_cast

### DIFF
--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -165,7 +165,7 @@ static bool instructionIsCoverable(Instruction *i) {
     if (it==bb->begin()) {
       return true;
     } else {
-      Instruction *prev = --it;
+      Instruction *prev = static_cast<Instruction *>(--it);
       if (isa<CallInst>(prev) || isa<InvokeInst>(prev)) {
         Function *target =
             getDirectCallTarget(prev, /*moduleIsFullyLinked=*/true);
@@ -539,7 +539,8 @@ void StatsTracker::writeIStats() {
       // Always try to write the filename before the function name, as otherwise
       // KCachegrind can create two entries for the function, one with an
       // unnamed file and one without.
-      const InstructionInfo &ii = executor.kmodule->infos->getFunctionInfo(fnIt);
+      Function *fn = static_cast<Function *>(fnIt);
+      const InstructionInfo &ii = executor.kmodule->infos->getFunctionInfo(fn);
       if (ii.file != sourceFile) {
         of << "fl=" << ii.file << "\n";
         sourceFile = ii.file;
@@ -635,9 +636,9 @@ static std::vector<Instruction*> getSuccs(Instruction *i) {
 
   if (i==bb->getTerminator()) {
     for (succ_iterator it = succ_begin(bb), ie = succ_end(bb); it != ie; ++it)
-      res.push_back(it->begin());
+      res.push_back(static_cast<Instruction *>(it->begin()));
   } else {
-    res.push_back(++BasicBlock::iterator(i));
+    res.push_back(static_cast<Instruction *>(++BasicBlock::iterator(i)));
   }
 
   return res;
@@ -684,18 +685,19 @@ void StatsTracker::computeReachableUncovered() {
            bbIt != bb_ie; ++bbIt) {
         for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
              it != ie; ++it) {
-          if (isa<CallInst>(it) || isa<InvokeInst>(it)) {
-            CallSite cs(it);
+          Instruction *inst = static_cast<Instruction *>(it);
+          if (isa<CallInst>(inst) || isa<InvokeInst>(inst)) {
+            CallSite cs(inst);
             if (isa<InlineAsm>(cs.getCalledValue())) {
               // We can never call through here so assume no targets
               // (which should be correct anyhow).
-              callTargets.insert(std::make_pair(it,
+              callTargets.insert(std::make_pair(inst,
                                                 std::vector<Function*>()));
             } else if (Function *target = getDirectCallTarget(
                            cs, /*moduleIsFullyLinked=*/true)) {
-              callTargets[it].push_back(target);
+              callTargets[inst].push_back(target);
             } else {
-              callTargets[it] = 
+              callTargets[inst] =
                 std::vector<Function*>(km->escapingFunctions.begin(),
                                        km->escapingFunctions.end());
             }
@@ -716,14 +718,15 @@ void StatsTracker::computeReachableUncovered() {
     std::vector<Instruction *> instructions;
     for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
          fnIt != fn_ie; ++fnIt) {
+      Function *fn = static_cast<Function *>(fnIt);
       if (fnIt->isDeclaration()) {
         if (fnIt->doesNotReturn()) {
-          functionShortestPath[fnIt] = 0;
+          functionShortestPath[fn] = 0;
         } else {
-          functionShortestPath[fnIt] = 1; // whatever
+          functionShortestPath[fn] = 1; // whatever
         }
       } else {
-        functionShortestPath[fnIt] = 0;
+        functionShortestPath[fn] = 0;
       }
 
       // Not sure if I should bother to preorder here. XXX I should.
@@ -731,13 +734,14 @@ void StatsTracker::computeReachableUncovered() {
            bbIt != bb_ie; ++bbIt) {
         for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
              it != ie; ++it) {
-          instructions.push_back(it);
-          unsigned id = infos.getInfo(it).id;
+          Instruction *inst = static_cast<Instruction *>(it);
+          instructions.push_back(inst);
+          unsigned id = infos.getInfo(inst).id;
           sm.setIndexedValue(stats::minDistToReturn, 
                              id, 
-                             isa<ReturnInst>(it)
+                             isa<ReturnInst>(inst)
 #if LLVM_VERSION_CODE < LLVM_VERSION(3, 1)
-                             || isa<UnwindInst>(it)
+                             || isa<UnwindInst>(inst)
 #endif
                              );
         }
@@ -790,13 +794,13 @@ void StatsTracker::computeReachableUncovered() {
           // that no return instructions are reachable)
           Function *f = inst->getParent()->getParent();
           if (best != cur
-              || (inst == f->begin()->begin()
+              || (inst == static_cast<Instruction *>(f->begin()->begin())
                   && functionShortestPath[f] != best)) {
             sm.setIndexedValue(stats::minDistToReturn, id, best);
             changed = true;
 
             // Update shortest path if this is the entry point.
-            if (inst==f->begin()->begin())
+            if (inst == static_cast<Instruction *>(f->begin()->begin()))
               functionShortestPath[f] = best;
           }
         }
@@ -813,8 +817,9 @@ void StatsTracker::computeReachableUncovered() {
          bbIt != bb_ie; ++bbIt) {
       for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
            it != ie; ++it) {
-        unsigned id = infos.getInfo(it).id;
-        instructions.push_back(&*it);
+        Instruction *inst = static_cast<Instruction *>(it);
+        unsigned id = infos.getInfo(inst).id;
+        instructions.push_back(inst);
         sm.setIndexedValue(stats::minDistToUncovered, 
                            id, 
                            sm.getIndexedValue(stats::uncoveredInstructions, id));

--- a/lib/Module/Checks.cpp
+++ b/lib/Module/Checks.cpp
@@ -71,7 +71,7 @@ bool DivCheckPass::runOnModule(Module &M) {
                                           Type::getInt64Ty(ctx),
                                           false,  /* sign doesn't matter */
                                           "int_cast_to_i64",
-                                          i);
+                                          static_cast<Instruction *>(i));
             
             // Lazily bind the function to avoid always importing it.
             if (!divZeroCheckFunction) {
@@ -129,7 +129,7 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
                                           Type::getInt64Ty(ctx),
                                           false,  /* sign doesn't matter */
                                           "int_cast_to_i64",
-                                          i);
+                                          static_cast<Instruction *>(i));
             args.push_back(shift);
 
 

--- a/lib/Module/InstructionInfoTable.cpp
+++ b/lib/Module/InstructionInfoTable.cpp
@@ -120,6 +120,7 @@ InstructionInfoTable::InstructionInfoTable(Module *m)
 
   for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
        fnIt != fn_ie; ++fnIt) {
+    Function *fn = static_cast<Function *>(fnIt);
 
     // We want to ensure that as all instructions have source information, if
     // available. Clang sometimes will not write out debug information on the
@@ -128,15 +129,14 @@ InstructionInfoTable::InstructionInfoTable(Module *m)
     // if any.
     const std::string *initialFile = &dummyString;
     unsigned initialLine = 0;
-    for (inst_iterator it = inst_begin(fnIt), ie = inst_end(fnIt); it != ie;
-         ++it) {
+    for (inst_iterator it = inst_begin(fn), ie = inst_end(fn); it != ie; ++it) {
       if (getInstructionDebugInfo(&*it, initialFile, initialLine))
         break;
     }
 
     const std::string *file = initialFile;
     unsigned line = initialLine;
-    for (inst_iterator it = inst_begin(fnIt), ie = inst_end(fnIt); it != ie;
+    for (inst_iterator it = inst_begin(fn), ie = inst_end(fn); it != ie;
         ++it) {
       Instruction *instr = &*it;
       unsigned assemblyLine = lineTable[instr];
@@ -193,6 +193,6 @@ InstructionInfoTable::getFunctionInfo(const Function *f) const {
     // and construct a test case for it if it does, though.
     return dummyInfo;
   } else {
-    return getInfo(f->begin()->begin());
+    return getInfo(static_cast<const Instruction *>(f->begin()->begin()));
   }
 }

--- a/lib/Module/LowerSwitch.cpp
+++ b/lib/Module/LowerSwitch.cpp
@@ -44,7 +44,8 @@ bool LowerSwitchPass::runOnFunction(Function &F) {
   bool changed = false;
 
   for (Function::iterator I = F.begin(), E = F.end(); I != E; ) {
-    BasicBlock *cur = I++; // Advance over block so we don't traverse new blocks
+    BasicBlock *cur = static_cast<BasicBlock *>(I);
+    I++; // Advance over block so we don't traverse new blocks
 
     if (SwitchInst *SI = dyn_cast<SwitchInst>(cur->getTerminator())) {
       changed = true;

--- a/lib/Module/RaiseAsm.cpp
+++ b/lib/Module/RaiseAsm.cpp
@@ -115,7 +115,7 @@ bool RaiseAsmPass::runOnModule(Module &M) {
   for (Module::iterator fi = M.begin(), fe = M.end(); fi != fe; ++fi) {
     for (Function::iterator bi = fi->begin(), be = fi->end(); bi != be; ++bi) {
       for (BasicBlock::iterator ii = bi->begin(), ie = bi->end(); ii != ie;) {
-        Instruction *i = ii;
+        Instruction *i = static_cast<Instruction *>(ii);
         ++ii;  
         changed |= runOnInstruction(M, i);
       }

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -677,10 +677,10 @@ static int initEnv(Module *mainModule) {
     klee_error("Cannot handle ""--posix-runtime"" when main() has less than two arguments.\n");
   }
 
-  Instruction* firstInst = mainFn->begin()->begin();
+  Instruction *firstInst = static_cast<Instruction *>(mainFn->begin()->begin());
 
-  Value* oldArgc = mainFn->arg_begin();
-  Value* oldArgv = ++mainFn->arg_begin();
+  Value *oldArgc = static_cast<Argument *>(mainFn->arg_begin());
+  Value *oldArgv = static_cast<Argument *>(++mainFn->arg_begin());
 
   AllocaInst* argcPtr =
     new AllocaInst(oldArgc->getType(), "argcPtr", firstInst);
@@ -1082,7 +1082,7 @@ static llvm::Module *linkWithUclibc(llvm::Module *mainModule, StringRef libDir) 
   // naming conflict.
   for (Module::iterator fi = mainModule->begin(), fe = mainModule->end();
        fi != fe; ++fi) {
-    Function *f = fi;
+    Function *f = static_cast<Function *>(fi);
     const std::string &name = f->getName();
     if (name[0]=='\01') {
       unsigned size = name.size();
@@ -1141,8 +1141,8 @@ static llvm::Module *linkWithUclibc(llvm::Module *mainModule, StringRef libDir) 
   std::vector<llvm::Value*> args;
   args.push_back(llvm::ConstantExpr::getBitCast(userMainFn,
                                                 ft->getParamType(0)));
-  args.push_back(stub->arg_begin()); // argc
-  args.push_back(++stub->arg_begin()); // argv
+  args.push_back(static_cast<Argument *>(stub->arg_begin())); // argc
+  args.push_back(static_cast<Argument *>(++stub->arg_begin())); // argv
   args.push_back(Constant::getNullValue(ft->getParamType(3))); // app_init
   args.push_back(Constant::getNullValue(ft->getParamType(4))); // app_fini
   args.push_back(Constant::getNullValue(ft->getParamType(5))); // rtld_fini


### PR DESCRIPTION
Newer versions of LLVM do not allow to implicitly cast iterators to
pointers where they point. So convert all such uses to explicit
static_cast, the same as LLVM code does.