### PR TITLE
Fix build for FreeBSD.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,7 +463,8 @@ if (HAVE_SYS_CAPABILITY_H)
     NAMES cap
     DOC "libcap library"
   )
-  if (NOT LIBCAP_LIBRARIES)
+# On FreeBSD <sys/capabilities.h> is present in libc, so we don't require libcap there.
+  if (NOT LIBCAP_LIBRARIES AND NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     message(FATAL_ERROR "Found \"sys/capability.h\" but could not find libcap")
   endif()
 else()

--- a/lib/Support/CompressionStream.cpp
+++ b/lib/Support/CompressionStream.cpp
@@ -18,6 +18,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #endif
+#include <unistd.h>
 
 namespace klee {
 


### PR DESCRIPTION
On FreeBSD <sys/capabilities.h> is present in libc, so we don't require libcap there.
Close and write functions are located in <unistd.h>.