### PR TITLE
Random-Path Searcher support for Merging (RBSM 2.5/3)

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2744,7 +2744,7 @@ void Executor::updateStates(ExecutionState *current) {
   removedStates.clear();
 
   if (searcher) {
-    searcher->update(nullptr, continuedStates, pausedStates);
+    searcher->updatePaused(continuedStates, pausedStates);
     pausedStates.clear();
     continuedStates.clear();
   }

--- a/lib/Core/Searcher.h
+++ b/lib/Core/Searcher.h
@@ -17,6 +17,7 @@
 #include <map>
 #include <queue>
 #include <set>
+#include <stack>
 #include <vector>
 
 namespace llvm {
@@ -40,6 +41,12 @@ namespace klee {
     virtual void update(ExecutionState *current,
                         const std::vector<ExecutionState *> &addedStates,
                         const std::vector<ExecutionState *> &removedStates) = 0;
+
+    virtual void
+    updatePaused(const std::vector<ExecutionState *> &unpausedStates,
+                 const std::vector<ExecutionState *> &pausedStates) {
+      update(nullptr, unpausedStates, pausedStates);
+    }
 
     virtual bool empty() = 0;
 
@@ -169,11 +176,20 @@ namespace klee {
   class RandomPathSearcher : public Searcher {
     Executor &executor;
 
+    /// The set of states that are not removed from the processTree, but the
+    /// searcher should ignore
+    std::set<ExecutionState *> ignoreStates;
+
+    ExecutionState &selectStateIgnore();
+    ExecutionState &selectStateStandard();
+
   public:
     RandomPathSearcher(Executor &_executor);
     ~RandomPathSearcher();
 
     ExecutionState &selectState();
+    void updatePaused(const std::vector<ExecutionState *> &unpausedStates,
+                      const std::vector<ExecutionState *> &pausedStates);
     void update(ExecutionState *current,
                 const std::vector<ExecutionState *> &addedStates,
                 const std::vector<ExecutionState *> &removedStates);

--- a/lib/Core/UserSearcher.cpp
+++ b/lib/Core/UserSearcher.cpp
@@ -137,12 +137,6 @@ Searcher *klee::constructUserSearcher(Executor &executor) {
     searcher = new InterleavedSearcher(s);
   }
 
-  if (UseMerge) {
-    if (std::find(CoreSearch.begin(), CoreSearch.end(), Searcher::RandomPath) != CoreSearch.end()){
-      klee_error("use-merge currently does not support random-path, please use another search strategy");
-    }
-  }
-
   if (UseBatchingSearch) {
     searcher = new BatchingSearcher(searcher, time::Span(BatchTime), BatchInstructions);
   }

--- a/test/Merging/batching_break.c
+++ b/test/Merging/batching_break.c
@@ -1,6 +1,6 @@
 // RUN: %clang -emit-llvm -g -c -o %t.bc %s
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc --use-batching-search 2>&1 | FileCheck %s
 
 // CHECK: open merge:
 // CHECK: close merge:

--- a/test/Merging/incomplete_merge.c
+++ b/test/Merging/incomplete_merge.c
@@ -7,6 +7,8 @@
 // RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --use-incomplete-merge --debug-log-incomplete-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --use-incomplete-merge --debug-log-incomplete-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --use-incomplete-merge --debug-log-incomplete-merge --search=random-path %t.bc 2>&1 | FileCheck %s
 
 // CHECK: open merge:
 // 5 close merges

--- a/test/Merging/loop_merge.c
+++ b/test/Merging/loop_merge.c
@@ -5,6 +5,8 @@
 // RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=random-path %t.bc 2>&1 | FileCheck %s
 
 // CHECK: open merge:
 // There will be 20 'close merge' statements. Only checking a few, the generated

--- a/test/Merging/merge_fail.c
+++ b/test/Merging/merge_fail.c
@@ -5,6 +5,8 @@
 // RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=random-path %t.bc 2>&1 | FileCheck %s
 
 // CHECK: open merge:
 // CHECK: generated tests = 2{{$}}

--- a/test/Merging/nested_merge.c
+++ b/test/Merging/nested_merge.c
@@ -7,6 +7,8 @@
 // RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=random-path %t.bc 2>&1 | FileCheck %s
 
 // CHECK: open merge:
 // 5 close merges

--- a/test/Merging/split_merge.c
+++ b/test/Merging/split_merge.c
@@ -7,7 +7,8 @@
 // RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
-
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=random-path %t.bc 2>&1 | FileCheck %s
 
 // CHECK: open merge:
 // CHECK: close merge:


### PR DESCRIPTION
This PR adds Random-Path Searcher support for the region-based state merging, by making the Random-Path Searcher able to ignore states. To do so, when it finds a state that has been marked as paused, it instead performs a backtracking step to find another state to schedule.

More detailed information:

- This PR also adds a test that uses state merging and the random path searcher. This adds code coverage for the new code.
- This PR adds a new virtual method `Searcher::updatePaused`. This method is called by the `Executor` when states are paused or unpaused. The default implementation in `Searcher` simply forwards the call to `Searcher::update`, since a paused state is the same as that state being removed for most searchers. Notably, the `RandomPathSearcher` class overrides this functionality to keep track of which states have been paused. The implementation uses this information to perform a backtracking step when a paused state would have been selected by the `RandomPathSearcher`.

Note that 235 of the 425 added lines are the new test, so the changes to KLEE itself are much smaller.

Currently, `RandomPathSearcher` has two different methods to select the next state (`selectStateStandard` and `selectStateIgnore`), so that backtracking information is only collected when paused states exist. The two methods could be easily merged into one, giving up the optimization and simply always keeping track of the backtracking information (which might be quite cheap).

`RandomPathSearcher::selectStateIgnore` internally uses a small helper class called `BacktrackHelper` which keeps a stack of backtrack information in the form of valid directions to choose from. 