### PR TITLE
Fix Merging Tests: use `%klee` instead of `klee`

### DIFF
--- a/test/Merging/batching_break.c
+++ b/test/Merging/batching_break.c
@@ -1,6 +1,6 @@
 // RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
 
 // CHECK: open merge:
 // CHECK: close merge:

--- a/test/Merging/easy_merge.c
+++ b/test/Merging/easy_merge.c
@@ -1,14 +1,14 @@
 // RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge %t.bc 2>&1 | FileCheck %s
 
 // CHECK: open merge:
 // CHECK: close merge:

--- a/test/Merging/indirect_value.c
+++ b/test/Merging/indirect_value.c
@@ -1,6 +1,6 @@
 // RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
 
 // CHECK: generated tests = 2{{$}}
 #include <stdlib.h>

--- a/test/Merging/loop_merge.c
+++ b/test/Merging/loop_merge.c
@@ -1,10 +1,10 @@
 // RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
 
 // CHECK: open merge:
 // There will be 20 'close merge' statements. Only checking a few, the generated

--- a/test/Merging/merge_fail.c
+++ b/test/Merging/merge_fail.c
@@ -1,10 +1,10 @@
 // RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
 
 // CHECK: open merge:
 // CHECK: generated tests = 2{{$}}

--- a/test/Merging/nested_merge.c
+++ b/test/Merging/nested_merge.c
@@ -1,12 +1,12 @@
 // RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
 
 // CHECK: open merge:
 // 5 close merges

--- a/test/Merging/split_merge.c
+++ b/test/Merging/split_merge.c
@@ -1,12 +1,12 @@
 // RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=bfs --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs --use-batching-search %t.bc 2>&1 | FileCheck %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=nurs:covnew %t.bc 2>&1 | FileCheck %s
 
 
 // CHECK: open merge:

--- a/test/Merging/unexpected_close.c
+++ b/test/Merging/unexpected_close.c
@@ -1,6 +1,6 @@
 // RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out --use-merge --search=nurs:covnew --max-time=2 %t.bc
+// RUN: %klee --output-dir=%t.klee-out --use-merge --search=nurs:covnew --max-time=2 %t.bc
 
 // CHECK: ran into a close at
 // CHECK: generated tests = 2{{$}}

--- a/test/regression/2016-11-24-bitcast-weak-alias.c
+++ b/test/regression/2016-11-24-bitcast-weak-alias.c
@@ -1,7 +1,7 @@
 // REQUIRES: not-darwin
 // RUN: %llvmgcc %s -Wall -emit-llvm -g -O0 -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out -exit-on-error -search=nurs:covnew %t.bc DUMMY_ARG >%t1.log 2>&1
+// RUN: %klee --output-dir=%t.klee-out -exit-on-error -search=nurs:covnew %t.bc DUMMY_ARG >%t1.log 2>&1
 // RUN: FileCheck -input-file=%t1.log %s
 
 // This test case is designed to cover code in `klee::getDirectCallTarget(CallSite)`.


### PR DESCRIPTION
See #800 

This fixes the merging tests, and also another test that was still using `klee` (instead of `%klee`).

The other test was: `test/regression/2016-11-24-bitcast-weak-alias.c`