### PR TITLE
Improve metaSMT support (proper version, support CVC4 and Yices, ...)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     #   SOLVERS : {Z3, STP, STP:Z3, metaSMT}
     #   STP_VERSION   : {2.1.2, master}
     #   METASMT_VERSION : {v4.rc1}
-    #   METASMT_DEFAULT : {BTOR, STP, Z3}
+    #   METASMT_DEFAULT : {BTOR, CVC4, STP, YICES2, Z3}
     #   METASMT_BOOST_VERSION : {x.y.z} // e.g. 1.60.0, libboost-dev will be used if unspecified
     #   UCLIBC: {0, klee_uclibc_v1.0.0, klee_0_9_29} // Note ``0`` means disabled
     #   DISABLE_ASSERTIONS: {0, 1}

--- a/.travis/klee.sh
+++ b/.travis/klee.sh
@@ -150,6 +150,9 @@ if [ "X${SOLVERS}" == "XmetaSMT" ]; then
   available_metasmt_backends="btor stp z3 yices2 cvc4"
   for backend in $available_metasmt_backends; do
     if [ "X${metasmt_default}" != "X$backend" ]; then
+      if [ "$backend" == "cvc4" ]; then
+        for num in {1..5}; do sleep 120; echo 'Keep Travis alive'; done &
+      fi
       lit -v --param klee_opts=-metasmt-backend=$backend --param kleaver_opts=-metasmt-backend=$backend test/
     fi
   done

--- a/.travis/klee.sh
+++ b/.travis/klee.sh
@@ -147,7 +147,7 @@ make systemtests
 # If metaSMT is the only solver, then rerun lit tests with non-default metaSMT backends
 if [ "X${SOLVERS}" == "XmetaSMT" ]; then
   metasmt_default=`echo "${METASMT_DEFAULT,,}"` # klee_opts and kleaver_opts use lowercase
-  available_metasmt_backends="btor stp z3"
+  available_metasmt_backends="btor stp z3 yices2 cvc4"
   for backend in $available_metasmt_backends; do
     if [ "X${metasmt_default}" != "X$backend" ]; then
       lit -v --param klee_opts=-metasmt-backend=$backend --param kleaver_opts=-metasmt-backend=$backend test/

--- a/.travis/metaSMT.sh
+++ b/.travis/metaSMT.sh
@@ -4,8 +4,8 @@ set -e
 
 : ${METASMT_VERSION?"METASMT_VERSION not specified"}
 
-# Get Z3, libgmp
-sudo apt-get -y install libz3 libz3-dev libgmp-dev
+# Get Z3, libgmp, gperf (required by yices2)
+sudo apt-get -y install libz3 libz3-dev libgmp-dev gperf
 
 # Get Boost
 if [ "X${METASMT_BOOST_VERSION}" != "X" ]; then
@@ -18,6 +18,11 @@ if [ "X${METASMT_BOOST_VERSION}" != "X" ]; then
 else
   sudo apt-get -y install libboost1.55-dev
 fi
+
+# Get CVC4
+wget http://www.informatik.uni-bremen.de/agra/systemc-verification/media/snapshots/cvc4-594301e.tar.gz
+tar -xf cvc4-594301e.tar.gz
+sudo mv cvc4 /usr
 
 # Clone
 git clone -b ${METASMT_VERSION} --single-branch --depth 1 https://github.com/hoangmle/metaSMT.git
@@ -33,11 +38,12 @@ fi
 # Bootstrap
 export BOOST_ROOT=/usr
 sudo cp dependencies/Z3-2.19/Z3Config.cmake /usr # this is a hack
