### PR TITLE
[WIP] Sketch Z3 custom tactic

### DIFF
--- a/lib/Solver/Z3Builder.cpp
+++ b/lib/Solver/Z3Builder.cpp
@@ -39,8 +39,7 @@ template <> void Z3NodeHandle<Z3_sort>::dump() {
                << "\n";
 }
 template <> void Z3NodeHandle<Z3_ast>::dump() {
-  llvm::errs() << "Z3ASTHandle:\n" << ::Z3_ast_to_string(context, as_ast())
-               << "\n";
+  llvm::errs() << "Z3ASTHandle:\n" << ::Z3_ast_to_string(context, node) << "\n";
 }
 
 void custom_z3_error_handler(Z3_context ctx, Z3_error_code ec) {

--- a/test/Feature/StatesCoveringNew.c
+++ b/test/Feature/StatesCoveringNew.c
@@ -24,7 +24,11 @@ void f2(void) {}
 void f3(void) {}
 
 int main() {
-  int x = klee_range(0, 256, "x");
+  // WORKAROUND broken cex implementation:
+  // https://github.com/klee/klee/issues/706
+  // int x = klee_range(0, 256, "x");
+  int x = 0;
+  klee_make_symbolic(&x, sizeof(x), "x");
 
   if (x == 17) {
     f0();


### PR DESCRIPTION
This depends on #658 **EDIT: Now merged**

This PR sketches implementing a custom tactic for using Z3 which I suspect will give us a performance boost. The tactic is the one sketched in #653 .

The implementation isn't really ideal

* We should just reset the solver rather than re-constructing it for every query. Without measuring I don't know which is faster though.
* The tactic builder API is a little clumsy. If this PR seems useful we should probably give `Z3TacticHandle` a "fluent" API so we write things like `t.then(x).then(y).then(z)`.

What we need to do now is benchmark this. I'd like to know

* What is the performance of `-z3-custom-tactic=array_ackermannize_to_qfbv` vs `-z3-custom-tactic=none`.
* How both of the above compare to STP.

@MartinNowack / @andreamattavelli : Seeing as you have the infrastructure for this when you have time would you be able to conduct these experiments?

Please use a recent version of Z3 for this ( 2834fea9b3977f2988c528e221ff51fa12bfbe52 ). I suspect the one we use in TravisCI is too old