### PR TITLE
Add cmake option to set GTest include dir

### DIFF
--- a/README-CMake.md
+++ b/README-CMake.md
@@ -63,6 +63,9 @@ cmake -DCMAKE_BUILD_TYPE=Release /path/to/klee/src
 
 * `GTEST_SRC_DIR` (STRING) - Path to GTest source tree.
 
+* `GTEST_INCLUDE_DIR` (STRING) - Path to GTest include directory,
+   if it is not under `GTEST_SRC_DIR`.
+
 * `KLEE_ENABLE_TIMESTAMP` (BOOLEAN) - Enable timestamps in KLEE sources.
 
 * `KLEE_UCLIBC_PATH` (STRING) - Path to klee-uclibc root directory.

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -52,7 +52,12 @@ define_property(GLOBAL
   FULL_DOCS "KLEE unit tests"
 )
 
-set(GTEST_INCLUDE_DIR "${GTEST_SRC_DIR}/include")
+set(GTEST_INCLUDE_DIR
+  "${GTEST_SRC_DIR}/include"
+  CACHE
+  PATH
+  "Path to GTest include directory"
+)
 
 if (NOT IS_DIRECTORY "${GTEST_INCLUDE_DIR}")
   message(FATAL_ERROR


### PR DESCRIPTION
For example, the archlinux gtest package splits its files in `/usr/include/gtest` and `/usr/src/gtest`.