### PR TITLE
klee_make_symbolic: warn on deprecated usage

### DIFF
--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -665,15 +665,22 @@ void SpecialFunctionHandler::handleMakeSymbolic(ExecutionState &state,
                                                 std::vector<ref<Expr> > &arguments) {
   std::string name;
 
-  // FIXME: For backwards compatibility, we should eventually enforce the
-  // correct arguments.
-  if (arguments.size() == 2) {
+  // FIXME: For backwards compatibility. We should eventually enforce the
+  // correct arguments and types.
+  switch (arguments.size()) {
+    case 2:
+      klee_warning("klee_make_symbolic: deprecated number of arguments (2 instead of 3)");
+      break;
+    case 3:
+      name = readStringAtAddress(state, arguments[2]);
+      break;
+    default:
+      executor.terminateStateOnError(state, "illegal number of arguments to klee_make_symbolic(void*, size_t, char*)", Executor::User);
+      return;
+  }
+  if (name.length() == 0) {
     name = "unnamed";
-  } else {
-    // FIXME: Should be a user.err, not an assert.
-    assert(arguments.size()==3 &&
-           "invalid number of arguments to klee_make_symbolic");  
-    name = readStringAtAddress(state, arguments[2]);
+    klee_warning("klee_make_symbolic: renamed empty name to \"unnamed\"");
   }
 
   Executor::ExactResolutionList rl;

--- a/test/Feature/MakeSymbolicAPI.c
+++ b/test/Feature/MakeSymbolicAPI.c
@@ -1,0 +1,19 @@
+// RUN: %llvmgcc %s -emit-llvm -g -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out %t1.bc 2> %t.stderr.log
+// RUN: FileCheck %s -check-prefix=CHECK-WRN --input-file=%t.klee-out/warnings.txt
+// RUN: FileCheck %s -check-prefix=CHECK-ERR --input-file=%t.stderr.log
+
+int main() {
+  unsigned a, b, c;
+
+  klee_make_symbolic(&a, sizeof(a), "");
+// CHECK-WRN: KLEE: WARNING: klee_make_symbolic: renamed empty name to "unnamed"
+
+  klee_make_symbolic(&b, sizeof(b));
+// CHECK-WRN: KLEE: WARNING: klee_make_symbolic: deprecated number of arguments (2 instead of 3)
+// CHECK-WRN: KLEE: WARNING: klee_make_symbolic: renamed empty name to "unnamed"
+
+  klee_make_symbolic(&c);
+// CHECK-ERR: KLEE: ERROR: {{.*}} illegal number of arguments to klee_make_symbolic(void*, size_t, char*)
+}

--- a/test/regression/2017-11-01-test-with-empty-varname.c
+++ b/test/regression/2017-11-01-test-with-empty-varname.c
@@ -1,0 +1,11 @@
+// RUN: %llvmgcc %s -emit-llvm -g -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out %t1.bc
+// RUN: FileCheck %s --input-file=%t.klee-out/warnings.txt
+
+int main() {
+  unsigned a;
+
+  klee_make_symbolic(&a, sizeof(a), "");
+// CHECK-NOT: KLEE: WARNING: unable to write output test case, losing it
+}


### PR DESCRIPTION
* uses `klee_error` instead of assertions for illegal argument number
* renames empty names to `unnamed` (otherwise test generation fails)
* deprecates two argument version