### PR TITLE
Provide errno independent of CTYPE_EXTERNALS being defined

### DIFF
--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -157,6 +157,9 @@ extern "C" {
 
   /* Merge all paths of the state that went through klee_open_merge */
   void klee_close_merge();
+
+  /* Get errno value of the current state */
+  int klee_get_errno(void);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Core/AddressSpace.cpp
+++ b/lib/Core/AddressSpace.cpp
@@ -313,19 +313,26 @@ bool AddressSpace::copyInConcretes() {
 
     if (!mo->isUserSpecified) {
       const ObjectState *os = it->second;
-      uint8_t *address = (uint8_t*) (unsigned long) mo->address;
 
-      if (memcmp(address, os->concreteStore, mo->size)!=0) {
-        if (os->readOnly) {
-          return false;
-        } else {
-          ObjectState *wos = getWriteable(mo, os);
-          memcpy(wos->concreteStore, address, mo->size);
-        }
-      }
+      if (!copyInConcrete(mo, os, mo->address))
+        return false;
     }
   }
 
+  return true;
+}
+
+bool AddressSpace::copyInConcrete(const MemoryObject *mo, const ObjectState *os,
+                                  uint64_t src_address) {
+  uint8_t *address = (uint8_t *)(unsigned long)src_address;
+  if (memcmp(address, os->concreteStore, mo->size) != 0) {
+    if (os->readOnly) {
+      return false;
+    } else {
+      ObjectState *wos = getWriteable(mo, os);
+      memcpy(wos->concreteStore, address, mo->size);
+    }
+  }
   return true;
 }
 

--- a/lib/Core/AddressSpace.h
+++ b/lib/Core/AddressSpace.h
@@ -125,6 +125,15 @@ namespace klee {
     /// \retval true The copy succeeded. 
     /// \retval false The copy failed because a read-only object was modified.
     bool copyInConcretes();
+
+    /// Updates the memory object with the raw memory from the address
+    ///
+    /// @param mo The MemoryObject to update
+    /// @param os The associated memory state containing the actual data
+    /// @param src_address the address to copy from
+    /// @return
+    bool copyInConcrete(const MemoryObject *mo, const ObjectState *os,
+                        uint64_t src_address);
   };
 } // End klee namespace
 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -525,6 +525,9 @@ public:
 
   Expr::Width getWidthForLLVMType(llvm::Type *type) const;
   size_t getAllocationAlignment(const llvm::Value *allocSite) const;
+
+  /// Returns the errno location in memory of the state
+  int *getErrnoLocation(const ExecutionState &state) const;
 };
   
 } // End klee namespace

--- a/lib/Core/ExternalDispatcher.h
+++ b/lib/Core/ExternalDispatcher.h
@@ -40,6 +40,9 @@ public:
   bool executeCall(llvm::Function *function, llvm::Instruction *i,
                    uint64_t *args);
   void *resolveSymbol(const std::string &name);
+
+  int getLastErrno();
+  void setLastErrno(int newErrno);
 };
 }
 

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -154,6 +154,7 @@ private:
   const MemoryObject *object;
 
   uint8_t *concreteStore;
+
   // XXX cleanup name of flushMask (its backwards or something)
   BitArray *concreteMask;
 

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -91,6 +91,11 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("klee_define_fixed_object", handleDefineFixedObject, false),
   add("klee_get_obj_size", handleGetObjSize, true),
   add("klee_get_errno", handleGetErrno, true),
+#ifndef __APPLE__
+  add("__errno_location", handleErrnoLocation, true),
+#else
+  add("__error", handleErrnoLocation, true),
+#endif
   add("klee_is_symbolic", handleIsSymbolic, true),
   add("klee_make_symbolic", handleMakeSymbolic, false),
   add("klee_mark_global", handleMarkGlobal, false),
