### PR TITLE
[CMake] Try to fix bug reported by #633.

### DIFF
--- a/cmake/find_llvm.cmake
+++ b/cmake/find_llvm.cmake
@@ -86,7 +86,7 @@ else()
       "${LLVM_PACKAGE_VERSION}")
   else()
     # try x.y pattern
-    set(_llvm_version_regex "^([0-9]+)\\.([0-9]+)$")
+    set(_llvm_version_regex "^([0-9]+)\\.([0-9]+)(svn)?$")
     if ("${LLVM_PACKAGE_VERSION}" MATCHES "${_llvm_version_regex}")
       string(REGEX REPLACE
         "${_llvm_version_regex}"


### PR DESCRIPTION
[CMake] Try to fix bug reported by #633.

It looks like older LLVM versions that were built from SVN/git didn't
have a patch version number (i.e. `3.4svn` rather than `3.4.0svn`).