### PR TITLE
[CMake] Implement clean-all (fixes #718)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,6 +490,23 @@ else()
 endif()
 
 ################################################################################
+# Global clean target
+################################################################################
+# CMake already uses the "clean" target name but it doesn't clean everything
+# unfortunately. We can't modify the target so we provide our own "clean_all"
+# target that runs clean. Other rules for performing clean up should declare
+# that "clean_all" depends on those rules.
+add_custom_target(clean_all
+  # Invoke CMake's own clean target
+  COMMAND
+    "${CMAKE_COMMAND}"
+    "--build"
+    "${CMAKE_BINARY_DIR}"
+    "--target"
+    "clean"
+)
+
+################################################################################
 # KLEE runtime support
 ################################################################################
 # This is set here and not in `runtime` because `config.h` needs to be generated.

--- a/README-CMake.md
+++ b/README-CMake.md
@@ -6,7 +6,10 @@ its autoconf/Makefile based build system.
 ## Useful top level targets
 
 * `check` - Build and run all tests.
-* `clean` - Clean the build tree. Note this won't clean the runtime build.
+* `clean` - Invoke CMake's built-in target to clean the build tree.  Note this
+  won't invoke the `clean_*` targets. It is advised that the `clean_all` target
+  is used instead.
+* `clean_all` - Run all clean targets.
 * `clean_runtime` - Clean the runtime build tree.
 * `docs` - Build documentation
 * `edit_cache` - Show cmake/ccmake/cmake-gui interface for chaning configure options.

--- a/README-CMake.md
+++ b/README-CMake.md
@@ -10,6 +10,7 @@ its autoconf/Makefile based build system.
   won't invoke the `clean_*` targets. It is advised that the `clean_all` target
   is used instead.
 * `clean_all` - Run all clean targets.
+* `clean_doxygen` - Clean doxygen build tree.
 * `clean_runtime` - Clean the runtime build tree.
 * `docs` - Build documentation
 * `edit_cache` - Show cmake/ccmake/cmake-gui interface for chaning configure options.

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -28,6 +28,20 @@ if (ENABLE_DOXYGEN)
       ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}
     )
     add_dependencies(docs doc-doxygen)
+
+    # FIXME: This variable should be used to set `OUTPUT_DIRECTORY` in
+    # doxygen.cfg
+    set(DOXYGEN_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/doxygen")
+
+    # Add rule to clean doxygen documentation
+    add_custom_target(clean_doxygen
+      COMMAND
+        "${CMAKE_COMMAND}"
+        "-E"
+        "remove_directory"
+        "${DOXYGEN_OUTPUT_DIR}"
+    )
+    add_dependencies(clean_all clean_doxygen)
   else()
     message(WARNING "Doxygen not found. Can't build Doxygen documentation")
     set(ENABLE_DOXYGEN OFF

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -115,13 +115,15 @@ ExternalProject_Add_Step(BuildKLEERuntimes RuntimeBuild
 )
 
 # Target for cleaning the bitcode build system
-# FIXME: Invoke `make clean` does not invoke this target. It's also weird
-# that `ExternalProject` provides no way to do a clean.
+# NOTE: Invoking `make clean` does not invoke this target.
+# Instead the user needs to invoke the `clean_all` target.
+# It's also weird that `ExternalProject` provides no way to do a clean.
 add_custom_target(clean_runtime
   COMMAND ${ENV_BINARY} MAKEFLAGS="" ${MAKE_BINARY} -f Makefile.cmake.bitcode clean
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}
 )
+add_dependencies(clean_all clean_runtime)
 
 ###############################################################################
 # Runtime install


### PR DESCRIPTION
Not sure if this should be `clean-all` or `clean_all`. `clean_all` would be more consistent with the other target names.