### PR TITLE
Add util.h shortcut for non-linux (ie: MacOS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,12 +422,13 @@ endif()
 # Detect libutil
 ################################################################################
 check_include_file("pty.h" HAVE_PTY_H)
-if (HAVE_PTY_H)
+check_include_file("util.h" HAVE_UTIL_H)
+if (HAVE_PTY_H OR HAVE_UTIL_H)
   find_library(LIBUTIL_LIBRARIES
     NAMES util
-    DOC "libutil library. Typically part of glibc")
+    DOC "libutil library. Typically part of libc")
   if (NOT LIBUTIL_LIBRARIES)
-    message(FATAL_ERROR "Found \"pty.h\" but could not find libutil")
+    message(FATAL_ERROR "Could not find libutil")
   endif()
 endif()
 

--- a/include/klee/Config/config.h.cmin
+++ b/include/klee/Config/config.h.cmin
@@ -43,6 +43,9 @@
 /* Define to 1 if you have the <zlib.h> header file. */
 #cmakedefine HAVE_ZLIB_H @HAVE_ZLIB_H@
 
+/* Define to 1 if you have the <pty.h> header file. */
+#cmakedefine HAVE_PTY_H @HAVE_PTY_H@
+
 /* Enable time stamping the sources */
 #cmakedefine KLEE_ENABLE_TIMESTAMP @KLEE_ENABLE_TIMESTAMP@
 

--- a/tools/klee-replay/CMakeLists.txt
+++ b/tools/klee-replay/CMakeLists.txt
@@ -6,7 +6,7 @@
 # License. See LICENSE.TXT for details.
 #
 #===------------------------------------------------------------------------===#
-if (HAVE_PTY_H)
+if (HAVE_PTY_H OR HAVE_UTIL_H)
   add_executable(klee-replay
     fd_init.c
     file-creator.c
@@ -26,5 +26,8 @@ if (HAVE_PTY_H)
   endif()
 install(TARGETS klee-replay RUNTIME DESTINATION bin)
 else()
-  message(WARNING "Not building klee-replay due to missing \"pty.h\" header file")
+  if (NOT LIBUTIL_LIBRARIES)
+    message(FATAL_ERROR "klee-replay needs libutil")
+  endif()
+  target_link_libraries(klee-replay PRIVATE ${LIBUTIL_LIBRARIES})
 endif()

--- a/tools/klee-replay/file-creator.c
+++ b/tools/klee-replay/file-creator.c
@@ -18,11 +18,15 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <termios.h>
-#include <pty.h>
 #include <time.h>
 #include <sys/wait.h>
 #include <sys/time.h>
 #include <assert.h>
+#ifdef HAVE_UTIL_H
+#include <util.h>
+#else
+#include <pty.h>
+#endif
 
 static void create_file(int target_fd, 
                        const char *target_name, 


### PR DESCRIPTION
libutil uses `util.h` in OSX, small patch to make it past the preprocessor.
  