### PR TITLE
Add util.h shortcut for non-linux (ie: MacOS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,12 +422,13 @@ endif()
 # Detect libutil
 ################################################################################
 check_include_file("pty.h" HAVE_PTY_H)
-if (HAVE_PTY_H)
+check_include_file("util.h" HAVE_UTIL_H)
+if (HAVE_PTY_H OR HAVE_UTIL_H)
   find_library(LIBUTIL_LIBRARIES
     NAMES util
-    DOC "libutil library. Typically part of glibc")
+    DOC "libutil library. Typically part of libc")
   if (NOT LIBUTIL_LIBRARIES)
-    message(FATAL_ERROR "Found \"pty.h\" but could not find libutil")
+    message(FATAL_ERROR "Found \"util.h\" but could not find libutil")
   endif()
 endif()
 

--- a/include/klee/Internal/System/Time.h
+++ b/include/klee/Internal/System/Time.h
@@ -10,7 +10,8 @@
 #ifndef KLEE_UTIL_TIME_H
 #define KLEE_UTIL_TIME_H
 
-#include <llvm/Support/TimeValue.h>
+#include <llvm/Support/Timer.h>
+#include <ctime>
 
 namespace klee {
   namespace util {
@@ -21,8 +22,8 @@ namespace klee {
     /// Wall time in seconds.
     double getWallTime();
 
-    /// Wall time as TimeValue object.
-    llvm::sys::TimeValue getWallTimeVal();
+    /// Wall time as unsigned int.
+    uint64_t getWallTimeMicros();
   }
 }
 

--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -328,7 +328,7 @@ ref<Expr> ConstantExpr::fromMemory(void *address, Width width) {
   // FIXME: what about machines without x87 support?
   default:
     return ConstantExpr::alloc(llvm::APInt(width,
-      (width+llvm::integerPartWidth-1)/llvm::integerPartWidth,
+      (width+llvm::APFloatBase::integerPartWidth-1)/llvm::APFloatBase::integerPartWidth,
       (const uint64_t*)address));
   }
 }

--- a/lib/Support/Time.cpp
+++ b/lib/Support/Time.cpp
@@ -10,23 +10,24 @@
 #include "klee/Config/Version.h"
 #include "klee/Internal/System/Time.h"
 
-#include "llvm/Support/TimeValue.h"
+#include "llvm/Support/Timer.h"
 #include "llvm/Support/Process.h"
 
 using namespace llvm;
 using namespace klee;
 
 double util::getUserTime() {
-  sys::TimeValue now(0,0),user(0,0),sys(0,0);
-  sys::Process::GetTimeUsage(now,user,sys);
-  return (user.seconds() + (double) user.nanoseconds() * 1e-9);
+  auto time_rec = TimeRecord::getCurrentTime();
+  return time_rec.getUserTime();
 }
 
 double util::getWallTime() {
-  sys::TimeValue now = getWallTimeVal();
-  return (now.seconds() + ((double) now.nanoseconds() * 1e-9));
+  auto time_rec = TimeRecord::getCurrentTime();
+  return time_rec.getWallTime();
 }
 
-sys::TimeValue util::getWallTimeVal() {
-  return sys::TimeValue::now();
+uint64_t util::getWallTimeMicros() {
+  std::time_t st = std::time(NULL);
+  auto millies = static_cast<std::chrono::milliseconds>(st).count();
+  return static_cast<uint64_t>(millies);
 }

--- a/lib/Support/Timer.cpp
+++ b/lib/Support/Timer.cpp
@@ -16,9 +16,9 @@ using namespace klee;
 using namespace llvm;
 
 WallTimer::WallTimer() {
-  startMicroseconds = util::getWallTimeVal().usec();
+  startMicroseconds = util::getWallTimeMicros();
 }
 
 uint64_t WallTimer::check() {
-  return util::getWallTimeVal().usec() - startMicroseconds;
+  return util::getWallTimeMicros() - startMicroseconds;
 }

--- a/tools/klee-replay/CMakeLists.txt
+++ b/tools/klee-replay/CMakeLists.txt
@@ -6,7 +6,7 @@
 # License. See LICENSE.TXT for details.
 #
 #===------------------------------------------------------------------------===#
-if (HAVE_PTY_H)
+if (HAVE_PTY_H OR HAVE_UTIL_H)
   add_executable(klee-replay
     fd_init.c
     file-creator.c
@@ -26,5 +26,8 @@ if (HAVE_PTY_H)
   endif()
 install(TARGETS klee-replay RUNTIME DESTINATION bin)
 else()
-  message(WARNING "Not building klee-replay due to missing \"pty.h\" header file")
+  if (NOT LIBUTIL_LIBRARIES)
+    message(FATAL_ERROR "klee-replay needs util.h")
+  endif()
+  target_link_libraries(klee-replay PRIVATE ${LIBUTIL_LIBRARIES})
 endif()

--- a/tools/klee-replay/file-creator.c
+++ b/tools/klee-replay/file-creator.c
@@ -18,7 +18,14 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <termios.h>
-#include <pty.h>
+#ifdef __linux
+  // linux
+  #include<pty.h>
+#else
+  // all unices not caught above
+  #include <util.h>
+#endif
+
 #include <time.h>
 #include <sys/wait.h>
 #include <sys/time.h>


### PR DESCRIPTION
Substitute `pty.h` for `util.h` in order to support MacOS for klee-replay.