### PR TITLE
llvm: rename ExitOnError to OptExitOnError

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -132,7 +132,7 @@ namespace {
                 cl::desc("Write .sym.path files for each test case"));
 
   cl::opt<bool>
-  ExitOnError("exit-on-error",
+  OptExitOnError("exit-on-error",
               cl::desc("Exit if errors occur"));
 
 
@@ -413,7 +413,7 @@ llvm::raw_fd_ostream *KleeHandler::openTestFile(const std::string &suffix,
 void KleeHandler::processTestCase(const ExecutionState &state,
                                   const char *errorMessage,
                                   const char *errorSuffix) {
-  if (errorMessage && ExitOnError) {
+  if (errorMessage && OptExitOnError) {
     m_interpreter->prepareForEarlyExit();
     klee_error("EXITING ON ERROR:\n%s\n", errorMessage);
   }


### PR DESCRIPTION
ExitOnError collides with llvm::ExitOnError from LLVM 4:
```
tools/klee/main.cpp:430:23: error: reference to 'ExitOnError' is ambiguous
  if (errorMessage && ExitOnError) {
                      ^
/usr/include/llvm/Support/Error.h:938:7: note: candidate found by name lookup is 'llvm::ExitOnError'
class ExitOnError {
      ^
klee/tools/klee/main.cpp:141:3: note: candidate found by name lookup is '(anonymous namespace)::ExitOnError'
  ExitOnError("exit-on-error",
  ^
1 error generated.
```