### PR TITLE
MergeHandler: remove unused closedStateCount

### DIFF
--- a/include/klee/MergeHandler.h
+++ b/include/klee/MergeHandler.h
@@ -76,10 +76,6 @@ class MergeHandler {
 private:
   Executor *executor;
 
-  /// @brief Number of states that are tracked by this MergeHandler, that ran
-  /// into a relevant klee_close_merge
-  unsigned closedStateCount;
-
   /// @brief Mapping the different 'klee_close_merge' calls to the states that ran into
   /// them
   std::map<llvm::Instruction *, std::vector<ExecutionState *> >


### PR DESCRIPTION
clang 5 reports:
```
In file included from ../lib/Core/MergeHandler.cpp:10:
../include/klee/MergeHandler.h:81:12: warning: private field 'closedStateCount' is not used [-Wunused-private-field]
  unsigned closedStateCount;
           ^
```
So fix it by removing the member.