### PR TITLE
Fixing huge allocation size constant to be unsigned

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3114,7 +3114,7 @@ void Executor::executeAlloc(ExecutionState &state,
         // malloc will fail for it, so lets fork and return 0.
         StatePair hugeSize = 
           fork(*fixedSize.second, 
-               UltExpr::create(ConstantExpr::alloc(1<<31, W), size), 
+               UltExpr::create(ConstantExpr::alloc(1U<<31, W), size),
                true);
         if (hugeSize.first) {
           klee_message("NOTE: found huge malloc, returning 0");


### PR DESCRIPTION
The boundary for a huge allocation is 1<<31.
Note that 1<<31 is of type signed int, so while passed to ConstandExpr::alloc,
it is sign-extended to 0xffffffff80000000, which is later cast to uint64_t.
As a result, the boundary actually becomes 18446744071562067968L instead of 2147483648.