### PR TITLE
llvm37: introduce type for PassManager

### DIFF
--- a/include/klee/Internal/Module/LLVMPassManager.h
+++ b/include/klee/Internal/Module/LLVMPassManager.h
@@ -1,0 +1,22 @@
+//===-- InstructionInfoTable.h ----------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+#include "llvm/IR/LegacyPassManager.h"
+#else
+#include "llvm/PassManager.h"
+#endif
+
+namespace klee {
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+typedef llvm::legacy::PassManager LegacyLLVMPassManagerTy;
+#else
+typedef llvm::PassManager LegacyLLVMPassManagerTy;
+#endif
+}

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -47,7 +47,7 @@
 #include "llvm/IR/CallSite.h"
 #endif
 
-#include "llvm/PassManager.h"
+#include "klee/Internal/Module/LLVMPassManager.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/raw_os_ostream.h"
@@ -305,7 +305,7 @@ void KModule::prepare(const Interpreter::ModuleOptions &opts,
   // invariant transformations that we will end up doing later so that
   // optimize is seeing what is as close as possible to the final
   // module.
-  PassManager pm;
+  LegacyLLVMPassManagerTy pm;
   pm.add(new RaiseAsmPass());
   if (opts.CheckDivZero) pm.add(new DivCheckPass());
   if (opts.CheckOvershift) pm.add(new OvershiftCheckPass());
@@ -373,7 +373,7 @@ void KModule::prepare(const Interpreter::ModuleOptions &opts,
   // linked in something with intrinsics but any external calls are
   // going to be unresolved. We really need to handle the intrinsics
   // directly I think?
-  PassManager pm3;
+  LegacyLLVMPassManagerTy pm3;
   pm3.add(createCFGSimplificationPass());
   switch(SwitchType) {
   case eSwitchTypeInternal: break;

--- a/lib/Module/Optimize.cpp
+++ b/lib/Module/Optimize.cpp
@@ -16,7 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "klee/Config/Version.h"
-#include "llvm/PassManager.h"
+#include "klee/Internal/Module/LLVMPassManager.h"
 #include "llvm/Analysis/Passes.h"
 #include "llvm/Analysis/LoopPass.h"
 #include "llvm/Support/CommandLine.h"
@@ -80,7 +80,7 @@ static cl::alias A1("S", cl::desc("Alias for --strip-debug"),
 
 // A utility function that adds a pass to the pass manager but will also add
 // a verifier pass after if we're supposed to verify.
-static inline void addPass(PassManager &PM, Pass *P) {
+static inline void addPass(klee::LegacyLLVMPassManagerTy &PM, Pass *P) {
   // Add the pass to the pass manager...
   PM.add(P);
 
@@ -92,7 +92,7 @@ static inline void addPass(PassManager &PM, Pass *P) {
 namespace llvm {
 
 
-static void AddStandardCompilePasses(PassManager &PM) {
+static void AddStandardCompilePasses(klee::LegacyLLVMPassManagerTy &PM) {
   PM.add(createVerifierPass());                  // Verify that input is correct
 
 #if LLVM_VERSION_CODE < LLVM_VERSION(3, 0)
@@ -166,7 +166,7 @@ static void AddStandardCompilePasses(PassManager &PM) {
 void Optimize(Module *M, const std::string &EntryPoint) {
 
   // Instantiate the pass manager to organize the passes.
-  PassManager Passes;
+  klee::LegacyLLVMPassManagerTy Passes;
 
   // If we're verifying, start off with a verification pass.
   if (VerifyEach)


### PR DESCRIPTION
In LLVM 3.7, PassManager was moved to the legacy:: namespace. Introduce
a type for it and use it in the code.