### PR TITLE
fix: test/Feature/BFSSearcherAndDFSSearcherInterleaved.c (LLVM 3.7)

### DIFF
--- a/test/Feature/BFSSearcherAndDFSSearcherInterleaved.c
+++ b/test/Feature/BFSSearcherAndDFSSearcherInterleaved.c
@@ -38,12 +38,6 @@ int main() {
     }
   }
 
-  // exactly 4 characters
-  // CHECK: {{^[A-D]{4}$}}
-
-  // for each of A, B, C and D: occurs exactly once
-  // CHECK-SAME: {{^[B-D]*A[B-D]*$}}
-  // CHECK-SAME: {{^[A,C-D]*B[A,C-D]*$}}
-  // CHECK-SAME: {{^[A-B,D]*C[A-B,D]*$}}
-  // CHECK-SAME: {{^[A-C]*D[A-C]*$}}
+  // exactly 4 characters, each of A, B, C and D occur exactly once
+  // CHECK: {{^(ABCD|ABDC|ACBD|ACDB|ADBC|ADCB|BACD|BADC|BCAD|BCDA|BDAC|BDCA|CABD|CADB|CBAD|CBDA|CDAB|CDBA|DABC|DACB|DBAC|DBCA|DCAB|DCBA)$}}
 }


### PR DESCRIPTION
When building KLEE with LLVM 3.7, `test/Feature/BFSSearcherAndDFSSearcherInterleaved.c` fails, as seen in #669.

As I introduced the failing test, I looked into the issue and found the problem: I wanted to check the output against two conditions:
- is exactly 4 characters long
- for each of A, B, C and D: occurs exactly once

To check these, I used `CHECK` and (multiple) `CHECK-SAME` expressions that all try to match the same whole line. Starting form LLVM 3.7, `FileCheck` seems to skip already matched parts of the ouput permanently, it is no longer possible to match the whole line from the beginning.

The only fix I could think of (that actually works, unlike regex lookaheads), is to explicitly enumerate all possible patterns in a single `CHECK`.