### PR TITLE
[CMake] Unbreak build due to not adding AssignmentValidatingSolver.cpp

### DIFF
--- a/lib/Solver/CMakeLists.txt
+++ b/lib/Solver/CMakeLists.txt
@@ -7,6 +7,7 @@
 #
 #===------------------------------------------------------------------------===#
 klee_add_component(kleaverSolver
+  AssignmentValidatingSolver.cpp
   CachingSolver.cpp
   CexCachingSolver.cpp
   ConstantDivision.cpp


### PR DESCRIPTION
[CMake] Unbreak build due to not adding AssignmentValidatingSolver.cpp to list of source files.