### PR TITLE
Added an optional KInstruction* argument to evalConstant and evalCons…

### DIFF
--- a/include/klee/Internal/Module/KInstruction.h
+++ b/include/klee/Internal/Module/KInstruction.h
@@ -44,7 +44,8 @@ namespace klee {
 
   public:
     virtual ~KInstruction();
-    void printFileLine(llvm::raw_ostream &);
+    void printFileLine(llvm::raw_ostream &) const;
+    std::string printFileLine() const;
 
   };
 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -349,9 +349,17 @@ private:
                     ExecutionState &state,
                     ref<Expr> value);
 
-  ref<klee::ConstantExpr> evalConstantExpr(const llvm::ConstantExpr *ce);
+  /// Evaluates an LLVM constant expression.  The optional argument ki
+  /// is the instruction where this constant was encountered, or NULL
+  /// if not applicable/unavailable.
+  ref<klee::ConstantExpr> evalConstantExpr(const llvm::ConstantExpr *c,
+					   const KInstruction *ki = NULL);
 
-  ref<klee::ConstantExpr> evalConstant(const llvm::Constant *c);
+  /// Evaluates an LLVM constant.  The optional argument ki is the
+  /// instruction where this constant was encountered, or NULL if
+  /// not applicable/unavailable.
+  ref<klee::ConstantExpr> evalConstant(const llvm::Constant *c,
+				       const KInstruction *ki = NULL);
 
   /// Return a unique constant value for the given expression in the
   /// given state, if it has one (i.e. it provably only has a single

--- a/lib/Module/KInstruction.cpp
+++ b/lib/Module/KInstruction.cpp
@@ -8,6 +8,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "klee/Internal/Module/KInstruction.h"
+#include "llvm/Support/raw_ostream.h"
+#include <string>
 
 using namespace llvm;
 using namespace klee;
@@ -18,9 +20,15 @@ KInstruction::~KInstruction() {
   delete[] operands;
 }
 
-void KInstruction::printFileLine(llvm::raw_ostream &debugFile) {
+void KInstruction::printFileLine(llvm::raw_ostream &debugFile) const {
   if (info->file != "")
     debugFile << info->file << ":" << info->line;
-  else
-    debugFile << "[no debug info]";
+  else debugFile << "[no debug info]";
+}
+
+std::string KInstruction::printFileLine() const {
+  std::string str;
+  llvm::raw_string_ostream oss(str);
+  printFileLine(oss);
+  return oss.str();
 }

--- a/test/Feature/AddressOfLabels.c
+++ b/test/Feature/AddressOfLabels.c
@@ -1,0 +1,36 @@
+// RUN: %llvmgcc -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: not %klee --output-dir=%t.klee-out %t.bc 2> %t.log
+// RUN: FileCheck --input-file %t.log %s
+
+/* 
+   This currently tests that KLEE clearly reports that it doesn't
+   support taking the address of the labels, in particular
+   blockaddress constants.
+
+   The test would need to be changes once support for this feature is
+   added. 
+*/
+
+#include <stdio.h>
+
+int main (int argc, char** argv)
+{
+  int i = 1;
+  // CHECK: Cannot handle constant 'i8* blockaddress 
+  // CHECK: AddressOfLabels.c:[[@LINE+1]]
+  void * lptr = &&one;
+
+  if (argc > 1)
+    lptr = &&two;
+  
+  goto *lptr;
+
+ one:
+  printf("argc is 1\n");
+  return 0;
+  
+ two:
+  printf("argc is >1\n");
+  return 0;
+}


### PR DESCRIPTION
…tantExpr which allows us to print the location associated with the constant in any error messages.  Added a test case for the unsupported features for taking the address of a label, which exercises the patch.