### PR TITLE
Support -fno-rtti with metaSMT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
     #   STP_VERSION   : {2.1.2, master}
     #   METASMT_VERSION : {v4.rc1}
     #   METASMT_DEFAULT : {btor, stp, z3}
+    #   METASMT_BOOST_VERSION : {x.y.z} // e.g. 1.60.0, libboost-dev will be used if unspecified
     #   UCLIBC: {0, klee_uclibc_v1.0.0, klee_0_9_29} // Note ``0`` means disabled
     #   DISABLE_ASSERTIONS: {0, 1}
     #   ENABLE_OPTIMIZED: {0, 1}
@@ -66,8 +67,8 @@ env:
 
     # Test metaSMT support
     - LLVM_VERSION=3.4 SOLVERS=metaSMT METASMT_VERSION=v4.rc1 METASMT_DEFAULT=btor KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
-    - LLVM_VERSION=2.9 SOLVERS=metaSMT METASMT_VERSION=v4.rc1 METASMT_DEFAULT=btor KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0
-    
+    - LLVM_VERSION=2.9 SOLVERS=metaSMT METASMT_VERSION=v4.rc1 METASMT_DEFAULT=btor KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0 METASMT_BOOST_VERSION=1.60.0
+
     # Check at least one build with Asserts disabled.
     - LLVM_VERSION=3.4 SOLVERS=STP STP_VERSION=2.1.2 KLEE_UCLIBC=klee_uclibc_v1.0.0 DISABLE_ASSERTIONS=1 ENABLE_OPTIMIZED=1 COVERAGE=0
 

--- a/.travis/metaSMT.sh
+++ b/.travis/metaSMT.sh
@@ -4,8 +4,20 @@ set -e
 
 : ${METASMT_VERSION?"METASMT_VERSION not specified"}
 
-# Get Boost, Z3, libgmp
-sudo apt-get -y install libboost1.55-dev libz3 libz3-dev libgmp-dev
+# Get Z3, libgmp
+sudo apt-get -y install libz3 libz3-dev libgmp-dev
+
+# Get Boost
+if [ "X${METASMT_BOOST_VERSION}" != "X" ]; then
+  # Taken from boost/hana/.travis.yml
+  BOOST_URL="http://sourceforge.net/projects/boost/files/boost/${METASMT_BOOST_VERSION}/boost_${METASMT_BOOST_VERSION//\./_}.tar.gz"
+  BOOST_DIR=`pwd`/boost-${METASMT_BOOST_VERSION}
+  mkdir -p ${BOOST_DIR}
+  wget --quiet -O - ${BOOST_URL} | tar --strip-components=1 -xz -C ${BOOST_DIR}
+  sudo ln -s ${BOOST_DIR}/boost /usr/include/boost
+else
+  sudo apt-get -y install libboost1.55-dev
+fi
 
 # Clone
 git clone -b ${METASMT_VERSION} --single-branch --depth 1 https://github.com/hoangmle/metaSMT.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,9 +395,8 @@ endif()
 ###############################################################################
 if (NOT LLVM_ENABLE_RTTI)
   if (ENABLE_SOLVER_METASMT AND metaSMT_REQUIRE_RTTI)
-    message(WARNING "Not disabling RTTI because metaSMT uses them")
-    # FIXME: Should this be FATAL_ERROR rather than ERROR?
-    message(WARNING
+    message(FATAL_ERROR
+      "RTTI cannot be disabled because metaSMT uses them."
       "This build configuration is not supported and will likely not work."
       "You should recompile LLVM with RTTI enabled.")
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,7 @@ endif()
 # RTTI
 ###############################################################################
 if (NOT LLVM_ENABLE_RTTI)
-  if (ENABLE_SOLVER_METASMT)
+  if (ENABLE_SOLVER_METASMT AND metaSMT_REQUIRE_RTTI)
     message(WARNING "Not disabling RTTI because metaSMT uses them")
     # FIXME: Should this be FATAL_ERROR rather than ERROR?
     message(WARNING

--- a/MetaSMT.mk
+++ b/MetaSMT.mk
@@ -8,6 +8,8 @@ ifeq ($(ENABLE_METASMT),1)
   CXX.Flags += $(metaSMT_CXXFLAGS)
   CXX.Flags += $(metaSMT_INCLUDES)
   CXX.Flags := $(filter-out -fno-exceptions,$(CXX.Flags))
-  CXX.Flags := $(filter-out -fno-rtti,$(CXX.Flags))
+  ifeq ($(metaSMT_REQUIRE_RTTI),true)
+    CXX.Flags := $(filter-out -fno-rtti,$(CXX.Flags))
+  endif  
   LIBS += $(metaSMT_LDLIBS)
 endif


### PR DESCRIPTION
if recent boost is used (version >= 1.57.0)