### PR TITLE
Removed the word 'unsigned' from integer overflow error messages

### DIFF
--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -74,9 +74,8 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   addDNR("_exit", handleExit),
   { "exit", &SpecialFunctionHandler::handleExit, true, false, true },
   addDNR("klee_abort", handleAbort),
-  addDNR("klee_silent_exit", handleSilentExit),  
+  addDNR("klee_silent_exit", handleSilentExit),
   addDNR("klee_report_error", handleReportError),
-
   add("calloc", handleCalloc, true),
   add("free", handleFree, false),
   add("klee_assume", handleAssume, false),
@@ -122,14 +121,15 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   // operator new(unsigned long)
   add("_Znwm", handleNew, true),
 
-  // clang -fsanitize=unsigned-integer-overflow
+  // Run clang with -fsanitize=signed-integer-overflow and/or
+  // -fsanitize=unsigned-integer-overflow
   add("__ubsan_handle_add_overflow", handleAddOverflow, false),
   add("__ubsan_handle_sub_overflow", handleSubOverflow, false),
   add("__ubsan_handle_mul_overflow", handleMulOverflow, false),
   add("__ubsan_handle_divrem_overflow", handleDivRemOverflow, false),
 
 #undef addDNR
-#undef add  
+#undef add
 };
 
 SpecialFunctionHandler::const_iterator SpecialFunctionHandler::begin() {
@@ -733,21 +733,21 @@ void SpecialFunctionHandler::handleMarkGlobal(ExecutionState &state,
 void SpecialFunctionHandler::handleAddOverflow(ExecutionState &state,
                                                KInstruction *target,
                                                std::vector<ref<Expr> > &arguments) {
-  executor.terminateStateOnError(state, "overflow on unsigned addition",
+  executor.terminateStateOnError(state, "overflow on addition",
                                  Executor::Overflow);
 }
 
 void SpecialFunctionHandler::handleSubOverflow(ExecutionState &state,
                                                KInstruction *target,
                                                std::vector<ref<Expr> > &arguments) {
-  executor.terminateStateOnError(state, "overflow on unsigned subtraction",
+  executor.terminateStateOnError(state, "overflow on subtraction",
                                  Executor::Overflow);
 }
 
 void SpecialFunctionHandler::handleMulOverflow(ExecutionState &state,
                                                KInstruction *target,
                                                std::vector<ref<Expr> > &arguments) {
-  executor.terminateStateOnError(state, "overflow on unsigned multiplication",
+  executor.terminateStateOnError(state, "overflow on multiplication",
                                  Executor::Overflow);
 }
 

--- a/test/Feature/ubsan_signed_overflow.c
+++ b/test/Feature/ubsan_signed_overflow.c
@@ -13,13 +13,13 @@ int main()
   klee_make_symbolic(&x, sizeof(x), "x");
   klee_make_symbolic(&y, sizeof(y), "y");
 
-  // CHECK: ubsan_signed_overflow.c:17: overflow on unsigned addition
+  // CHECK: ubsan_signed_overflow.c:17: overflow on addition
   result = x + y;
 
-  // CHECK: ubsan_signed_overflow.c:20: overflow on unsigned subtraction
+  // CHECK: ubsan_signed_overflow.c:20: overflow on subtraction
   result = x - y;
 
-  // CHECK: ubsan_signed_overflow.c:23: overflow on unsigned multiplication
+  // CHECK: ubsan_signed_overflow.c:23: overflow on multiplication
   result = x * y;
 
   return 0;

--- a/test/Feature/ubsan_unsigned_overflow.c
+++ b/test/Feature/ubsan_unsigned_overflow.c
@@ -13,13 +13,13 @@ int main()
   klee_make_symbolic(&x, sizeof(x), "x");
   klee_make_symbolic(&y, sizeof(y), "y");
 
-  // CHECK: ubsan_unsigned_overflow.c:17: overflow on unsigned addition
+  // CHECK: ubsan_unsigned_overflow.c:17: overflow on addition
   result = x + y;
 
-  // CHECK: ubsan_unsigned_overflow.c:20: overflow on unsigned subtraction
+  // CHECK: ubsan_unsigned_overflow.c:20: overflow on subtraction
   result = x - y;
 
-  // CHECK: ubsan_unsigned_overflow.c:23: overflow on unsigned multiplication
+  // CHECK: ubsan_unsigned_overflow.c:23: overflow on multiplication
   result = x * y;
 
   return 0;


### PR DESCRIPTION
This may resolve #731. Although I could think of a technique to detect signed / unsigned operations by detecting comparison with the constant 2147483647 or 4294967295 right before the call to `__ubsan` functions to distinguish signed or unsigned cases, but since ubsan itself does not distinguish both cases, KLEE should probably not try further. So the solution adopted here is to simply remove the word 'unsigned' from the error messages.