### PR TITLE
Fix test case for OSX: only weak aliases are supported on darwin

### DIFF
--- a/test/Feature/Alias.c
+++ b/test/Feature/Alias.c
@@ -1,9 +1,8 @@
+// Darwin does not have strong aliases.
+// REQUIRES: not-darwin
 // RUN: %llvmgcc %s -emit-llvm -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --exit-on-error %t1.bc
-
-// Darwin does not have strong aliases.
-// XFAIL: darwin
 
 #include <assert.h>
 
@@ -17,10 +16,10 @@ extern int foo() __attribute__((alias("__foo")));
 
 int *c = &a;
 
-int main() { 
+int main() {
   assert(a == 52);
   assert(foo() == 52);
   assert(*c == 52);
-  
+
   return 0;
 }

--- a/test/Feature/LargeReturnTypes.cpp
+++ b/test/Feature/LargeReturnTypes.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: not-darwin
 // RUN: %llvmgxx -g -fno-exceptions -emit-llvm -O0 -c -o %t.bc %s
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --libc=klee --no-output --exit-on-error %t.bc > %t.log
@@ -9,8 +10,6 @@
 // This test currently doesn't work on darwin because this isn't how things work
 // in libc++. This test should be rewritten to not depend on an external
 // dependency.
-//
-// XFAIL: darwin
 
 #include <fstream>
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -151,3 +151,11 @@ else:
 # POSIX runtime feature
 if config.enable_posix_runtime:
   config.available_features.add('posix-runtime')
+
+# Target operating system features
+supported_targets = ['linux', 'darwin']
+for target in supported_targets:
+  if config.target_triple.find(target) != -1:
+    config.available_features.add(target)
+  else:
+    config.available_features.add('not-{}'.format(target))

--- a/test/regression/2016-11-24-bitcast-weak-alias.c
+++ b/test/regression/2016-11-24-bitcast-weak-alias.c
@@ -1,3 +1,4 @@
+// REQUIRES: not-darwin
 // RUN: %llvmgcc %s -Wall -emit-llvm -g -O0 -c -o %t.bc
 // RUN: rm -rf %t.klee-out
 // RUN: klee --output-dir=%t.klee-out -exit-on-error -search=nurs:covnew %t.bc DUMMY_ARG >%t1.log 2>&1


### PR DESCRIPTION
PR #514 introduces a test case that fails on OS X:

```bash
FAIL: KLEE :: regression/2016-11-24-bitcast-weak-alias.c (190 of 197)
******************** TEST 'KLEE :: regression/2016-11-24-bitcast-weak-alias.c' FAILED ********************
Script:
--
/usr/local/bin/clang-3.4 -I/Users/andrea/Work/SRG/klee/klee/include /Users/andrea/Work/SRG/klee/klee/test/regression/2016-11-24-bitcast-weak-alias.c -Wall -emit-llvm -g -O0 -c -o /Users/andrea/Work/SRG/klee/klee-build/test/regression/Output/2016-11-24-bitcast-weak-alias.c.tmp.bc
rm -rf /Users/andrea/Work/SRG/klee/klee-build/test/regression/Output/2016-11-24-bitcast-weak-alias.c.tmp.klee-out
klee --output-dir=/Users/andrea/Work/SRG/klee/klee-build/test/regression/Output/2016-11-24-bitcast-weak-alias.c.tmp.klee-out -exit-on-error -search=nurs:covnew /Users/andrea/Work/SRG/klee/klee-build/test/regression/Output/2016-11-24-bitcast-weak-alias.c.tmp.bc DUMMY_ARG >/Users/andrea/Work/SRG/klee/klee-build/test/regression/Output/2016-11-24-bitcast-weak-alias.c.tmp1.log 2>&1
FileCheck -input-file=/Users/andrea/Work/SRG/klee/klee-build/test/regression/Output/2016-11-24-bitcast-weak-alias.c.tmp1.log /Users/andrea/Work/SRG/klee/klee/test/regression/2016-11-24-bitcast-weak-alias.c
--
Exit Code: 1

Command Output (stdout):
--
$ "/usr/local/bin/clang-3.4" "-I/Users/andrea/Work/SRG/klee/klee/include" "/Users/andrea/Work/SRG/klee/klee/test/regression/2016-11-24-bitcast-weak-alias.c" "-Wall" "-emit-llvm" "-g" "-O0" "-c" "-o" "/Users/andrea/Work/SRG/klee/klee-build/test/regression/Output/2016-11-24-bitcast-weak-alias.c.tmp.bc"
# command stderr:
/Users/andrea/Work/SRG/klee/klee/test/regression/2016-11-24-bitcast-weak-alias.c:24:26: error: only weak aliases are supported on darwin
    __attribute__((weak, alias("__real_function")));
                         ^
1 error generated.

error: command failed with exit status: 1

--
```