### PR TITLE
Disabled unit testing in default build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -651,7 +651,7 @@ add_subdirectory(tools)
 ################################################################################
 # Testing
 ################################################################################
-option(ENABLE_UNIT_TESTS "Enable unit tests" ON)
+option(ENABLE_UNIT_TESTS "Enable unit tests" OFF)
 option(ENABLE_SYSTEM_TESTS "Enable system tests" ON)
 
 # This provides a migration path for older build directories that have this


### PR DESCRIPTION
Addresses #768 

CMake can now be invoked without any additional configuration flag.