-./bootstrap.sh -d deps -m RELEASE build -DmetaSMT_ENABLE_TESTS=off -DmetaSMT_REQUIRE_CXX11=off --build stp-git-basic --build boolector-2.2.0 --build minisat-git --build lingeling-ayv-86bf266-140429 -DZ3_DIR=/usr
+./bootstrap.sh -d deps -m RELEASE build -DmetaSMT_ENABLE_TESTS=off -DmetaSMT_REQUIRE_CXX11=off --build stp-git-basic --build boolector-2.2.0 --build minisat-git --build lingeling-ayv-86bf266-140429 --build yices-2.5.1 -DZ3_DIR=/usr -DCVC4_DIR=/usr/cvc4
 sudo cp deps/boolector-2.2.0/lib/* /usr/lib/              #
 sudo cp deps/lingeling-ayv-86bf266-140429/lib/* /usr/lib/ #
 sudo cp deps/minisat-git/lib/* /usr/lib/                  # hack
 sudo cp -r deps/stp-git-basic/lib/lib* /usr/lib/          #
+sudo cp deps/yices-2.5.1/lib/* /usr/lib/                  #
 
 # Build
 make -C build install

--- a/.travis/metaSMT.sh
+++ b/.travis/metaSMT.sh
@@ -38,7 +38,7 @@ fi
 # Bootstrap
 export BOOST_ROOT=/usr
 sudo cp dependencies/Z3-2.19/Z3Config.cmake /usr # this is a hack
-./bootstrap.sh -d deps -m RELEASE build -DmetaSMT_ENABLE_TESTS=off -DmetaSMT_REQUIRE_CXX11=off --build stp-git-basic --build boolector-2.2.0 --build minisat-git --build lingeling-ayv-86bf266-140429 --build yices-2.5.1 -DZ3_DIR=/usr -DCVC4_DIR=/usr/cvc4
+./bootstrap.sh -d deps -m RELEASE build -DmetaSMT_ENABLE_TESTS=off --build stp-git-basic --build boolector-2.2.0 --build minisat-git --build lingeling-ayv-86bf266-140429 --build yices-2.5.1 -DZ3_DIR=/usr -DCVC4_DIR=/usr/cvc4
 sudo cp deps/boolector-2.2.0/lib/* /usr/lib/              #
 sudo cp deps/lingeling-ayv-86bf266-140429/lib/* /usr/lib/ #
 sudo cp deps/minisat-git/lib/* /usr/lib/                  # hack

--- a/cmake/find_metasmt.cmake
+++ b/cmake/find_metasmt.cmake
@@ -62,7 +62,13 @@ if (ENABLE_SOLVER_METASMT)
     klee_component_add_cxx_flag(${f} REQUIRED)
   endforeach()
 
-  set(available_metasmt_backends "BTOR" "STP" "Z3")
+  # Check if metaSMT provides an useable backend
+  if (NOT metaSMT_AVAILABLE_QF_ABV_SOLVERS)
+    message(FATAL_ERROR "metaSMT does not provide an useable backend.")
+  endif()
+
+  message(STATUS "metaSMT has the following backend(s): ${metaSMT_AVAILABLE_QF_ABV_SOLVERS}.")
+  set(available_metasmt_backends ${metaSMT_AVAILABLE_QF_ABV_SOLVERS})
   set(METASMT_DEFAULT_BACKEND "STP"
     CACHE
     STRING
@@ -79,9 +85,12 @@ if (ENABLE_SOLVER_METASMT)
       "Valid values are ${available_metasmt_backends}")
   endif()
 
-  # Set appropriate define
+  # Set appropriate defines
   list(APPEND KLEE_COMPONENT_CXX_DEFINES
     -DMETASMT_DEFAULT_BACKEND_IS_${METASMT_DEFAULT_BACKEND})
+  foreach(backend ${available_metasmt_backends})
+    list(APPEND KLEE_COMPONENT_CXX_DEFINES -DMETASMT_HAVE_${backend})
+  endforeach()
 else()
   message(STATUS "metaSMT solver support disabled")
   set(ENABLE_METASMT 0) # For config.h

--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -61,7 +61,9 @@ enum MetaSMTBackendType
 {
     METASMT_BACKEND_STP,
     METASMT_BACKEND_Z3,
-    METASMT_BACKEND_BOOLECTOR
+    METASMT_BACKEND_BOOLECTOR,
+    METASMT_BACKEND_CVC4,
+    METASMT_BACKEND_YICES2
 };
 
 extern llvm::cl::opt<klee::MetaSMTBackendType> MetaSMTBackend;

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -112,6 +112,12 @@ void KCommandLine::HideUnrelatedOptions(
 #elif METASMT_DEFAULT_BACKEND_IS_Z3
 #define METASMT_DEFAULT_BACKEND_STR "(default = z3)."
 #define METASMT_DEFAULT_BACKEND METASMT_BACKEND_Z3
+#elif METASMT_DEFAULT_BACKEND_IS_CVC4
+#define METASMT_DEFAULT_BACKEND_STR "(default = cvc4)."
+#define METASMT_DEFAULT_BACKEND METASMT_BACKEND_CVC4
+#elif METASMT_DEFAULT_BACKEND_IS_YICES2
+#define METASMT_DEFAULT_BACKEND_STR "(default = yices2)."
+#define METASMT_DEFAULT_BACKEND METASMT_BACKEND_YICES2
 #else
 #define METASMT_DEFAULT_BACKEND_STR "(default = stp)."
 #define METASMT_DEFAULT_BACKEND METASMT_BACKEND_STP
@@ -123,7 +129,9 @@ MetaSMTBackend("metasmt-backend",
                cl::values(clEnumValN(METASMT_BACKEND_STP, "stp", "Use metaSMT with STP"),
                           clEnumValN(METASMT_BACKEND_Z3, "z3", "Use metaSMT with Z3"),
                           clEnumValN(METASMT_BACKEND_BOOLECTOR, "btor",
-                                     "Use metaSMT with Boolector")
+                                     "Use metaSMT with Boolector"),
+                          clEnumValN(METASMT_BACKEND_CVC4, "cvc4", "Use metaSMT with CVC4"),
+                          clEnumValN(METASMT_BACKEND_YICES2, "yices2", "Use metaSMT with Yices2")
                           KLEE_LLVM_CL_VAL_END),
                cl::init(METASMT_DEFAULT_BACKEND));
 

--- a/lib/Solver/MetaSMTSolver.cpp
+++ b/lib/Solver/MetaSMTSolver.cpp
@@ -23,14 +23,18 @@
 #include <metaSMT/DirectSolver_Context.hpp>
 #include <metaSMT/backend/Z3_Backend.hpp>
 #include <metaSMT/backend/Boolector.hpp>
+#include <metaSMT/backend/CVC4.hpp>
+#include <metaSMT/backend/Yices2.hpp>
 
 #define Expr VCExpr
 #define Type VCType
 #define STP STP_Backend
+#define type_t STP_type_t
 #include <metaSMT/backend/STP.hpp>
 #undef Expr
 #undef Type
 #undef STP
+#undef type_t
 
 #include <errno.h>
 #include <unistd.h>
@@ -405,30 +409,35 @@ void MetaSMTSolver<SolverContext>::setCoreSolverTimeout(double timeout) {
   impl->setCoreSolverTimeout(timeout);
 }
 
-template class MetaSMTSolver<DirectSolver_Context<metaSMT::solver::Boolector> >;
-template class MetaSMTSolver<DirectSolver_Context<metaSMT::solver::Z3_Backend> >;
-template class MetaSMTSolver<DirectSolver_Context<metaSMT::solver::STP_Backend> >;
-
 Solver *createMetaSMTSolver() {
-  using metaSMT::DirectSolver_Context;
-  using namespace metaSMT::solver;
+  using namespace metaSMT;
 
   Solver *coreSolver = NULL;
   std::string backend;
   switch (MetaSMTBackend) {
   case METASMT_BACKEND_STP:
     backend = "STP";
-    coreSolver = new MetaSMTSolver<DirectSolver_Context<STP_Backend> >(
+    coreSolver = new MetaSMTSolver<DirectSolver_Context<solver::STP_Backend> >(
         UseForkedCoreSolver, CoreSolverOptimizeDivides);
     break;
   case METASMT_BACKEND_Z3:
     backend = "Z3";
-    coreSolver = new MetaSMTSolver<DirectSolver_Context<Z3_Backend> >(
+    coreSolver = new MetaSMTSolver<DirectSolver_Context<solver::Z3_Backend> >(
         UseForkedCoreSolver, CoreSolverOptimizeDivides);
     break;
   case METASMT_BACKEND_BOOLECTOR:
     backend = "Boolector";
-    coreSolver = new MetaSMTSolver<DirectSolver_Context<Boolector> >(
+    coreSolver = new MetaSMTSolver<DirectSolver_Context<solver::Boolector> >(
+        UseForkedCoreSolver, CoreSolverOptimizeDivides);
+    break;
+  case METASMT_BACKEND_CVC4:
+    backend = "CVC4";
+    coreSolver = new MetaSMTSolver<DirectSolver_Context<solver::CVC4> >(
+        UseForkedCoreSolver, CoreSolverOptimizeDivides);
+    break;
+  case METASMT_BACKEND_YICES2:
+    backend = "Yices2";
+    coreSolver = new MetaSMTSolver<DirectSolver_Context<solver::Yices2> >(
         UseForkedCoreSolver, CoreSolverOptimizeDivides);
     break;
   default:

--- a/lib/Solver/MetaSMTSolver.cpp
+++ b/lib/Solver/MetaSMTSolver.cpp
@@ -21,11 +21,24 @@
 #include "llvm/Support/ErrorHandling.h"
 
 #include <metaSMT/DirectSolver_Context.hpp>
-#include <metaSMT/backend/Z3_Backend.hpp>
-#include <metaSMT/backend/Boolector.hpp>
-#include <metaSMT/backend/CVC4.hpp>
-#include <metaSMT/backend/Yices2.hpp>
 
+#ifdef METASMT_HAVE_Z3
+#include <metaSMT/backend/Z3_Backend.hpp>
+#endif
+
+#ifdef METASMT_HAVE_BTOR
+#include <metaSMT/backend/Boolector.hpp>
+#endif
+
+#ifdef METASMT_HAVE_CVC4
+#include <metaSMT/backend/CVC4.hpp>
+#endif
+
+#ifdef METASMT_HAVE_YICES2
+#include <metaSMT/backend/Yices2.hpp>
+#endif
+
+#ifdef METASMT_HAVE_STP
 #define Expr VCExpr
 #define Type VCType
 #define STP STP_Backend
@@ -35,6 +48,7 @@
 #undef Type
 #undef STP
 #undef type_t
+#endif
 
 #include <errno.h>
 #include <unistd.h>
@@ -415,31 +429,41 @@ Solver *createMetaSMTSolver() {
   Solver *coreSolver = NULL;
   std::string backend;
   switch (MetaSMTBackend) {
+#ifdef METASMT_HAVE_STP
   case METASMT_BACKEND_STP:
     backend = "STP";
     coreSolver = new MetaSMTSolver<DirectSolver_Context<solver::STP_Backend> >(
         UseForkedCoreSolver, CoreSolverOptimizeDivides);
     break;
+#endif
+#ifdef METASMT_HAVE_Z3
   case METASMT_BACKEND_Z3:
     backend = "Z3";
     coreSolver = new MetaSMTSolver<DirectSolver_Context<solver::Z3_Backend> >(
         UseForkedCoreSolver, CoreSolverOptimizeDivides);
     break;
+#endif
+#ifdef METASMT_HAVE_BTOR
   case METASMT_BACKEND_BOOLECTOR:
     backend = "Boolector";
     coreSolver = new MetaSMTSolver<DirectSolver_Context<solver::Boolector> >(
         UseForkedCoreSolver, CoreSolverOptimizeDivides);
     break;
+#endif
+#ifdef METASMT_HAVE_CVC4
   case METASMT_BACKEND_CVC4:
     backend = "CVC4";
     coreSolver = new MetaSMTSolver<DirectSolver_Context<solver::CVC4> >(
         UseForkedCoreSolver, CoreSolverOptimizeDivides);
     break;
+#endif
+#ifdef METASMT_HAVE_YICES2
   case METASMT_BACKEND_YICES2:
     backend = "Yices2";
     coreSolver = new MetaSMTSolver<DirectSolver_Context<solver::Yices2> >(
         UseForkedCoreSolver, CoreSolverOptimizeDivides);
     break;
+#endif
   default:
     llvm_unreachable("Unrecognised MetaSMT backend");
     break;


### PR DESCRIPTION
1. Update to use a proper version of metaSMT (v4.rc1).
2. Add support for CVC4 and Yices2.
3. Update to use two new flags generated by metaSMT: list of available backends and whether RTTI is required.
4. Several small improvements.

The commits are rather small to make review easier (hopefully). Once approved , they can be squashed together if desired.

Currently, travis_wait is required because CVC4 needs around 10m to finish Solver/2016-04-12-array-parsing-bug.kquery. This test case appears to be rather complex, I recall that boolector-1.5 also had difficulties solving it. @andreamattavelli is it possible to simplify the test case a bit or can you shed some light on how it is supposed to be solved quickly?