### PR TITLE
Core: MCJIT functions need unique names

### DIFF
--- a/lib/Core/ExternalDispatcher.cpp
+++ b/lib/Core/ExternalDispatcher.cpp
@@ -207,10 +207,11 @@ Function *ExternalDispatcher::createDispatcher(Function *target, Instruction *in
 
   std::vector<LLVM_TYPE_Q Type*> nullary;
   
+  // MCJIT functions need unique names, or wrong function can be called
   Function *dispatcher = Function::Create(FunctionType::get(Type::getVoidTy(ctx),
 							    nullary, false),
 					  GlobalVariable::ExternalLinkage, 
-					  "",
+					  "dispatcher_" + target->getName().str(),
 					  dispatchModule);
 
 


### PR DESCRIPTION
We will use newer MCJIT with newer LLVM versions. But it needs unique
names of functions or a wrong function can be called. So prepend
"dispatcher_" to function names (even for older LLVMs).