### PR TITLE
runtime: change __get_sym_file to return NULL when path is NULL

### DIFF
--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -37,6 +37,9 @@ int klee_get_errno(void);
 
 /* Returns pointer to the symbolic file structure fs the pathname is symbolic */
 static exe_disk_file_t *__get_sym_file(const char *pathname) {
+  if (!pathname)
+    return NULL;
+
   char c = pathname[0];
   unsigned i;
 


### PR DESCRIPTION
clang warns about check-after-use in POSIX runtime:
```
runtime/POSIX/fd.c:573:17: warning: nonnull parameter 'path' will evaluate to 'true' on first
r [-Wpointer-bool-conversion]
               (path ? __concretize_string(path) : NULL),
                ^~~~ ~
```
path is dereferenced in __get_sym_file before this check. So if this
were an error it would crash much earlier before this check point.
Remove these checks completely, as we assume path cannot be NULL per
docco of these functions.

Actually the glibc version of futimesat allows path to be NULL and
changes times of dirfd in that case. But I have no idea how we could
implement that (return an error?).