### PR TITLE
Use assembly line for printing debug information

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1252,7 +1252,7 @@ void Executor::printDebugInstructions(ExecutionState &state) {
     (*stream) << ":";
   }
 
-  (*stream) << state.pc->info->id;
+  (*stream) << state.pc->info->assemblyLine;
 
   if (optionIsSet(DebugPrintInstructions, STDERR_ALL) ||
       optionIsSet(DebugPrintInstructions, FILE_ALL))


### PR DESCRIPTION
Instead of using an id, use the assembly line number executed.

This correctly reflects the appropriate line in assembly.ll.