### PR TITLE
Fix vector handling

### DIFF
--- a/lib/Core/Context.h
+++ b/lib/Core/Context.h
@@ -37,6 +37,7 @@ namespace klee {
 
     bool isLittleEndian() const { return IsLittleEndian; }
 
+    /// Returns width of the pointer in bits
     Expr::Width getPointerWidth() const { return PointerWidth; }
   };
   

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2392,15 +2392,11 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     const unsigned elementCount = vt->getNumElements();
     llvm::SmallVector<ref<Expr>, 8> elems;
     elems.reserve(elementCount);
-    for (unsigned i = 0; i < elementCount; ++i) {
-      // evalConstant() will use ConcatExpr to build vectors with the
-      // zero-th element leftmost (most significant bits), followed
-      // by the next element (second leftmost) and so on. This means
-      // that we have to adjust the index so we read left to right
-      // rather than right to left.
-      unsigned bitOffset = EltBits * (elementCount - i - 1);
-      elems.push_back(i == iIdx ? newElt
-                                : ExtractExpr::create(vec, bitOffset, EltBits));
+    for (unsigned i = elementCount; i != 0; --i) {
+      auto of = i - 1;
+      unsigned bitOffset = EltBits * of;
+      elems.push_back(
+          of == iIdx ? newElt : ExtractExpr::create(vec, bitOffset, EltBits));
     }
 
     ref<Expr> Result = ConcatExpr::createN(elementCount, elems.data());
@@ -2430,12 +2426,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
       return;
     }
 
-    // evalConstant() will use ConcatExpr to build vectors with the
-    // zero-th element left most (most significant bits), followed
-    // by the next element (second left most) and so on. This means
-    // that we have to adjust the index so we read left to right
-    // rather than right to left.
-    unsigned bitOffset = EltBits*(vt->getNumElements() - iIdx -1);
+    unsigned bitOffset = EltBits * iIdx;
     ref<Expr> Result = ExtractExpr::create(vec, bitOffset, EltBits);
     bindLocal(ki, state, Result);
     break;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2399,6 +2399,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
           of == iIdx ? newElt : ExtractExpr::create(vec, bitOffset, EltBits));
     }
 
+    assert(Context::get().isLittleEndian() && "FIXME:Broken for big endian");
     ref<Expr> Result = ConcatExpr::createN(elementCount, elems.data());
     bindLocal(ki, state, Result);
     break;

