### PR TITLE
Implement basic region-based state merging (RBSM 2/3)

### DIFF
--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -13,6 +13,7 @@
 #include "klee/Constraints.h"
 #include "klee/Expr.h"
 #include "klee/Internal/ADT/TreeStream.h"
+#include "klee/MergeHandler.h"
 
 // FIXME: We do not want to be exposing these? :(
 #include "../../lib/Core/AddressSpace.h"
@@ -144,6 +145,9 @@ public:
   std::string getFnAlias(std::string fn);
   void addFnAlias(std::string old_fn, std::string new_fn);
   void removeFnAlias(std::string fn);
+
+  // The objects handling the klee_open_merge calls this state ran through
+  std::vector<ref<MergeHandler> > openMergeStack;
 
 private:
   ExecutionState() : ptreeNode(0) {}

--- a/include/klee/MergeHandler.h
+++ b/include/klee/MergeHandler.h
@@ -1,0 +1,110 @@
+//===-- MergeHandler.h --------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+/** 
+ * @file MergeHandler.h
+ * @brief Implementation of the region based merging
+ *
+ * ## Basic usage:
+ * 
+ * @code{.cpp}
+ * klee_open_merge();
+ * 
+ * code containing branches etc. 
+ * 
+ * klee_close_merge();
+ * @endcode
+ * 
+ * Will lead to all states that forked from the state that executed the
+ * klee_open_merge() being merged in the klee_close_merge(). This allows for
+ * fine-grained regions to be specified for merging.
+ * 
+ * # Implementation Structure
+ * 
+ * The main part of the new functionality is implemented in the class
+ * klee::MergeHandler. The Special Function Handler generates an instance of
+ * this class every time a state runs into a klee_open_merge() call.
+ * 
+ * This instance is appended to a `std::vector<klee::ref<klee::MergeHandler>>`
+ * in the ExecutionState that passed the merge open point. This stack is also
+ * copied during forks. We use a stack instead of a single instance to support
+ * nested merge regions.
+ * 
+ * Once a state runs into a `klee_close_merge()`, the Special Function Handler
+ * notifies the top klee::MergeHandler in the state's stack, pauses the state
+ * from scheduling, and tries to merge it with all other states that already
+ * arrived at the same close merge point. This top instance is then popped from
+ * the stack, resulting in a decrease of the ref count of the
+ * klee::MergeHandler.
+ * 
+ * Since the only references to this MergeHandler are in the stacks of
+ * the ExecutionStates currently in the merging region, once the ref count
+ * reaches zero, every state which ran into the same `klee_open_merge()` is now
+ * paused and waiting to be merged. The destructor of the MergeHandler
+ * then continues the scheduling of the corresponding paused states.
+*/
+
+#ifndef KLEE_MERGEHANDLER_H
+#define KLEE_MERGEHANDLER_H
+
+#include <vector>
+#include <map>
+#include <stdint.h>
+#include "llvm/Support/CommandLine.h"
+
+namespace llvm {
+class Instruction;
+}
+
+namespace klee {
+extern llvm::cl::opt<bool> UseMerge;
+
+extern llvm::cl::opt<bool> DebugLogMerge;
+
+class Executor;
+class ExecutionState;
+
+/// @brief Represents one `klee_open_merge()` call. 
+/// Handles merging of states that branched from it
+class MergeHandler {
+private:
+  Executor *executor;
+
+  /// @brief Number of states that are tracked by this MergeHandler, that ran
+  /// into a relevant klee_close_merge
+  unsigned closedStateCount;
+
+  /// @brief Mapping the different 'klee_close_merge' calls to the states that ran into
+  /// them
+  std::map<llvm::Instruction *, std::vector<ExecutionState *> >
+      reachedMergeClose;
+
+public:
+
+  /// @brief Called when a state runs into a 'klee_close_merge()' call
+  void addClosedState(ExecutionState *es, llvm::Instruction *mp);
+
+  /// @brief True, if any states have run into 'klee_close_merge()' and have
+  /// not been released yet
+  bool hasMergedStates();
+  
+  /// @brief Immediately release the merged states that have run into a
+  /// 'klee_merge_close()'
+  void releaseStates();
+
+  /// @brief Required by klee::ref objects
+  unsigned refCount;
+
+
+  MergeHandler(Executor *_executor);
+  ~MergeHandler();
+};
+}
+
+#endif	/* KLEE_MERGEHANDLER_H */

