### PR TITLE
llvm37: handle GetElementPtrInst::Create's new parameter

### DIFF
--- a/include/klee/Config/Version.h
+++ b/include/klee/Config/Version.h
@@ -15,6 +15,12 @@
 #define LLVM_VERSION(major, minor) (((major) << 8) | (minor))
 #define LLVM_VERSION_CODE LLVM_VERSION(LLVM_VERSION_MAJOR, LLVM_VERSION_MINOR)
 
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+#  define KLEE_LLVM_GEP_TYPE(x) (x),
+#else
+#  define KLEE_LLVM_GEP_TYPE(x)
+#endif
+
 #if LLVM_VERSION_CODE >= LLVM_VERSION(4, 0)
 #  define KLEE_LLVM_CL_VAL_END
 #else

--- a/lib/Core/ExternalDispatcher.cpp
+++ b/lib/Core/ExternalDispatcher.cpp
@@ -319,6 +319,7 @@ Function *ExternalDispatcherImpl::createDispatcher(Function *target,
     Type *argTy =
         (i < FTy->getNumParams() ? FTy->getParamType(i) : (*ai)->getType());
     Instruction *argI64p = GetElementPtrInst::Create(
+        KLEE_LLVM_GEP_TYPE(nullptr)
         argI64s, ConstantInt::get(Type::getInt32Ty(ctx), idx), "", dBB);
 
     Instruction *argp =

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -82,11 +82,15 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
           Value *pSrc = CastInst::CreatePointerCast(src, i64p, "vacopy.cast.src", ii);
           Value *val = new LoadInst(pSrc, std::string(), ii); new StoreInst(val, pDst, ii);
           Value *off = ConstantInt::get(Type::getInt64Ty(ctx), 1);
-          pDst = GetElementPtrInst::Create(pDst, off, std::string(), ii);
-          pSrc = GetElementPtrInst::Create(pSrc, off, std::string(), ii);
+          pDst = GetElementPtrInst::Create(KLEE_LLVM_GEP_TYPE(nullptr)
+              pDst, off, std::string(), ii);
+          pSrc = GetElementPtrInst::Create(KLEE_LLVM_GEP_TYPE(nullptr)
+              pSrc, off, std::string(), ii);
           val = new LoadInst(pSrc, std::string(), ii); new StoreInst(val, pDst, ii);
-          pDst = GetElementPtrInst::Create(pDst, off, std::string(), ii);
-          pSrc = GetElementPtrInst::Create(pSrc, off, std::string(), ii);
+          pDst = GetElementPtrInst::Create(KLEE_LLVM_GEP_TYPE(nullptr)
+              pDst, off, std::string(), ii);
+          pSrc = GetElementPtrInst::Create(KLEE_LLVM_GEP_TYPE(nullptr)
+              pSrc, off, std::string(), ii);
           val = new LoadInst(pSrc, std::string(), ii); new StoreInst(val, pDst, ii);
         }
         ii->removeFromParent();


### PR DESCRIPTION
LLVM 3.7 added a PointeeType parameter to GetElementPtrInst::Create.
Let's handle that by a macro called KLEE_LLVM_GEP_INST_1ST, defined in
Version.h.