### PR TITLE
Prevent test failure when realloc fails in test/Feature/Realloc.c

### DIFF
--- a/test/Feature/Realloc.c
+++ b/test/Feature/Realloc.c
@@ -13,7 +13,7 @@ int main() {
 
   // CHECK: KLEE: WARNING ONCE: Large alloc
   int *p2 = realloc(p, 1<<30);
-  assert(p2[1] == 52);
+  assert(!p2 || p2[1] == 52);
 
   return 0;
 }


### PR DESCRIPTION
I have experienced rare test failure in our fork of KLEE due to failure of realloc where it returns NULL. I propose that the original assertion should only be checked when realloc succeeds.