### PR TITLE
Fix #382

### DIFF
--- a/include/klee/IncompleteSolver.h
+++ b/include/klee/IncompleteSolver.h
@@ -102,7 +102,7 @@ public:
                             std::vector< std::vector<unsigned char> > &values,
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
-  char *getConstraintLog(const Query&);
+  char *getConstraintLog(const Query &, const char **fileExtension);
   void setCoreSolverTimeout(double timeout);
 };
 

--- a/include/klee/Interpreter.h
+++ b/include/klee/Interpreter.h
@@ -64,11 +64,10 @@ public:
           CheckDivZero(_CheckDivZero), CheckOvershift(_CheckOvershift) {}
   };
 
-  enum LogType
-  {
-	  STP, //.CVC (STP's native language)
-	  KQUERY, //.KQUERY files (kQuery native language)
-	  SMTLIB2 //.SMT2 files (SMTLIB version 2 files)
+  enum LogType {
+    CORE_SOLVER_LANG, // Core solver's native query language
+    KQUERY,           //.KQUERY files (kQuery native language)
+    SMTLIB2           //.SMT2 files (SMTLIB version 2 files)
   };
 
   /// InterpreterOptions - Options varying the runtime behavior during
@@ -145,10 +144,10 @@ public:
   virtual unsigned getPathStreamID(const ExecutionState &state) = 0;
 
   virtual unsigned getSymbolicPathStreamID(const ExecutionState &state) = 0;
-  
-  virtual void getConstraintLog(const ExecutionState &state,
-                                std::string &res,
-                                LogType logFormat = STP) = 0;
+
+  virtual void getConstraintLog(const ExecutionState &state, std::string &res,
+                                LogType logFormat,
+                                std::string &fileExtension) = 0;
 
   virtual bool getSymbolicSolution(const ExecutionState &state, 
                                    std::vector< 

--- a/include/klee/Solver.h
+++ b/include/klee/Solver.h
@@ -198,8 +198,19 @@ namespace klee {
     //
     // FIXME: This should go into a helper class, and should handle failure.
     virtual std::pair< ref<Expr>, ref<Expr> > getRange(const Query&);
-    
-    virtual char *getConstraintLog(const Query& query);
+
+    /// getConstraintLog - Get constraints in the solver's native query
+    /// language.
+    ///
+    /// \param query - The Query to output
+    /// \param fileExtension - If not set to NULL the passed in pointer is
+    ///                        modified to point to a C string containing the
+    ///                        file extension appropriate for the constraints.
+    ///
+    /// \return Constraints in the solver's native query language.
+    ///         Clients must free this.
+    virtual char *getConstraintLog(const Query &query,
+                                   const char **fileExtension = NULL);
     virtual void setCoreSolverTimeout(double timeout);
   };
 
@@ -217,7 +228,7 @@ namespace klee {
 
     /// getConstraintLog - Return the constraint log for the given state in CVC
     /// format.
-    virtual char *getConstraintLog(const Query&);
+    virtual char *getConstraintLog(const Query &, const char **fileExtension);
 
     /// setCoreSolverTimeout - Set constraint solver timeout delay to the given value; 0
     /// is off.
@@ -234,7 +245,7 @@ namespace klee {
 
     /// Get the query in SMT-LIBv2 format.
     /// \return A C-style string. The caller is responsible for freeing this.
-    virtual char *getConstraintLog(const Query &);
+    virtual char *getConstraintLog(const Query &, const char **fileExtension);
 
     /// setCoreSolverTimeout - Set constraint solver timeout delay to the given
     /// value; 0
@@ -250,8 +261,8 @@ namespace klee {
   public:
     MetaSMTSolver(bool useForked, bool optimizeDivides);
     virtual ~MetaSMTSolver();
-  
-    virtual char *getConstraintLog(const Query&);
+
+    virtual char *getConstraintLog(const Query &, const char **fileExtension);
     virtual void setCoreSolverTimeout(double timeout);
 };
 

--- a/include/klee/SolverImpl.h
+++ b/include/klee/SolverImpl.h
@@ -98,9 +98,10 @@ namespace klee {
     /// status code
     static const char* getOperationStatusString(SolverRunStatus statusCode);
 
-    virtual char *getConstraintLog(const Query& query)  {
-        // dummy
-        return(NULL);
+    virtual char *getConstraintLog(const Query &query,
+                                   const char **fileExtension) {
+      // dummy
+      return (NULL);
     }
 
     virtual void setCoreSolverTimeout(double timeout) {};

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -495,9 +495,9 @@ public:
 
   virtual unsigned getSymbolicPathStreamID(const ExecutionState &state);
 
-  virtual void getConstraintLog(const ExecutionState &state,
-                                std::string &res,
-                                Interpreter::LogType logFormat = Interpreter::STP);
+  virtual void getConstraintLog(const ExecutionState &state, std::string &res,
+                                Interpreter::LogType logFormat,
+                                std::string &fileExtension);
 
   virtual bool getSymbolicSolution(const ExecutionState &state, 
                                    std::vector< 

--- a/lib/Core/TimingSolver.h
+++ b/lib/Core/TimingSolver.h
@@ -41,9 +41,9 @@ namespace klee {
     void setTimeout(double t) {
       solver->setCoreSolverTimeout(t);
     }
-    
-    char *getConstraintLog(const Query& query) {
-      return solver->getConstraintLog(query);
+
+    char *getConstraintLog(const Query &query, const char **fileExtension) {
+      return solver->getConstraintLog(query, fileExtension);
     }
 
     bool evaluate(const ExecutionState&, ref<Expr>, Solver::Validity &result);

--- a/lib/Solver/AssignmentValidatingSolver.cpp
+++ b/lib/Solver/AssignmentValidatingSolver.cpp
@@ -31,7 +31,7 @@ public:
                             std::vector<std::vector<unsigned char> > &values,
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
-  char *getConstraintLog(const Query &);
+  char *getConstraintLog(const Query &, const char **fileExtension);
   void setCoreSolverTimeout(double timeout);
 };
 
@@ -144,8 +144,9 @@ AssignmentValidatingSolver::getOperationStatusCode() {
   return solver->impl->getOperationStatusCode();
 }
 
-char *AssignmentValidatingSolver::getConstraintLog(const Query &query) {
-  return solver->impl->getConstraintLog(query);
+char *AssignmentValidatingSolver::getConstraintLog(const Query &query,
+                                                   const char **fileExtension) {
+  return solver->impl->getConstraintLog(query, fileExtension);
 }
 
 void AssignmentValidatingSolver::setCoreSolverTimeout(double timeout) {

--- a/lib/Solver/CachingSolver.cpp
+++ b/lib/Solver/CachingSolver.cpp
@@ -92,7 +92,7 @@ public:
                                               hasSolution);
   }
   SolverRunStatus getOperationStatusCode();
-  char *getConstraintLog(const Query&);
+  char *getConstraintLog(const Query &, const char **fileExtension);
   void setCoreSolverTimeout(double timeout);
 };
 
@@ -253,8 +253,9 @@ SolverImpl::SolverRunStatus CachingSolver::getOperationStatusCode() {
   return solver->impl->getOperationStatusCode();
 }
 
-char *CachingSolver::getConstraintLog(const Query& query) {
-  return solver->impl->getConstraintLog(query);
+char *CachingSolver::getConstraintLog(const Query &query,
+                                      const char **fileExtension) {
+  return solver->impl->getConstraintLog(query, fileExtension);
 }
 
 void CachingSolver::setCoreSolverTimeout(double timeout) {

--- a/lib/Solver/CexCachingSolver.cpp
+++ b/lib/Solver/CexCachingSolver.cpp
@@ -90,7 +90,7 @@ public:
                             std::vector< std::vector<unsigned char> > &values,
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
-  char *getConstraintLog(const Query& query);
+  char *getConstraintLog(const Query &query, const char **fileExtension);
   void setCoreSolverTimeout(double timeout);
 };
 
@@ -367,8 +367,9 @@ SolverImpl::SolverRunStatus CexCachingSolver::getOperationStatusCode() {
   return solver->impl->getOperationStatusCode();
 }
 
-char *CexCachingSolver::getConstraintLog(const Query& query) {
-  return solver->impl->getConstraintLog(query);
+char *CexCachingSolver::getConstraintLog(const Query &query,
+                                         const char **fileExtension) {
+  return solver->impl->getConstraintLog(query, fileExtension);
 }
 
 void CexCachingSolver::setCoreSolverTimeout(double timeout) {

--- a/lib/Solver/IncompleteSolver.cpp
+++ b/lib/Solver/IncompleteSolver.cpp
@@ -139,8 +139,9 @@ SolverImpl::SolverRunStatus StagedSolverImpl::getOperationStatusCode() {
   return secondary->impl->getOperationStatusCode();
 }
 
-char *StagedSolverImpl::getConstraintLog(const Query& query) {
-  return secondary->impl->getConstraintLog(query);
+char *StagedSolverImpl::getConstraintLog(const Query &query,
+                                         const char **fileExtension) {
+  return secondary->impl->getConstraintLog(query, fileExtension);
 }
 
 void StagedSolverImpl::setCoreSolverTimeout(double timeout) {

--- a/lib/Solver/IndependentSolver.cpp
+++ b/lib/Solver/IndependentSolver.cpp
@@ -407,7 +407,7 @@ public:
                             std::vector< std::vector<unsigned char> > &values,
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
-  char *getConstraintLog(const Query&);
+  char *getConstraintLog(const Query &, const char **fileExtension);
   void setCoreSolverTimeout(double timeout);
 };
   
@@ -551,8 +551,9 @@ SolverImpl::SolverRunStatus IndependentSolver::getOperationStatusCode() {
   return solver->impl->getOperationStatusCode();      
 }
 
-char *IndependentSolver::getConstraintLog(const Query& query) {
-  return solver->impl->getConstraintLog(query);
+char *IndependentSolver::getConstraintLog(const Query &query,
+                                          const char **fileExtension) {
+  return solver->impl->getConstraintLog(query, fileExtension);
 }
 
 void IndependentSolver::setCoreSolverTimeout(double timeout) {

--- a/lib/Solver/MetaSMTSolver.cpp
+++ b/lib/Solver/MetaSMTSolver.cpp
@@ -65,7 +65,7 @@ public:
                     bool optimizeDivides);
   virtual ~MetaSMTSolverImpl();
 
-  char *getConstraintLog(const Query &);
+  char *getConstraintLog(const Query &, const char **fileExtension);
   void setCoreSolverTimeout(double timeout) { _timeout = timeout; }
 
   bool computeTruth(const Query &, bool &isValid);
@@ -115,10 +115,15 @@ template <typename SolverContext>
 MetaSMTSolverImpl<SolverContext>::~MetaSMTSolverImpl() {}
 
 template <typename SolverContext>
-char *MetaSMTSolverImpl<SolverContext>::getConstraintLog(const Query &) {
+char *
+MetaSMTSolverImpl<SolverContext>::getConstraintLog(const Query &,
+                                                   const char **fileExtension) {
   const char *msg = "Not supported";
   char *buf = new char[strlen(msg) + 1];
   strcpy(buf, msg);
+  if (fileExtension) {
+    *fileExtension = "unknown";
+  }
   return (buf);
 }
 
@@ -393,8 +398,10 @@ template <typename SolverContext>
 MetaSMTSolver<SolverContext>::~MetaSMTSolver() {}
 
 template <typename SolverContext>
-char *MetaSMTSolver<SolverContext>::getConstraintLog(const Query &query) {
-  return (impl->getConstraintLog(query));
+char *
+MetaSMTSolver<SolverContext>::getConstraintLog(const Query &query,
+                                               const char **fileExtension) {
+  return (impl->getConstraintLog(query, fileExtension));
 }
 
 template <typename SolverContext>

--- a/lib/Solver/QueryLoggingSolver.cpp
+++ b/lib/Solver/QueryLoggingSolver.cpp
@@ -224,8 +224,9 @@ SolverImpl::SolverRunStatus QueryLoggingSolver::getOperationStatusCode() {
   return solver->impl->getOperationStatusCode();
 }
 
-char *QueryLoggingSolver::getConstraintLog(const Query &query) {
-  return solver->impl->getConstraintLog(query);
+char *QueryLoggingSolver::getConstraintLog(const Query &query,
+                                           const char **fileExtension) {
+  return solver->impl->getConstraintLog(query, fileExtension);
 }
 
 void QueryLoggingSolver::setCoreSolverTimeout(double timeout) {

--- a/lib/Solver/QueryLoggingSolver.h
+++ b/lib/Solver/QueryLoggingSolver.h
@@ -72,7 +72,7 @@ public:
                             std::vector<std::vector<unsigned char> > &values,
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
-  char *getConstraintLog(const Query &);
+  char *getConstraintLog(const Query &, const char **fileExtension);
   void setCoreSolverTimeout(double timeout);
 };
 

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -72,7 +72,7 @@ public:
   STPSolverImpl(bool _useForkedSTP, bool _optimizeDivides = true);
   ~STPSolverImpl();
 
-  char *getConstraintLog(const Query &);
+  char *getConstraintLog(const Query &, const char **fileExtension);
   void setCoreSolverTimeout(double _timeout) { timeout = _timeout; }
 
   bool computeTruth(const Query &, bool &isValid);
@@ -129,7 +129,8 @@ STPSolverImpl::~STPSolverImpl() {
 
 /***/
 
-char *STPSolverImpl::getConstraintLog(const Query &query) {
+char *STPSolverImpl::getConstraintLog(const Query &query,
+                                      const char **fileExtension) {
   vc_push(vc);
   for (std::vector<ref<Expr> >::const_iterator it = query.constraints.begin(),
                                                ie = query.constraints.end();
@@ -142,6 +143,10 @@ char *STPSolverImpl::getConstraintLog(const Query &query) {
   unsigned long length;
   vc_printQueryStateToBuffer(vc, builder->getFalse(), &buffer, &length, false);
   vc_pop(vc);
+
+  if (fileExtension) {
+    *fileExtension = "cvc";
+  }
 
   return buffer;
 }
@@ -378,8 +383,9 @@ SolverImpl::SolverRunStatus STPSolverImpl::getOperationStatusCode() {
 STPSolver::STPSolver(bool useForkedSTP, bool optimizeDivides)
     : Solver(new STPSolverImpl(useForkedSTP, optimizeDivides)) {}
 
-char *STPSolver::getConstraintLog(const Query &query) {
-  return impl->getConstraintLog(query);
+char *STPSolver::getConstraintLog(const Query &query,
+                                  const char **fileExtension) {
+  return impl->getConstraintLog(query, fileExtension);
 }
 
 void STPSolver::setCoreSolverTimeout(double timeout) {

--- a/lib/Solver/Solver.cpp
+++ b/lib/Solver/Solver.cpp
@@ -25,8 +25,8 @@ Solver::~Solver() {
   delete impl; 
 }
 
-char *Solver::getConstraintLog(const Query& query) {
-    return impl->getConstraintLog(query);
+char *Solver::getConstraintLog(const Query &query, const char **fileExtension) {
+  return impl->getConstraintLog(query, fileExtension);
 }
 
 void Solver::setCoreSolverTimeout(double timeout) {

--- a/lib/Solver/ValidatingSolver.cpp
+++ b/lib/Solver/ValidatingSolver.cpp
@@ -30,7 +30,7 @@ public:
                             std::vector<std::vector<unsigned char> > &values,
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
-  char *getConstraintLog(const Query &);
+  char *getConstraintLog(const Query &, const char **fileExtension);
   void setCoreSolverTimeout(double timeout);
 };
 
@@ -128,8 +128,9 @@ SolverImpl::SolverRunStatus ValidatingSolver::getOperationStatusCode() {
   return solver->impl->getOperationStatusCode();
 }
 
-char *ValidatingSolver::getConstraintLog(const Query &query) {
-  return solver->impl->getConstraintLog(query);
+char *ValidatingSolver::getConstraintLog(const Query &query,
+                                         const char **fileExtension) {
+  return solver->impl->getConstraintLog(query, fileExtension);
 }
 
 void ValidatingSolver::setCoreSolverTimeout(double timeout) {

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -38,7 +38,7 @@ public:
   Z3SolverImpl();
   ~Z3SolverImpl();
 
-  char *getConstraintLog(const Query &);
+  char *getConstraintLog(const Query &, const char **fileExtension);
   void setCoreSolverTimeout(double _timeout) {
     assert(_timeout >= 0.0 && "timeout must be >= 0");
     timeout = _timeout;
@@ -81,15 +81,17 @@ Z3SolverImpl::~Z3SolverImpl() {
 
 Z3Solver::Z3Solver() : Solver(new Z3SolverImpl()) {}
 
-char *Z3Solver::getConstraintLog(const Query &query) {
-  return impl->getConstraintLog(query);
+char *Z3Solver::getConstraintLog(const Query &query,
+                                 const char **fileExtension) {
+  return impl->getConstraintLog(query, fileExtension);
 }
 
 void Z3Solver::setCoreSolverTimeout(double timeout) {
   impl->setCoreSolverTimeout(timeout);
 }
 
-char *Z3SolverImpl::getConstraintLog(const Query &query) {
+char *Z3SolverImpl::getConstraintLog(const Query &query,
+                                     const char **fileExtension) {
   std::vector<Z3ASTHandle> assumptions;
   for (std::vector<ref<Expr> >::const_iterator it = query.constraints.begin(),
                                                ie = query.constraints.end();
@@ -125,6 +127,11 @@ char *Z3SolverImpl::getConstraintLog(const Query &query) {
 
   if (numAssumptions)
     free(assumptionsArray);
+
+  if (fileExtension) {
+    *fileExtension = "smt2";
+  }
+
   // Client is responsible for freeing the returned C-string
   return strdup(result);
 }

--- a/test/Feature/ExprLogging.c
+++ b/test/Feature/ExprLogging.c
@@ -1,7 +1,7 @@
 // RUN: %llvmgcc %s -emit-llvm -g -O0 -c -o %t1.bc
 // We disable the cex-cache to eliminate nondeterminism across different solvers, in particular when counting the number of queries in the last two commands
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --use-cex-cache=false --use-query-log=all:kquery,all:smt2,solver:kquery,solver:smt2 --write-kqueries --write-cvcs --write-smt2s %t1.bc 2> %t2.log
+// RUN: %klee --output-dir=%t.klee-out --use-cex-cache=false --use-query-log=all:kquery,all:smt2,solver:kquery,solver:smt2 --write-kqueries --write-core-solver-queries --write-smt2s %t1.bc 2> %t2.log
 // RUN: %kleaver -print-ast %t.klee-out/all-queries.kquery > %t3.log
 // RUN: %kleaver -print-ast %t3.log > %t4.log
 // RUN: diff %t3.log %t4.log


### PR DESCRIPTION
Fix #382

There are numerous changes here which removes the assumption that
STP is the core solver.

* `-write-cvcs` has been renamed to `-write-core-solver-queries`
* `LogType::STP` has been renamed to `LogType::CORE_SOLVER_LANG`
* `Interpreter::getConstraintLog()` and `Executor::getConstraintLog()`
  now have a `fileExtension` parameter which returns the file extension
  for constraint language requested.
* The `Solver::getConstraintLog()` and `SolverImpl::getConstraintLog()`
  methods (and all their descendants) now have a `fileExtension`
  parameter which will be set (if requested by the client) to the file
  extension for the core solver's constraint language.