### PR TITLE
Core: explicitly create CallSite from Instruction

### DIFF
--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -168,7 +168,7 @@ static bool instructionIsCoverable(Instruction *i) {
       Instruction *prev = static_cast<Instruction *>(--it);
       if (isa<CallInst>(prev) || isa<InvokeInst>(prev)) {
         Function *target =
-            getDirectCallTarget(prev, /*moduleIsFullyLinked=*/true);
+            getDirectCallTarget(CallSite(prev), /*moduleIsFullyLinked=*/true);
         if (target && target->doesNotReturn())
           return false;
       }


### PR DESCRIPTION
Newer LLVMs do not allow implicit conversion from Instruction to
CallSite. We see this error:
```
Internal/Support/ModuleUtil.h:36:19: note: candidate function not viable: no known conversion from 'llvm::Instruction *' to 'llvm::CallSite' for 1st argument
  llvm::Function *getDirectCallTarget(llvm::CallSite);
                  ^
```
So explicitly create a CallSite from Instruction.