@@ -578,10 +583,41 @@ void SpecialFunctionHandler::handleGetErrno(ExecutionState &state,
   // XXX should type check args
   assert(arguments.size()==0 &&
          "invalid number of arguments to klee_get_errno");
-  executor.bindLocal(target, state,
-                     ConstantExpr::create(errno, Expr::Int32));
+#ifndef WINDOWS
+  int *errno_addr = executor.getErrnoLocation(state);
+#else
+  int *errno_addr = nullptr;
+#endif
+
+  // Retrieve the memory object of the errno variable
+  ObjectPair result;
+  bool resolved = state.addressSpace.resolveOne(
+      ConstantExpr::create((uint64_t)errno_addr, Expr::Int64), result);
+  if (!resolved)
+    executor.terminateStateOnError(state, "Could not resolve address for errno",
+                                   Executor::User);
+  executor.bindLocal(target, state, result.second->read(0, Expr::Int32));
 }
 
+void SpecialFunctionHandler::handleErrnoLocation(
+    ExecutionState &state, KInstruction *target,
+    std::vector<ref<Expr> > &arguments) {
+  // Returns the address of the errno variable
+  assert(arguments.size() == 0 &&
+         "invalid number of arguments to __errno_location/__error");
+
+#ifndef WINDOWS
+  int *errno_addr = executor.getErrnoLocation(state);
+#else
+  int *errno_addr = nullptr;
+#endif
+
+  executor.bindLocal(
+      target, state,
+      ConstantExpr::create((uint64_t)errno_addr,
+                           executor.kmodule->targetData->getTypeSizeInBits(
+                               target->inst->getType())));
+}
 void SpecialFunctionHandler::handleCalloc(ExecutionState &state,
                             KInstruction *target,
                             std::vector<ref<Expr> > &arguments) {

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -107,6 +107,7 @@ namespace klee {
     HANDLER(handleDelete);    
     HANDLER(handleDeleteArray);
     HANDLER(handleExit);
+    HANDLER(handleErrnoLocation);
     HANDLER(handleAliasFunction);
     HANDLER(handleFree);
     HANDLER(handleGetErrno);

--- a/test/Runtime/POSIX/DirSeek.c
+++ b/test/Runtime/POSIX/DirSeek.c
@@ -1,4 +1,4 @@
-// RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t2.bc
+// RUN: %llvmgcc %s -emit-llvm -O0 -c -g -o %t2.bc
 // RUN: rm -rf %t.klee-out %t.klee-out-tmp
 // RUN: %gentmp %t.klee-out-tmp
 // RUN: %klee --output-dir=%t.klee-out --run-in=%t.klee-out-tmp --libc=uclibc --posix-runtime --exit-on-error %t2.bc --sym-files 2 2
@@ -11,8 +11,8 @@
 
 // For this test really to work as intended it needs to be run in a
 // directory large enough to cause uclibc to do multiple getdents
-// calls (otherwise uclibc will handle the seeks itself). We should
-// create a bunch of files or something.
+// calls (otherwise uclibc will handle the seeks itself).
+// Therefore gentmp generates a directory with a specific amount of entries
 
 #include <assert.h>
 #include <stdio.h>
@@ -29,7 +29,6 @@ int main(int argc, char **argv) {
   assert(de);
   strcpy(first, de->d_name);
   off_t pos = telldir(d);
-  printf("pos: %ld\n", telldir(d));
   de = readdir(d);
   assert(de);
   strcpy(second, de->d_name);
@@ -41,9 +40,10 @@ int main(int argc, char **argv) {
   assert(strcmp(de->d_name, second) == 0);
 
   // Go to end, then back to 2nd
-  while (de)
+  while (de) {
     de = readdir(d);
-  assert(!errno);
+    assert(!errno);
+  }
   seekdir(d, pos);
   assert(telldir(d) == pos);
   de = readdir(d);

--- a/test/Runtime/POSIX/Ioctl.c
+++ b/test/Runtime/POSIX/Ioctl.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/ioctl.h>
 #include <termios.h>
 #include <asm/ioctls.h>
 #include <errno.h>

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -698,6 +698,8 @@ static const char *modelledExternals[] = {
   "_assert",
   "__assert_fail",
   "__assert_rtn",
+  "__errno_location",
+  "__error",
   "calloc",
   "_exit",
   "exit",


### PR DESCRIPTION
The object pointed to by `__errno_location()` should be part of the execution state.

Currently, this is only the case if `CTYPE_EXTERNALS` is defined and we are neither on Windows nor Darwin.