### PR TITLE
[TravisCI] Try to unbreak the build against upstream STP.

### DIFF
--- a/.travis/stp.sh
+++ b/.travis/stp.sh
@@ -33,6 +33,23 @@ if [ "x${STP_VERSION}" != "x" ]; then
   sudo make install
   cd ../../
 
+  # Determine STP build flags
+  if [ "X${STP_VERSION}" = "Xmaster" ]; then
+    # 7e0b096ee79d59bb5c344b7dd4d51b5b8d226221 s/NO_BOOST/ONLY_SIMPLE/
+    # 5e9ca6339a2b3b000aa7a90c18601fdcf1212fe1 Silently BUILD_SHARED_LIBS removed. STATICCOMPILE does something similar
+    STP_CMAKE_FLAGS=( \
+      "-DENABLE_PYTHON_INTERFACE:BOOL=OFF" \
+      "-DONLY_SIMPLE:BOOL=ON" \
+      "-DSTATICCOMPILE:BOOL=ON" \
+    )
+  else
+    STP_CMAKE_FLAGS=( \
+      "-DENABLE_PYTHON_INTERFACE:BOOL=OFF" \
+      "-DNO_BOOST:BOOL=ON" \
+      "-DBUILD_SHARED_LIBS:BOOL=OFF" \
+    )
+  fi
+
   # Build STP
   git clone --depth 1 -b "${STP_VERSION}" git://github.com/stp/stp.git src
   mkdir build
@@ -41,7 +58,7 @@ if [ "x${STP_VERSION}" != "x" ]; then
   # Don't build against boost because that is broken when mixing packaged boost libraries and gcc 4.8
   CFLAGS="${SANITIZER_C_FLAGS}" \
   CXXFLAGS="${SANITIZER_CXX_FLAGS}" \
-  cmake -DBUILD_SHARED_LIBS:BOOL=OFF -DENABLE_PYTHON_INTERFACE:BOOL=OFF -DNO_BOOST:BOOL=ON ../src
+  cmake "${STP_CMAKE_FLAGS[@]}" ../src
 
   set +e # Do not exit if build fails because we need to display the log
   make >> "${STP_LOG}" 2>&1


### PR DESCRIPTION
It seems there are have been quite a few changes upstream that
change the way CMake is invoked. There doesn't seem to be any good
reason for doing this.

I advise we drop this configuration so we don't have to worry about upstream STP breaking things.