--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -152,6 +152,11 @@ extern "C" {
   /* Print range for given argument and tagged with name */
   void klee_print_range(const char * name, int arg );
 
+  /* Open a merge */
+  void klee_open_merge();
+
+  /* Merge all paths of the state that went through klee_open_merge */
+  void klee_close_merge();
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -8,6 +8,7 @@
 #===------------------------------------------------------------------------===#
 klee_add_component(kleeCore
   AddressSpace.cpp
+  MergeHandler.cpp
   CallPathManager.cpp
   Context.cpp
   CoreStats.cpp

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -116,7 +116,8 @@ ExecutionState::ExecutionState(const ExecutionState& state):
     coveredLines(state.coveredLines),
     ptreeNode(state.ptreeNode),
     symbolics(state.symbolics),
-    arrayNames(state.arrayNames)
+    arrayNames(state.arrayNames),
+    openMergeStack(state.openMergeStack)
 {
   for (unsigned int i=0; i<symbolics.size(); i++)
     symbolics[i].first->refCount++;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2456,6 +2456,9 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 void Executor::updateStates(ExecutionState *current) {
   if (searcher) {
     searcher->update(current, addedStates, removedStates);
+    searcher->update(0, continuedStates, pausedStates);
+    pausedStates.clear();
+    continuedStates.clear();
   }
   
   states.insert(addedStates.begin(), addedStates.end());
@@ -2740,6 +2743,31 @@ std::string Executor::getAddressInfo(ExecutionState &state,
 
   return info.str();
 }
+
+void Executor::pauseState(ExecutionState &state){
+  std::vector<ExecutionState *>::iterator it = std::find(continuedStates.begin(), continuedStates.end(), &state);
+  // If the state was to be continued, but now gets paused again
+  if (it != continuedStates.end()){
+    // ...just don't continue it
+    std::swap(*it, continuedStates.back());
+    continuedStates.pop_back();
+  } else {
+    pausedStates.push_back(&state);
+  }
+}
+
+void Executor::continueState(ExecutionState &state){
+  std::vector<ExecutionState *>::iterator it = std::find(pausedStates.begin(), pausedStates.end(), &state);
+  // If the state was to be paused, but now gets continued again
+  if (it != pausedStates.end()){
+    // ...don't pause it
+    std::swap(*it, pausedStates.back());
+    pausedStates.pop_back();
+  } else {
+    continuedStates.push_back(&state);
+  }
+}
+
 
 void Executor::terminateState(ExecutionState &state) {
   if (replayKTest && replayPosition!=replayKTest->numObjects) {

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2456,7 +2456,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 void Executor::updateStates(ExecutionState *current) {
   if (searcher) {
     searcher->update(current, addedStates, removedStates);
-    searcher->update(0, continuedStates, pausedStates);
+    searcher->update(nullptr, continuedStates, pausedStates);
     pausedStates.clear();
     continuedStates.clear();
   }
@@ -2745,7 +2745,7 @@ std::string Executor::getAddressInfo(ExecutionState &state,
 }
 
 void Executor::pauseState(ExecutionState &state){
-  std::vector<ExecutionState *>::iterator it = std::find(continuedStates.begin(), continuedStates.end(), &state);
+  auto it = std::find(continuedStates.begin(), continuedStates.end(), &state);
   // If the state was to be continued, but now gets paused again
   if (it != continuedStates.end()){
     // ...just don't continue it
@@ -2757,7 +2757,7 @@ void Executor::pauseState(ExecutionState &state){
 }
 
 void Executor::continueState(ExecutionState &state){
-  std::vector<ExecutionState *>::iterator it = std::find(pausedStates.begin(), pausedStates.end(), &state);
+  auto it = std::find(pausedStates.begin(), pausedStates.end(), &state);
   // If the state was to be paused, but now gets continued again
   if (it != pausedStates.end()){
     // ...don't pause it
@@ -2767,7 +2767,6 @@ void Executor::continueState(ExecutionState &state){
     continuedStates.push_back(&state);
   }
 }
-
 
 void Executor::terminateState(ExecutionState &state) {
   if (replayKTest && replayPosition!=replayKTest->numObjects) {

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -69,6 +69,7 @@ namespace klee {
   class StatsTracker;
   class TimingSolver;
   class TreeStreamWriter;
+  class MergeHandler;
   template<class T> class ref;
 
 
@@ -78,13 +79,12 @@ namespace klee {
   /// removedStates, and haltExecution, among others.
 
 class Executor : public Interpreter {
-  friend class BumpMergingSearcher;
-  friend class MergingSearcher;
   friend class RandomPathSearcher;
   friend class OwningSearcher;
   friend class WeightedRandomSearcher;
   friend class SpecialFunctionHandler;
   friend class StatsTracker;
+  friend class MergeHandler;
 
 public:
   class Timer {

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -144,6 +144,13 @@ private:
   /// \invariant \ref addedStates and \ref removedStates are disjoint.
   std::vector<ExecutionState *> removedStates;
 
+  /// Used to track states that are not terminated, but should not
+  /// be scheduled by the searcher.
+  std::vector<ExecutionState *> pausedStates;
+  /// States that were 'paused' from scheduling, that now may be
+  /// scheduled again
+  std::vector<ExecutionState *> continuedStates;
+
   /// When non-empty the Executor is running in "seed" mode. The
   /// states in this map will be executed in an arbitrary order
   /// (outside the normal search interface) until they terminate. When
@@ -389,6 +396,10 @@ private:
 
   bool shouldExitOn(enum TerminateReason termReason);
 
+  // remove state from searcher only
+  void pauseState(ExecutionState& state);
+  // add state to searcher only
+  void continueState(ExecutionState& state);
   // remove state from queue and delete
   void terminateState(ExecutionState &state);
   // call exit handler and terminate state

--- a/lib/Core/MergeHandler.cpp
+++ b/lib/Core/MergeHandler.cpp
@@ -1,0 +1,76 @@
+//===-- MergeHandler.cpp --------------------------------------------------===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "klee/MergeHandler.h"
+
+#include "CoreStats.h"
+#include "Executor.h"
+#include "klee/ExecutionState.h"
+
+namespace klee {
+llvm::cl::opt<bool>
+    UseMerge("use-merge",
+        llvm::cl::init(false),
+        llvm::cl::desc("Enable support for klee_open_merge() and klee_close_merge() (experimental)"));
+
+llvm::cl::opt<bool>
+    DebugLogMerge("debug-log-merge",
+        llvm::cl::init(false),
+        llvm::cl::desc("Enhanced verbosity for region based merge operations"));
+
+void MergeHandler::addClosedState(ExecutionState *es,
+                                         llvm::Instruction *mp) {
+  auto closePoint = reachedMergeClose.find(mp);
+
+  // If no other state has yet encountered this klee_close_merge instruction,
+  // add a new element to the map
+  if (closePoint == reachedMergeClose.end()) {
+    reachedMergeClose[mp].push_back(es);
+    executor->pauseState(*es);
+  } else {
+    // Otherwise try to merge with any state in the map element for this
+    // instruction
+    auto &cpv = closePoint->second;
+    bool mergedSuccessful = false;
+
+    for (auto& mState: cpv) {
+      if (mState->merge(*es)) {
+        executor->terminateState(*es);
+        mergedSuccessful = true;
+        break;
+      }
+    }
+    if (!mergedSuccessful) {
+      cpv.push_back(es);
+      executor->pauseState(*es);
+    }
+  }
+}
+
+void MergeHandler::releaseStates() {
+  for (auto& curMergeGroup: reachedMergeClose) {
+    for (auto curState: curMergeGroup.second) {
+      executor->continueState(*curState);
+    }
+  }
+  reachedMergeClose.clear();
+}
+
+bool MergeHandler::hasMergedStates() {
+  return (!reachedMergeClose.empty());
+}
+
+MergeHandler::MergeHandler(Executor *_executor)
+    : executor(_executor), refCount(0) {
+}
+
+MergeHandler::~MergeHandler() {
+  releaseStates();
+}
+}

--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -42,11 +42,6 @@
 using namespace klee;
 using namespace llvm;
 
-namespace {
-  cl::opt<bool>
-  DebugLogMerge("debug-log-merge");
-}
-
 namespace klee {
   extern RNG theRNG;
 }

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -116,6 +116,8 @@ namespace klee {
     HANDLER(handleMakeSymbolic);
     HANDLER(handleMalloc);
     HANDLER(handleMarkGlobal);
+    HANDLER(handleOpenMerge);
+    HANDLER(handleCloseMerge);
     HANDLER(handleNew);
     HANDLER(handleNewArray);
     HANDLER(handlePreferCex);

--- a/test/Merging/batching_break.c
+++ b/test/Merging/batching_break.c
@@ -1,0 +1,42 @@
+// RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+
+// CHECK: open merge:
+// CHECK: close merge:
+// CHECK: KLEE: done: generated tests = 3{{$}}
+
+#include <klee/klee.h>
+
+int main(int argc, char** args){
+
+  int x;
+  int p;
+  int i;
+
+  klee_make_symbolic(&x, sizeof(x), "x");
+  x = x % 20;
+
+  klee_open_merge();
+  for (i = 0; i < x; ++i){
+    if (x % 3 == 0){
+      klee_close_merge();
+      if (x > 10){
+        return 1;
+      } else {
+        return 2;
+      }
+    }
+  }
+  klee_close_merge();
+
+  klee_open_merge();
+  if (x > 10){
+    p = 1;
+  } else {
+    p = 2;
+  }
+  klee_close_merge();
+  return p;
+
+}

--- a/test/Merging/easy_merge.c
+++ b/test/Merging/easy_merge.c
@@ -1,0 +1,44 @@
+// RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge %t.bc 2>&1 | FileCheck %s
+
+// CHECK: open merge:
+// CHECK: close merge:
+// CHECK: close merge:
+// CHECK: close merge:
+// CHECK: generated tests = 2{{$}}
+#include <klee/klee.h>
+
+int main(int argc, char** args){
+
+  int x;
+  int a;
+  int foo = 0;
+
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_make_symbolic(&a, sizeof(a), "a");
+
+  if (a == 0){
+    klee_open_merge();
+
+    if (x == 1) {
+      foo = 5;
+    } else if (x == 2) {
+      foo = 6;
+    } else {
+      foo = 7;
+    }
+
+    klee_close_merge();
+  }
+
+  return foo;
+}

--- a/test/Merging/indirect_value.c
+++ b/test/Merging/indirect_value.c
@@ -1,0 +1,32 @@
+// RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
+
+// CHECK: generated tests = 2{{$}}
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <klee/klee.h>
+
+int main(int argc, char** argv) {
+
+  int sym = klee_int("sym");
+  int* heap_int = calloc(1, sizeof(*heap_int));
+
+  klee_open_merge();
+
+  if(sym != 0) {
+    *heap_int = 1;
+  }
+
+  klee_close_merge();
+
+  klee_print_expr("*heap_int: ", *heap_int);
+  if(*heap_int != 0) {
+    printf("true\n");
+  } else {
+    printf("false\n");
+  }
+
+  return 0;
+}

--- a/test/Merging/loop_merge.c
+++ b/test/Merging/loop_merge.c
@@ -1,0 +1,38 @@
+// RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+
+// CHECK: open merge:
+// There will be 20 'close merge' statements. Only checking a few, the generated
+// test count will confirm that the merge was closed correctly
+// CHECK: close merge:
+// CHECK: close merge:
+// CHECK: close merge:
+// CHECK: close merge:
+// CHECK: generated tests = 2{{$}}
+
+#include <klee/klee.h>
+
+int main(int argc, char** args){
+
+  int x;
+  int i;
+
+  klee_make_symbolic(&x, sizeof(x), "x");
+  x = x % 20;
+
+  klee_open_merge();
+  for (i = 0; i < x; ++i){
+    if (x % 3 == 0){
+      klee_close_merge();
+      return 1;
+    }
+  }
+  klee_close_merge();
+
+  return 0;
+}

--- a/test/Merging/merge_fail.c
+++ b/test/Merging/merge_fail.c
@@ -1,0 +1,36 @@
+// RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+
+// CHECK: open merge:
+// CHECK: generated tests = 2{{$}}
+
+// This test will not merge because we cannot merge states when they allocated memory.
+
+#include <klee/klee.h>
+
+int main(int argc, char **args) {
+
+  int* arr = 0;
+  int a = 0;
+
+  klee_make_symbolic(&a, sizeof(a), "a");
+
+  klee_open_merge();
+  if (a == 0) {
+    arr = (int*) malloc(7 * sizeof(int));
+    arr[0] = 7;
+  } else {
+    arr = (int*) malloc(8 * sizeof(int));
+    arr[0] = 8;
+  }
+  klee_close_merge();
+  a = arr[0];
+  free(arr);
+
+  return a;
+}

--- a/test/Merging/nested_merge.c
+++ b/test/Merging/nested_merge.c
@@ -1,0 +1,48 @@
+// RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+
+// CHECK: open merge:
+// 5 close merges
+// CHECK: close merge:
+// CHECK: close merge:
+// CHECK: close merge:
+// CHECK: close merge:
+// CHECK: close merge:
+// CHECK: generated tests = 1{{$}}
+
+#include <klee/klee.h>
+
+int main(int argc, char **args) {
+
+  int x;
+  int a;
+  int foo = 0;
+
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_make_symbolic(&a, sizeof(a), "a");
+
+  klee_open_merge();
+  if (a == 0) {
+    klee_open_merge();
+
+    if (x == 1) {
+      foo = 5;
+    } else if (x == 2) {
+      foo = 6;
+    } else {
+      foo = 7;
+    }
+
+    klee_close_merge();
+  }
+  klee_close_merge();
+
+  return foo;
+}

--- a/test/Merging/split_merge.c
+++ b/test/Merging/split_merge.c
@@ -1,0 +1,41 @@
+// RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+
+
+// CHECK: open merge:
+// CHECK: close merge:
+// CHECK: close merge:
+// CHECK: close merge:
+// CHECK: generated tests = 2{{$}}
+
+#include <klee/klee.h>
+
+int main(int argc, char** args){
+
+  int x;
+  int foo = 0;
+
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+  klee_open_merge();
+
+  if (x == 1){
+    foo = 5;
+  } else if (x == 2){
+    klee_close_merge();
+    return 6;
+  } else {
+    foo = 7;
+  }
+
+  klee_close_merge();
+
+  return foo;
+}

--- a/test/Merging/unexpected_close.c
+++ b/test/Merging/unexpected_close.c
@@ -1,0 +1,35 @@
+// RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out --use-merge --search=nurs:covnew --max-time=2 %t.bc
+
+// CHECK: ran into a close at
+// CHECK: generated tests = 2{{$}}
+
+#include <klee/klee.h>
+
+int main(int argc, char **args) {
+
+  int x;
+  int a;
+  int foo = 0;
+
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_make_symbolic(&a, sizeof(a), "a");
+
+  if (a == 0) {
+    klee_open_merge();
+
+    if (x == 1) {
+      foo = 5;
+    } else if (x == 2) {
+      foo = 6;
+    } else {
+      foo = 7;
+    }
+
+    klee_close_merge();
+  }
+  klee_close_merge();
+
+  return foo;
+}

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -718,6 +718,8 @@ static const char *modelledExternals[] = {
   "klee_is_symbolic",
   "klee_make_symbolic",
   "klee_mark_global",
+  "klee_open_merge",
+  "klee_close_merge",
   "klee_prefer_cex",
   "klee_posix_prefer_cex",
   "klee_print_expr",


### PR DESCRIPTION
This PR implements the basic version of a region-based state merging approach, behind the `-use-bounded-merge` flag. PR #691 adds additional functionality to this basic approach.

### Basic usage:
```c
klee_open_merge();

/* code containing branches etc. */

klee_close_merge();
```

Will lead to all states that forked from the state that executed the `klee_open_merge()` being merged in the `klee_close_merge()`. This allows for fine-grained regions to be specified for merging.

Tests for the implementation are also included in this PR, which give a few examples of how this technique can be used.

## Implementation Structure

The main part of the new functionality is implemented in the class `BoundedMergeHandler`. The Special Function Handler generates an instance of this class every time a state runs into a `klee_open_merge()` call.

This instance is appended to a `std::vector<klee::ref<BoundedMergeHandler>>` in the `ExecutionState` that passed the merge open point.  This stack is also copied during forks. We use a stack instead of a single instance to support nested merge regions.

Once a state runs into a `klee_close_merge()`, the Special Function Handler notifies the top `BoundedMergeHandler` in the state's stack, pauses the state from scheduling, and tries to merge it with all other states that already arrived at the same close merge point. This top instance is then popped from the stack, resulting in a decrease of the ref count of the `BoundedMergeHandler`.

Since the only references to this `BoundedMergeHandler` are in the stacks of the `ExecutionState`s currently in the merging region, once the ref count reaches zero, every state which ran into the same `klee_open_merge()` is now paused and waiting to be merged. The destructor of the `BoundedMergeHandler` then continues the scheduling of the corresponding paused states.

### Pausing and continuing states

For this purpose, we added the functionality to 'pause' a specific state from being scheduled again, but without terminating the state (commit e604ca1).

### Random Path Searcher

The `RandomPathSearcher` required additional changes to work with paused states (the `BumpMergingSearcher` also had problems with this, and would simply run into an endless loop if used together). In our version, we perform a simple backtracking step to find a non-paused state.

## Overhead

The biggest overhead introduced by this implementation is an additional vector of `Ref`s in each execution state. When state merging is not used, this vector will always be empty, and thus only take up the space required by an empty vector. In case state merging is used, the vector will contain an entry for each nested merging-region the state is in; this number should usually be rather low.

Additionally, some new member variables were added to the `Executor` class, but the additional space required should be negligible, especially if state merging is not used. However, the state-pausing functionality requires some bookkeeping inside `Executor::updateStates`, which is performed even if state merging is disabled (because the pausing/continuing of states is independent of state merging). This should still be extremely cheap, especially if there are no paused states (e.g., currently this means when state merging is not enabled).

Further the `RandomPathSearcher` has to check whether there are paused states, so the backtracking functionality can be used if required. This, too, should not make a visible performance difference, and also means that the `RandomPathSearcher` continues to work as before if state merging is turned off (the default).