### PR TITLE
llvm37: do not copy DILocation to getDSPIPath

### DIFF
--- a/lib/Module/InstructionInfoTable.cpp
+++ b/lib/Module/InstructionInfoTable.cpp
@@ -87,7 +87,7 @@ static void buildInstructionToLineMap(Module *m,
   }
 }
 
-static std::string getDSPIPath(DILocation Loc) {
+static std::string getDSPIPath(const DILocation &Loc) {
   std::string dir = Loc.getDirectory();
   std::string file = Loc.getFilename();
   if (dir.empty() || file[0] == '/') {


### PR DESCRIPTION
DILocation is not copyable in LLVM 3.7. So, pass it as reference and
make it const given we do not write to it.