### PR TITLE
consistent spacing for conditional expressions

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -475,7 +475,7 @@ void KleeHandler::processTestCase(const ExecutionState &state,
       delete f;
     }
 
-    if(WriteSMT2s) {
+    if (WriteSMT2s) {
       std::string constraints;
         m_interpreter->getConstraintLog(state, constraints, Interpreter::SMTLIB2);
         llvm::raw_ostream *f = openTestFile("smt2", id);


### PR DESCRIPTION
The formatting of this file is consistent with a `if (`. This commit replaces instances of `if(` with `if (`