--- a/lib/Core/ExecutorUtil.cpp
+++ b/lib/Core/ExecutorUtil.cpp
@@ -58,9 +58,11 @@ namespace klee {
         return ConstantExpr::create(0, getWidthForLLVMType(c->getType()));
       } else if (const ConstantDataSequential *cds =
                  dyn_cast<ConstantDataSequential>(c)) {
+        // Handle a vector or array: first element has the smallest address,
+        // the last element the highest
         std::vector<ref<Expr> > kids;
-        for (unsigned i = 0, e = cds->getNumElements(); i != e; ++i) {
-          ref<Expr> kid = evalConstant(cds->getElementAsConstant(i), ki);
+        for (unsigned i = cds->getNumElements(); i != 0; --i) {
+          ref<Expr> kid = evalConstant(cds->getElementAsConstant(i - 1), ki);
           kids.push_back(kid);
         }
         ref<Expr> res = ConcatExpr::createN(kids.size(), kids.data());

--- a/lib/Core/ExecutorUtil.cpp
+++ b/lib/Core/ExecutorUtil.cpp
@@ -104,8 +104,8 @@ namespace klee {
         llvm::SmallVector<ref<Expr>, 8> kids;
         const size_t numOperands = cv->getNumOperands();
         kids.reserve(numOperands);
-        for (unsigned i = 0; i < numOperands; ++i) {
-          kids.push_back(evalConstant(cv->getOperand(i), ki));
+        for (unsigned i = numOperands; i != 0; --i) {
+          kids.push_back(evalConstant(cv->getOperand(i - 1), ki));
         }
         ref<Expr> res = ConcatExpr::createN(numOperands, kids.data());
         assert(isa<ConstantExpr>(res) &&

--- a/lib/Core/ExecutorUtil.cpp
+++ b/lib/Core/ExecutorUtil.cpp
@@ -69,6 +69,8 @@ namespace klee {
           ref<Expr> kid = evalConstant(cds->getElementAsConstant(i - 1), ki);
           kids.push_back(kid);
         }
+        assert(Context::get().isLittleEndian() &&
+               "FIXME:Broken for big endian");
         ref<Expr> res = ConcatExpr::createN(kids.size(), kids.data());
         return cast<ConstantExpr>(res);
       } else if (const ConstantStruct *cs = dyn_cast<ConstantStruct>(c)) {
@@ -89,6 +91,8 @@ namespace klee {
 
           kids.push_back(kid);
         }
+        assert(Context::get().isLittleEndian() &&
+               "FIXME:Broken for big endian");
         ref<Expr> res = ConcatExpr::createN(kids.size(), kids.data());
         return cast<ConstantExpr>(res);
       } else if (const ConstantArray *ca = dyn_cast<ConstantArray>(c)){
@@ -98,6 +102,8 @@ namespace klee {
           ref<Expr> kid = evalConstant(ca->getOperand(op), ki);
           kids.push_back(kid);
         }
+        assert(Context::get().isLittleEndian() &&
+               "FIXME:Broken for big endian");
         ref<Expr> res = ConcatExpr::createN(kids.size(), kids.data());
         return cast<ConstantExpr>(res);
       } else if (const ConstantVector *cv = dyn_cast<ConstantVector>(c)) {
@@ -107,6 +113,8 @@ namespace klee {
         for (unsigned i = numOperands; i != 0; --i) {
           kids.push_back(evalConstant(cv->getOperand(i - 1), ki));
         }
+        assert(Context::get().isLittleEndian() &&
+               "FIXME:Broken for big endian");
         ref<Expr> res = ConcatExpr::createN(numOperands, kids.data());
         assert(isa<ConstantExpr>(res) &&
                "result of constant vector built is not a constant");

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -577,7 +577,7 @@ void ObjectState::write64(unsigned offset, uint64_t value) {
   }
 }
 
-void ObjectState::print() {
+void ObjectState::print() const {
   llvm::errs() << "-- ObjectState --\n";
   llvm::errs() << "\tMemoryObject ID: " << object->id << "\n";
   llvm::errs() << "\tRoot Object: " << updates.root << "\n";

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -205,6 +205,8 @@ public:
   void write32(unsigned offset, uint32_t value);
   void write64(unsigned offset, uint64_t value);
 
+  void print() const;
+
 private:
   const UpdateList &getUpdates() const;
 
@@ -231,7 +233,6 @@ private:
   void markByteUnflushed(unsigned offset);
   void setKnownSymbolic(unsigned offset, Expr *value);
 
-  void print();
   ArrayCache *getArrayCache() const;
 };
   

--- a/test/Concrete/ConstantInit.ll
+++ b/test/Concrete/ConstantInit.ll
@@ -1,0 +1,26 @@
+; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
+
+%struct.dirent = type { i64, i64, i16, i8, [256 x i8] }
+declare void @print_i64(i64)
+
+define i32 @main() {
+entry:
+	%a = alloca %struct.dirent
+	%tmp1 = getelementptr %struct.dirent* %a, i32 0
+	%tmp2 = bitcast %struct.dirent* %tmp1 to <2 x i64>*
+	; Initialize with constant vector
+	store <2 x i64> <i64 0, i64 4096>, <2 x i64>* %tmp2, align 8
+	br label %exit
+exit:
+	; Print first initialized element
+	%idx = getelementptr %struct.dirent* %a, i32 0, i32 0
+	%val = load i64* %idx	
+	call void @print_i64(i64 %val)
+
+	; Print second initialized element	
+	%idx2 = getelementptr %struct.dirent* %a, i32 0, i32 1
+	%val2 = load i64* %idx2	
+	call void @print_i64(i64 %val2)
+	
+	ret i32 0
+}

--- a/test/Concrete/ConstantInit.ll
+++ b/test/Concrete/ConstantInit.ll
@@ -1,15 +1,16 @@
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
-%struct.dirent = type { i64, i64, i16, i8, [256 x i8] }
+%struct.dirent = type { i64, i64, i16, i8 }
 declare void @print_i64(i64)
 
-define i32 @main() {
-entry:
+define void @test_constant_vector_simple() {
+  entry:
 	%a = alloca %struct.dirent
 	%tmp1 = getelementptr %struct.dirent* %a, i32 0
 	%tmp2 = bitcast %struct.dirent* %tmp1 to <2 x i64>*
-	; Initialize with constant vector
+	; Initialize with constant vector parsed as ConstantDataSequential
 	store <2 x i64> <i64 0, i64 4096>, <2 x i64>* %tmp2, align 8
+	
 	br label %exit
 exit:
 	; Print first initialized element
@@ -21,6 +22,38 @@ exit:
 	%idx2 = getelementptr %struct.dirent* %a, i32 0, i32 1
 	%val2 = load i64* %idx2	
 	call void @print_i64(i64 %val2)
-	
+	ret void	
+}
+
+define void @test_constant_vector_complex() {
+entry:
+    ; Create a vector using an uncommon type: i1024: Force usage of constant vector
+	%a = alloca <2 x i1024>
+	store <2 x i1024> <i1024 5, i1024 1024>, <2 x i1024>* %a, align 8
+
+	br label %exit
+exit:
+	; Print first initialized element
+	%idx = getelementptr <2 x i1024>* %a, i32 0, i32 0
+	%narrow = bitcast i1024* %idx to i64*
+	%val = load i64* %narrow
+	call void @print_i64(i64 %val)
+
+	; Print second initialized element
+	%idx2 = getelementptr <2 x i1024>* %a, i32 0, i32 1
+	%narrow2 = bitcast i1024* %idx2 to i64*
+	%val2 = load i64* %narrow2
+	call void @print_i64(i64 %val2)
+
+	ret void	
+}
+
+define i32 @main() {
+entry:
+	call void @test_constant_vector_simple()
+	call void @test_constant_vector_complex()
+
+	br label %exit
+exit:
 	ret i32 0
 }

--- a/test/Feature/ConstantArray.ll
+++ b/test/Feature/ConstantArray.ll
@@ -1,0 +1,51 @@
+; RUN: llvm-as %s -f -o %t1.bc
+; RUN: rm -rf %t.klee-out
+; RUN: %klee --output-dir=%t.klee-out -disable-opt %t1.bc 2>&1 | FileCheck %s
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@.str = private unnamed_addr constant [2 x i8] c"0\00", align 1
+@.str2 = private unnamed_addr constant [2 x i8] c"1\00", align 1
+
+%struct.dirent = type { i32, i32, i16, i8 }
+declare void @klee_print_expr(i8*, ...)
+
+define i32 @main() {
+entry:
+	%a = alloca %struct.dirent
+	%tmp1 = getelementptr %struct.dirent* %a, i32 0
+	%tmp2 = bitcast %struct.dirent* %tmp1 to <2 x i32>*
+	; Initialize with constant vector
+	store <2 x i32> <i32 42, i32 4096>, <2 x i32>* %tmp2
+	br label %exit
+exit:
+	; Print first initialized element
+	%idx = getelementptr %struct.dirent* %a, i32 0, i32 0
+	%val = load i32* %idx
+	call void(i8*, ...)* @klee_print_expr(i8* getelementptr inbounds ([2 x i8]* @.str, i32 0, i32 0), i32 %val)
+	; CHECK: 0:42
+
+	; Print second initialized element
+	%idx2 = getelementptr %struct.dirent* %a, i32 0, i32 1
+	%val2 = load i32* %idx2
+	call void(i8*, ...)* @klee_print_expr(i8* getelementptr inbounds ([2 x i8]* @.str2, i32 0, i32 0), i32 %val2)
+	; CHECK: 1:4096
+	
+	; Initialize with constant array
+	%array = alloca [2 x i32];
+	store [2 x i32][i32 7, i32 9], [2 x i32]* %array
+
+	; Print first initialized element
+	%idx3 = getelementptr [2 x i32]* %array, i32 0, i32 0
+	%val3 = load i32* %idx3
+	call void(i8*, ...)* @klee_print_expr(i8* getelementptr inbounds ([2 x i8]* @.str, i32 0, i32 0), i32 %val3)
+	; CHECK: 0:7
+
+	; Print second initialized element
+	%idx4 = getelementptr [2 x i32]* %array, i32 0, i32 1
+	%val4 = load i32* %idx4
+	call void(i8*, ...)* @klee_print_expr(i8* getelementptr inbounds ([2 x i8]* @.str2, i32 0, i32 0), i32 %val4)
+	; CHECK: 1:9
+	
+	ret i32 0
+}

--- a/test/regression/2007-08-01-bool-zext-in-call.ll
+++ b/test/regression/2007-08-01-bool-zext-in-call.ll
@@ -1,7 +1,8 @@
 ; RUN: rm -rf %t.klee-out
 ; RUN: llvm-as -f %s -o - | %klee --output-dir=%t.klee-out
 ; RUN: not test -f %t.klee-out/test0001.abort.err
-
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
 declare void @klee_abort()
 
 define i32 @foo(i8 signext %val) {


### PR DESCRIPTION
This PR handles a couple of issues:
* fix handling of `getElementPtr` for vectors and arrays
* fix handling of constant-ordered vector
* fix handling of `ExtractElement`/`InsertElement`

Fixes root cause of issue with #669 .

