### PR TITLE
[travis] fix a git submodule failure of metaSMT

### DIFF
--- a/.travis/metaSMT.sh
+++ b/.travis/metaSMT.sh
@@ -6,7 +6,7 @@ sudo apt-get -y install libboost1.55-dev libz3 libz3-dev libgmp-dev
 # Clone
 git clone -b ${METASMT_VERSION} --single-branch --depth 1 https://github.com/hoangmle/metaSMT.git
 cd metaSMT
-git submodule update --init --depth 1
+git submodule update --init
 
 source ${KLEE_SRC}/.travis/sanitizer_flags.sh
 if [ "X${IS_SANITIZED_BUILD}" != "X0" ]; then


### PR DESCRIPTION
@delcypher @ccadar @andreamattavelli 
Due to my inexperience with git, I introduced an "optimization" (git submodule update --depth 1) that now fails because more commits have been added to the submodule. This needs to be merged ASAP... Sorry!