### PR TITLE
This reverts incorrect patch https://github.com/klee/klee/commit/db29…

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1073,9 +1073,6 @@ static llvm::Module *linkWithUclibc(llvm::Module *mainModule, StringRef libDir) 
   replaceOrRenameFunction(mainModule, "__libc_open", "open");
   replaceOrRenameFunction(mainModule, "__libc_fcntl", "fcntl");
 
-  // Take care of fortified functions
-  replaceOrRenameFunction(mainModule, "__fprintf_chk", "fprintf");
-
   // XXX we need to rearchitect so this can also be used with
   // programs externally linked with uclibc.
 


### PR DESCRIPTION
…a0bba74b672cdf4b8fef4d94ffa6ab845e6d

__fprintf_chk has a different prototype than fprintf
