### PR TITLE
Fix generation of initial values using CEX cache

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -751,9 +751,8 @@ void Executor::branch(ExecutionState &state,
       unsigned i;
       for (i=0; i<N; ++i) {
         ref<ConstantExpr> res;
-        bool success = 
-          solver->getValue(state, siit->assignment.evaluate(conditions[i]), 
-                           res);
+        bool success = solver->getValue(
+            state, siit->assignment.evaluate(conditions[i], true), res);
         assert(success && "FIXME: Unhandled solver failure");
         (void) success;
         if (res->isTrue())
@@ -890,8 +889,8 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
     for (std::vector<SeedInfo>::iterator siit = it->second.begin(), 
            siie = it->second.end(); siit != siie; ++siit) {
       ref<ConstantExpr> res;
-      bool success = 
-        solver->getValue(current, siit->assignment.evaluate(condition), res);
+      bool success = solver->getValue(
+          current, siit->assignment.evaluate(condition, true), res);
       assert(success && "FIXME: Unhandled solver failure");
       (void) success;
       if (res->isTrue()) {
@@ -951,10 +950,11 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
       for (std::vector<SeedInfo>::iterator siit = seeds.begin(), 
              siie = seeds.end(); siit != siie; ++siit) {
         ref<ConstantExpr> res;
-        bool success = 
-          solver->getValue(current, siit->assignment.evaluate(condition), res);
+        bool success = solver->getValue(
+            current, siit->assignment.evaluate(condition, false), res);
         assert(success && "FIXME: Unhandled solver failure");
         (void) success;
+        assert(isa<ConstantExpr>(res));
         if (res->isTrue()) {
           trueSeeds.push_back(*siit);
         } else {
@@ -1029,8 +1029,8 @@ void Executor::addConstraint(ExecutionState &state, ref<Expr> condition) {
     for (std::vector<SeedInfo>::iterator siit = it->second.begin(), 
            siie = it->second.end(); siit != siie; ++siit) {
       bool res;
-      bool success = 
-        solver->mustBeFalse(state, siit->assignment.evaluate(condition), res);
+      bool success = solver->mustBeFalse(
+          state, siit->assignment.evaluate(condition, false), res);
       assert(success && "FIXME: Unhandled solver failure");
       (void) success;
       if (res) {
@@ -1206,8 +1206,11 @@ void Executor::executeGetValue(ExecutionState &state,
     for (std::vector<SeedInfo>::iterator siit = it->second.begin(), 
            siie = it->second.end(); siit != siie; ++siit) {
       ref<ConstantExpr> value;
-      bool success = 
-        solver->getValue(state, siit->assignment.evaluate(e), value);
+      bool success =
+          solver->getValue(state, siit->assignment.evaluate(e, false), value);
+      assert(isa<ConstantExpr>(value) &&
+             "Should result in a constant expression");
+
       assert(success && "FIXME: Unhandled solver failure");
       (void) success;
       values.insert(value);

--- a/lib/Core/SeedInfo.cpp
+++ b/lib/Core/SeedInfo.cpp
@@ -115,7 +115,8 @@ void SeedInfo::patchSeed(const ExecutionState &state,
   }
 
   bool res;
-  bool success = solver->mayBeTrue(state, assignment.evaluate(condition), res);
+  bool success =
+      solver->mayBeTrue(state, assignment.evaluate(condition, false), res);
   assert(success && "FIXME: Unhandled solver failure");
   (void) success;
   if (res)
@@ -154,8 +155,8 @@ void SeedInfo::patchSeed(const ExecutionState &state,
 #ifndef NDEBUG
   {
     bool res;
-    bool success = 
-      solver->mayBeTrue(state, assignment.evaluate(condition), res);
+    bool success =
+        solver->mayBeTrue(state, assignment.evaluate(condition, false), res);
     assert(success && "FIXME: Unhandled solver failure");            
     (void) success;
     assert(res && "seed patching failed");

--- a/lib/Core/SeedInfo.h
+++ b/lib/Core/SeedInfo.h
@@ -29,11 +29,9 @@ namespace klee {
     std::set<struct KTestObject*> used;
     
   public:
-    explicit
-    SeedInfo(KTest *_input) : assignment(true),
-                             input(_input),
-                             inputPosition(0) {}
-    
+    explicit SeedInfo(KTest *_input)
+        : assignment(), input(_input), inputPosition(0) {}
+
     KTestObject *getNextInput(const MemoryObject *mo,
                              bool byName);
     

--- a/lib/Solver/AssignmentValidatingSolver.cpp
+++ b/lib/Solver/AssignmentValidatingSolver.cpp
@@ -57,15 +57,16 @@ bool AssignmentValidatingSolver::computeInitialValues(
   if (!hasSolution)
     return success;
 
-  // Use `_allowFreeValues` so that if we are missing an assignment
-  // we can't compute a constant and flag this as a problem.
-  Assignment assignment(objects, values, /*_allowFreeValues=*/true);
+  Assignment assignment(objects, values);
   // Check computed assignment satisfies query
   for (ConstraintManager::const_iterator it = query.constraints.begin(),
                                          ie = query.constraints.end();
        it != ie; ++it) {
     ref<Expr> constraint = *it;
-    ref<Expr> constraintEvaluated = assignment.evaluate(constraint);
+    // Use `_allowFreeValues` so that if we are missing an assignment
+    // we can't compute a constant and flag this as a problem.
+    ref<Expr> constraintEvaluated =
+        assignment.evaluate(constraint, true /* allow free values */);
     ConstantExpr *CE = dyn_cast<ConstantExpr>(constraintEvaluated);
     if (CE == NULL) {
       llvm::errs() << "Constraint did not evalaute to a constant:\n";
@@ -86,7 +87,10 @@ bool AssignmentValidatingSolver::computeInitialValues(
     }
   }
 
-  ref<Expr> queryExprEvaluated = assignment.evaluate(query.expr);
+  // Use `_allowFreeValues` so that if we are missing an assignment
+  // we can't compute a constant and flag this as a problem.
+  ref<Expr> queryExprEvaluated =
+      assignment.evaluate(query.expr, true /* allow free value */);
   ConstantExpr *CE = dyn_cast<ConstantExpr>(queryExprEvaluated);
   if (CE == NULL) {
     llvm::errs() << "Query expression did not evalaute to a constant:\n";

--- a/lib/Solver/MetaSMTSolver.cpp
+++ b/lib/Solver/MetaSMTSolver.cpp
@@ -158,7 +158,7 @@ bool MetaSMTSolverImpl<SolverContext>::computeValue(const Query &query,
     assert(hasSolution && "state has invalid constraint set");
     // Evaluate the expression with the computed assignment.
     Assignment a(objects, values);
-    result = a.evaluate(query.expr);
+    result = a.evaluate(query.expr, true);
     success = true;
   }
 

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -173,7 +173,11 @@ bool STPSolverImpl::computeValue(const Query &query, ref<Expr> &result) {
 
   // Evaluate the expression with the computed assignment.
   Assignment a(objects, values);
-  result = a.evaluate(query.expr);
+  // We just compute any value, therefore the expression can be either true or
+  // false
+  // force concretization to acquire one possible outcome
+  // Currently we assume that computeValue generates a constant
+  result = a.evaluate(query.expr, true /* concretize symbolics */);
 
   return true;
 }

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -221,7 +221,7 @@ bool Z3SolverImpl::computeValue(const Query &query, ref<Expr> &result) {
 
   // Evaluate the expression with the computed assignment.
   Assignment a(objects, values);
-  result = a.evaluate(query.expr);
+  result = a.evaluate(query.expr, true);
 
   return true;
 }

--- a/unittests/Assignment/AssignmentTest.cpp
+++ b/unittests/Assignment/AssignmentTest.cpp
@@ -19,16 +19,16 @@ TEST(AssignmentTest, FoldNotOptimized)
   objects.push_back(array);
   value.push_back(128);
   values.push_back(value);
-  // We want to simplify to a constant so allow free values so
-  // if the assignment is incomplete we don't get back a constant.
-  Assignment assignment(objects, values, /*_allowFreeValues=*/true);
+  Assignment assignment(objects, values);
 
   // Now make an expression that reads from the array at position
   // zero.
   ref<Expr> read = NotOptimizedExpr::alloc(Expr::createTempRead(array, Expr::Int8));
 
   // Now evaluate. The OptimizedExpr should be folded
-  ref<Expr> evaluated = assignment.evaluate(read);
+  // We want to simplify to a constant so allow free values so
+  // if the assignment is incomplete we don't get back a constant.
+  ref<Expr> evaluated = assignment.evaluate(read, false);
   const ConstantExpr* asConstant = dyn_cast<ConstantExpr>(evaluated);
   ASSERT_TRUE(asConstant != NULL);
   ASSERT_EQ(asConstant->getZExtValue(), (unsigned) 128);


### PR DESCRIPTION
Assignments used by the CEX cache concretize free symbolics during
evaluation of expressions.
This has the side effect that if a conclusion contains symbolic
variables, which are independent of the premise, the evaluation of the
conclusion can lead to either a true or false outcome.

Specifically with `computeValidity()` and `computeTruth()`, such
assignments can be added to the CEX cache. As the whole query is
used as a key in such case, the conclusion is indistinguishable
from the premise.

This is an undesired behavior for generating initial values: If the path
constraints resemble a subset of constraints which match a previously
inserted query, despite an assignment, the concretization might lead to
an invalid assignment for the initial values.

To counteract that behavior, this patch forces the decision on how
to evaluate an assignment (concrete/symbolic) to the time of evaluation
not the time of the creation of the assignment.

Depending on the invoked method of the CEX solver, a concretization is
possible and reduces the number of solver invocations (e.g.
`computeValidity()`, `computeTruth()`) or the concretization is avoided
and a solver is called.