### PR TITLE
llvm: get rid of static_casts from iterators

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -546,7 +546,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
   // ensures that we won't conflict. we don't need to allocate a memory object
   // since reading/writing via a function pointer is unsupported anyway.
   for (Module::iterator i = m->begin(), ie = m->end(); i != ie; ++i) {
-    Function *f = static_cast<Function *>(i);
+    Function *f = &*i;
     ref<ConstantExpr> addr(0);
 
     // If the symbol has external weak linkage then it is implicitly
@@ -600,7 +600,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
   for (Module::const_global_iterator i = m->global_begin(),
          e = m->global_end();
        i != e; ++i) {
-    const GlobalVariable *v = static_cast<const GlobalVariable *>(i);
+    const GlobalVariable *v = &*i;
     size_t globalObjectAlignment = getAllocationAlignment(v);
     if (i->isDeclaration()) {
       // FIXME: We have no general way of handling unknown external
@@ -678,8 +678,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
        i != ie; ++i) {
     // Map the alias to its aliasee's address. This works because we have
     // addresses for everything, even undefined functions. 
-    globalAddresses.insert(std::make_pair(static_cast<GlobalAlias *>(i),
-	  evalConstant(i->getAliasee())));
+    globalAddresses.insert(std::make_pair(&*i, evalConstant(i->getAliasee())));
   }
 
   // once all objects are allocated, do the actual initialization
@@ -687,7 +686,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
          e = m->global_end();
        i != e; ++i) {
     if (i->hasInitializer()) {
-      const GlobalVariable *v = static_cast<const GlobalVariable *>(i);
+      const GlobalVariable *v = &*i;
       MemoryObject *mo = globalObjects.find(v)->second;
       const ObjectState *os = state.addressSpace.findObject(mo);
       assert(os);
@@ -3554,7 +3553,7 @@ void Executor::runFunctionAsMain(Function *f,
   if (ai!=ae) {
     arguments.push_back(ConstantExpr::alloc(argc, Expr::Int32));
     if (++ai!=ae) {
-      Instruction *first = static_cast<Instruction *>(f->begin()->begin());
+      Instruction *first = &*(f->begin()->begin());
       argvMO =
           memory->allocate((argc + 1 + envc + 1 + 1) * NumPtrBytes,
                            /*isLocal=*/false, /*isGlobal=*/true,

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -165,7 +165,7 @@ static bool instructionIsCoverable(Instruction *i) {
     if (it==bb->begin()) {
       return true;
     } else {
-      Instruction *prev = static_cast<Instruction *>(--it);
+      Instruction *prev = &*(--it);
       if (isa<CallInst>(prev) || isa<InvokeInst>(prev)) {
         Function *target =
             getDirectCallTarget(CallSite(prev), /*moduleIsFullyLinked=*/true);
@@ -542,7 +542,7 @@ void StatsTracker::writeIStats() {
       // Always try to write the filename before the function name, as otherwise
       // KCachegrind can create two entries for the function, one with an
       // unnamed file and one without.
-      Function *fn = static_cast<Function *>(fnIt);
+      Function *fn = &*fnIt;
       const InstructionInfo &ii = executor.kmodule->infos->getFunctionInfo(fn);
       if (ii.file != sourceFile) {
         of << "fl=" << ii.file << "\n";
@@ -639,9 +639,9 @@ static std::vector<Instruction*> getSuccs(Instruction *i) {
 
   if (i==bb->getTerminator()) {
     for (succ_iterator it = succ_begin(bb), ie = succ_end(bb); it != ie; ++it)
-      res.push_back(static_cast<Instruction *>(it->begin()));
+      res.push_back(&*(it->begin()));
   } else {
-    res.push_back(static_cast<Instruction *>(++BasicBlock::iterator(i)));
+    res.push_back(&*(++BasicBlock::iterator(i)));
   }
 
   return res;
@@ -688,7 +688,7 @@ void StatsTracker::computeReachableUncovered() {
            bbIt != bb_ie; ++bbIt) {
         for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
              it != ie; ++it) {
-          Instruction *inst = static_cast<Instruction *>(it);
+          Instruction *inst = &*it;
           if (isa<CallInst>(inst) || isa<InvokeInst>(inst)) {
             CallSite cs(inst);
             if (isa<InlineAsm>(cs.getCalledValue())) {
@@ -721,7 +721,7 @@ void StatsTracker::computeReachableUncovered() {
     std::vector<Instruction *> instructions;
     for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
          fnIt != fn_ie; ++fnIt) {
-      Function *fn = static_cast<Function *>(fnIt);
+      Function *fn = &*fnIt;
       if (fnIt->isDeclaration()) {
         if (fnIt->doesNotReturn()) {
           functionShortestPath[fn] = 0;
@@ -737,7 +737,7 @@ void StatsTracker::computeReachableUncovered() {
            bbIt != bb_ie; ++bbIt) {
         for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
              it != ie; ++it) {
-          Instruction *inst = static_cast<Instruction *>(it);
+          Instruction *inst = &*it;
           instructions.push_back(inst);
           unsigned id = infos.getInfo(inst).id;
           sm.setIndexedValue(stats::minDistToReturn, 
@@ -796,14 +796,13 @@ void StatsTracker::computeReachableUncovered() {
           // functionShortestPath, or it will remain 0 (erroneously indicating
           // that no return instructions are reachable)
           Function *f = inst->getParent()->getParent();
-          if (best != cur
-              || (inst == static_cast<Instruction *>(f->begin()->begin())
+          if (best != cur || (inst == &*(f->begin()->begin())
                   && functionShortestPath[f] != best)) {
             sm.setIndexedValue(stats::minDistToReturn, id, best);
             changed = true;
 
             // Update shortest path if this is the entry point.
-            if (inst == static_cast<Instruction *>(f->begin()->begin()))
+            if (inst == &*(f->begin()->begin()))
               functionShortestPath[f] = best;
           }
         }
@@ -820,7 +819,7 @@ void StatsTracker::computeReachableUncovered() {
          bbIt != bb_ie; ++bbIt) {
       for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
            it != ie; ++it) {
-        Instruction *inst = static_cast<Instruction *>(it);
+        Instruction *inst = &*it;
         unsigned id = infos.getInfo(inst).id;
         instructions.push_back(inst);
         sm.setIndexedValue(stats::minDistToUncovered, 

--- a/lib/Module/Checks.cpp
+++ b/lib/Module/Checks.cpp
@@ -71,7 +71,7 @@ bool DivCheckPass::runOnModule(Module &M) {
                                           Type::getInt64Ty(ctx),
                                           false,  /* sign doesn't matter */
                                           "int_cast_to_i64",
-                                          static_cast<Instruction *>(i));
+                                          &*i);
             
             // Lazily bind the function to avoid always importing it.
             if (!divZeroCheckFunction) {
@@ -129,7 +129,7 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
                                           Type::getInt64Ty(ctx),
                                           false,  /* sign doesn't matter */
                                           "int_cast_to_i64",
-                                          static_cast<Instruction *>(i));
+                                          &*i);
             args.push_back(shift);
 
 

--- a/lib/Module/InstructionInfoTable.cpp
+++ b/lib/Module/InstructionInfoTable.cpp
@@ -120,7 +120,7 @@ InstructionInfoTable::InstructionInfoTable(Module *m)
 
   for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
        fnIt != fn_ie; ++fnIt) {
-    Function *fn = static_cast<Function *>(fnIt);
+    Function *fn = &*fnIt;
 
     // We want to ensure that as all instructions have source information, if
     // available. Clang sometimes will not write out debug information on the
@@ -193,6 +193,6 @@ InstructionInfoTable::getFunctionInfo(const Function *f) const {
     // and construct a test case for it if it does, though.
     return dummyInfo;
   } else {
-    return getInfo(static_cast<const Instruction *>(f->begin()->begin()));
+    return getInfo(&*(f->begin()->begin()));
   }
 }

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -196,7 +196,7 @@ static void injectStaticConstructorsAndDestructors(Module *m) {
 
     if (ctors)
     CallInst::Create(getStubFunctionForCtorList(m, ctors, "klee.ctor_stub"),
-		     "", static_cast<Instruction *>(mainFn->begin()->begin()));
+		     "", &*(mainFn->begin()->begin()));
     if (dtors) {
       Function *dtorStub = getStubFunctionForCtorList(m, dtors, "klee.dtor_stub");
       for (Function::iterator it = mainFn->begin(), ie = mainFn->end();
@@ -286,7 +286,7 @@ void KModule::prepare(const Interpreter::ModuleOptions &opts,
       llvm::errs() << "KLEE: adding klee_merge at exit of: " << name << "\n";
       for (llvm::Function::iterator bbit = f->begin(), bbie = f->end(); 
            bbit != bbie; ++bbit) {
-	BasicBlock *bb = static_cast<BasicBlock *>(bbit);
+	BasicBlock *bb = &*bbit;
         if (bb != exit) {
           Instruction *i = bbit->getTerminator();
           if (i->getOpcode()==Instruction::Ret) {
@@ -451,7 +451,7 @@ void KModule::prepare(const Interpreter::ModuleOptions &opts,
     if (it->isDeclaration())
       continue;
 
-    Function *fn = static_cast<Function *>(it);
+    Function *fn = &*it;
     KFunction *kf = new KFunction(fn, this);
     
     for (unsigned i=0; i<kf->numInstructions; ++i) {
@@ -542,7 +542,7 @@ KFunction::KFunction(llvm::Function *_function,
     trackCoverage(true) {
   for (llvm::Function::iterator bbit = function->begin(), 
          bbie = function->end(); bbit != bbie; ++bbit) {
-    BasicBlock *bb = static_cast<BasicBlock *>(bbit);
+    BasicBlock *bb = &*bbit;
     basicBlockEntry[bb] = numInstructions;
     numInstructions += bb->size();
   }
@@ -557,7 +557,7 @@ KFunction::KFunction(llvm::Function *_function,
          bbie = function->end(); bbit != bbie; ++bbit) {
     for (llvm::BasicBlock::iterator it = bbit->begin(), ie = bbit->end();
          it != ie; ++it)
-      registerMap[static_cast<Instruction *>(it)] = rnum++;
+      registerMap[&*it] = rnum++;
   }
   numRegisters = rnum;
   
@@ -577,7 +577,7 @@ KFunction::KFunction(llvm::Function *_function,
         ki = new KInstruction(); break;
       }
 
-      Instruction *inst = static_cast<Instruction *>(it);
+      Instruction *inst = &*it;
       ki->inst = inst;
       ki->dest = registerMap[inst];
 

--- a/lib/Module/LowerSwitch.cpp
+++ b/lib/Module/LowerSwitch.cpp
@@ -44,7 +44,7 @@ bool LowerSwitchPass::runOnFunction(Function &F) {
   bool changed = false;
 
   for (Function::iterator I = F.begin(), E = F.end(); I != E; ) {
-    BasicBlock *cur = static_cast<BasicBlock *>(I);
+    BasicBlock *cur = &*I;
     I++; // Advance over block so we don't traverse new blocks
 
     if (SwitchInst *SI = dyn_cast<SwitchInst>(cur->getTerminator())) {

--- a/lib/Module/RaiseAsm.cpp
+++ b/lib/Module/RaiseAsm.cpp
@@ -124,7 +124,7 @@ bool RaiseAsmPass::runOnModule(Module &M) {
   for (Module::iterator fi = M.begin(), fe = M.end(); fi != fe; ++fi) {
     for (Function::iterator bi = fi->begin(), be = fi->end(); bi != be; ++bi) {
       for (BasicBlock::iterator ii = bi->begin(), ie = bi->end(); ii != ie;) {
-        Instruction *i = static_cast<Instruction *>(ii);
+        Instruction *i = &*ii;
         ++ii;  
         changed |= runOnInstruction(M, i);
       }

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -670,10 +670,10 @@ static int initEnv(Module *mainModule) {
     klee_error("Cannot handle ""--posix-runtime"" when main() has less than two arguments.\n");
   }
 
-  Instruction *firstInst = static_cast<Instruction *>(mainFn->begin()->begin());
+  Instruction *firstInst = &*(mainFn->begin()->begin());
 
-  Value *oldArgc = static_cast<Argument *>(mainFn->arg_begin());
-  Value *oldArgv = static_cast<Argument *>(++mainFn->arg_begin());
+  Value *oldArgc = &*(mainFn->arg_begin());
+  Value *oldArgv = &*(++mainFn->arg_begin());
 
   AllocaInst* argcPtr =
     new AllocaInst(oldArgc->getType(), "argcPtr", firstInst);
@@ -1080,7 +1080,7 @@ static llvm::Module *linkWithUclibc(llvm::Module *mainModule, StringRef libDir) 
   // naming conflict.
   for (Module::iterator fi = mainModule->begin(), fe = mainModule->end();
        fi != fe; ++fi) {
-    Function *f = static_cast<Function *>(fi);
+    Function *f = &*fi;
     const std::string &name = f->getName();
     if (name[0]=='\01') {
       unsigned size = name.size();
@@ -1139,8 +1139,8 @@ static llvm::Module *linkWithUclibc(llvm::Module *mainModule, StringRef libDir) 
   std::vector<llvm::Value*> args;
   args.push_back(llvm::ConstantExpr::getBitCast(userMainFn,
                                                 ft->getParamType(0)));
-  args.push_back(static_cast<Argument *>(stub->arg_begin())); // argc
-  args.push_back(static_cast<Argument *>(++stub->arg_begin())); // argv
+  args.push_back(&*(stub->arg_begin())); // argc
+  args.push_back(&*(++stub->arg_begin())); // argv
   args.push_back(Constant::getNullValue(ft->getParamType(3))); // app_init
   args.push_back(Constant::getNullValue(ft->getParamType(4))); // app_fini
   args.push_back(Constant::getNullValue(ft->getParamType(5))); // rtld_fini


### PR DESCRIPTION
In commit b7a6aec4eeb4 (convert iterators using static_cast), I switched
all implicit casts to static_cast. It turned out that llvm 4.0 banned
casting via static_cast. See e.g. 1e2bc42eb988 in the llvm repo what
they do.

So similarly to the above commit, change all the casts of iterators to
"&*" which is what they do in LLVM.