### PR TITLE
Allow function aliases to use regular expressions

### DIFF
--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -20,6 +20,7 @@
 #include "klee/Internal/Module/KInstIterator.h"
 
 #include <map>
+#include <regex>
 #include <set>
 #include <vector>
 
@@ -62,6 +63,13 @@ struct StackFrame {
   ~StackFrame();
 };
 
+struct FunctionAlias {
+  bool isRegex;
+  std::regex nameRegex;
+  std::string name;
+  std::string alias;
+};
+
 /// @brief ExecutionState representing a path under exploration
 class ExecutionState {
 public:
@@ -71,7 +79,7 @@ private:
   // unsupported, use copy constructor
   ExecutionState &operator=(const ExecutionState &);
 
-  std::map<std::string, std::string> fnAliases;
+  std::vector<FunctionAlias> fnAliases;
 
 public:
   // Execution - Control Flow specific
@@ -144,6 +152,7 @@ public:
 
   std::string getFnAlias(std::string fn);
   void addFnAlias(std::string old_fn, std::string new_fn);
+  void addFnRegexAlias(std::string fn_regex, std::string new_fn);
   void removeFnAlias(std::string fn);
 
   // The objects handling the klee_open_merge calls this state ran through

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -68,6 +68,8 @@ struct FunctionAlias {
   std::regex nameRegex;
   std::string name;
   std::string alias;
+  // required by klee:ref
+  unsigned refCount;
 };
 
 /// @brief ExecutionState representing a path under exploration
@@ -79,7 +81,7 @@ private:
   // unsupported, use copy constructor
   ExecutionState &operator=(const ExecutionState &);
 
-  std::vector<FunctionAlias> fnAliases;
+  std::vector<ref<FunctionAlias>> fnAliases;
 
 public:
   // Execution - Control Flow specific

--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -146,6 +146,16 @@ extern "C" {
      may not always work. */
   void klee_alias_function(const char* fn_name, const char* new_fn_name);
 
+  /* Similar to klee_alias_function, but uses a regex to match
+     the function's name; e.g. klee_alias_function_regex("foo.*", "bar")
+     will replace "foo", "foox", "foo123" with "bar".
+     Particularly useful to replace a static function, which
+     may be replicated many times with a suffixed name. */
+  void klee_alias_function_regex(const char* fn_regex, const char* new_fn_name);
+
+  /* Undoes an alias (either a name or a regex). */
+  void klee_alias_undo(const char* alias);
+
   /* Print stack trace. */
   void klee_stack_trace(void);
 

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -168,12 +168,12 @@ void ExecutionState::addSymbolic(const MemoryObject *mo, const Array *array) {
 
 std::string ExecutionState::getFnAlias(std::string fn) {
   for (auto& candidate : fnAliases) {
-    if (candidate.isRegex) {
-      if (std::regex_match(fn, candidate.nameRegex)) {
-        return candidate.alias;
+    if (candidate->isRegex) {
+      if (std::regex_match(fn, candidate->nameRegex)) {
+        return candidate->alias;
       }
-    } else if (fn == candidate.name) {
-      return candidate.alias;
+    } else if (fn == candidate->name) {
+      return candidate->alias;
     }
   }
 
@@ -183,31 +183,27 @@ std::string ExecutionState::getFnAlias(std::string fn) {
 void ExecutionState::addFnAlias(std::string old_fn, std::string new_fn) {
   removeFnAlias(old_fn);
 
-  FunctionAlias alias {
-    .isRegex = false,
-    .nameRegex = std::regex(""),
-    .name = old_fn,
-    .alias = new_fn
-  };
+  FunctionAlias* alias = new FunctionAlias();
+  alias->name = old_fn,
+  alias->alias = new_fn,
   fnAliases.push_back(alias);
 }
 
 void ExecutionState::addFnRegexAlias(std::string fn_regex, std::string new_fn) {
   removeFnAlias(fn_regex);
 
-  FunctionAlias alias = {
-    .isRegex = true,
-    .nameRegex = std::regex(fn_regex),
-    .name = fn_regex,
-    .alias = new_fn
-  };
+  FunctionAlias* alias = new FunctionAlias();
+  alias->isRegex = true,
+  alias->nameRegex = std::regex(fn_regex),
+  alias->name = fn_regex,
+  alias->alias = new_fn,
   fnAliases.push_back(alias);
 }
 
 void ExecutionState::removeFnAlias(std::string fn) {
   fnAliases.erase(std::remove_if(fnAliases.begin(), fnAliases.end(),
-                                 [fn](FunctionAlias candidate) {
-                                   return candidate.name == fn;
+                                 [fn](ref<FunctionAlias> candidate) {
+                                   return candidate->name == fn;
                                  }),
                   fnAliases.end());
 }

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -304,8 +304,12 @@ void SpecialFunctionHandler::handleSilentExit(ExecutionState &state,
 void SpecialFunctionHandler::handleAliasFunction(ExecutionState &state,
 						 KInstruction *target,
 						 std::vector<ref<Expr> > &arguments) {
-  assert(arguments.size()==2 && 
-         "invalid number of arguments to klee_alias_function");
+  if (arguments.size() != 2) {
+    executor.terminateStateOnError(state,
+        "invalid number of arguments to klee_alias_function",
+        Executor::TerminateReason::User);
+  }
+
   std::string old_fn = readStringAtAddress(state, arguments[0]);
   std::string new_fn = readStringAtAddress(state, arguments[1]);
   KLEE_DEBUG_WITH_TYPE("alias_handling", llvm::errs() << "Replacing " << old_fn
@@ -318,12 +322,22 @@ void SpecialFunctionHandler::handleAliasFunction(ExecutionState &state,
 void SpecialFunctionHandler::handleAliasFunctionRegex(ExecutionState &state,
 						      KInstruction *target,
 						      std::vector<ref<Expr> > &arguments) {
-  assert(arguments.size()==2 && 
-         "invalid number of arguments to klee_alias_function_regex");
-  assert(isa<klee::ConstantExpr>(arguments[0]) &&
-         "first arg to klee_alias_function_regex cannot be a symbol");
-  assert(isa<klee::ConstantExpr>(arguments[1]) &&
-         "second arg to klee_alias_function_regex cannot be a symbol");
+  if (arguments.size() != 2) {
+    executor.terminateStateOnError(state,
+        "invalid number of arguments to klee_alias_function_regex",
+        Executor::TerminateReason::User);
+  }
+  if (!isa<klee::ConstantExpr>(arguments[0])) {
+    executor.terminateStateOnError(state,
+        "first arg to klee_alias_function_regex cannot be a symbol",
+        Executor::TerminateReason::User);
+  }
+  if (!isa<klee::ConstantExpr>(arguments[1])) {
+    executor.terminateStateOnError(state,
+        "second arg to klee_alias_function_regex cannot be a symbol",
+        Executor::TerminateReason::User);
+  }
+
   std::string fn_regex = readStringAtAddress(state, arguments[0]);
   std::string new_fn = readStringAtAddress(state, arguments[1]);
   KLEE_DEBUG_WITH_TYPE("alias_handling", llvm::errs() << "Replacing by regex " << fn_regex
@@ -334,10 +348,17 @@ void SpecialFunctionHandler::handleAliasFunctionRegex(ExecutionState &state,
 void SpecialFunctionHandler::handleAliasUndo(ExecutionState &state,
 					     KInstruction *target,
 					     std::vector<ref<Expr> > &arguments) {
-  assert(arguments.size()==1 && 
-         "invalid number of arguments to klee_alias_undo");
-  assert(isa<klee::ConstantExpr>(arguments[0]) &&
-         "single arg to klee_alias_undo cannot be a symbol");
+  if (arguments.size() != 1) {
+    executor.terminateStateOnError(state,
+        "invalid number of arguments to klee_alias_undo",
+        Executor::TerminateReason::User);
+  }
+  if (!isa<klee::ConstantExpr>(arguments[0])) {
+    executor.terminateStateOnError(state,
+        "single arg to klee_alias_undo cannot be a symbol",
+        Executor::TerminateReason::User);
+  }
+
   std::string alias = readStringAtAddress(state, arguments[0]);
   KLEE_DEBUG_WITH_TYPE("alias_handling", llvm::errs() << "Undoing alias " << alias << "\n");
   state.removeFnAlias(alias);

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -112,6 +112,8 @@ namespace klee {
     HANDLER(handleExit);
     HANDLER(handleErrnoLocation);
     HANDLER(handleAliasFunction);
+    HANDLER(handleAliasFunctionRegex);
+    HANDLER(handleAliasUndo);
     HANDLER(handleFree);
     HANDLER(handleGetErrno);
     HANDLER(handleGetObjSize);

--- a/test/Feature/AliasFunction.c
+++ b/test/Feature/AliasFunction.c
@@ -1,8 +1,6 @@
 // RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out %t1.bc > %t1.log
-// RUN: grep -c foo %t1.log | grep 5
-// RUN: grep -c bar %t1.log | grep 4
+// RUN: %klee -search=dfs --output-dir=%t.klee-out %t1.bc | FileCheck %s
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,10 +13,23 @@ int main() {
   klee_make_symbolic(&x, sizeof(x), "x");
 
   // call once, so that it is not removed by optimizations
+  // CHECK: bar()
   bar();
 
   // no aliases
+  // CHECK: foo()
   foo();
+
+  // First path: (x <= 10)
+  // CHECK: foo()
+  // CHECK: foo()
+  // Second path: (x > 10 && x <= 20)
+  // CHECK: bar()
+  // CHECK: foo()
+  // Third path: (x > 20)
+  // CHECK: bar()
+  // CHECK: bar()
+  // CHECK: foo()
 
   if (x > 10)
   {
@@ -28,7 +39,7 @@ int main() {
     if (x > 20)
       foo();
   }
-  
+
   foo();
 
   // undo

--- a/test/Feature/AliasFunction.c
+++ b/test/Feature/AliasFunction.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <klee/klee.h>
+
 void __attribute__ ((noinline)) foo() { printf("  foo()\n"); }
 void __attribute__ ((noinline)) bar() { printf("  bar()\n"); }
 

--- a/test/Feature/AliasFunctionExit.c
+++ b/test/Feature/AliasFunctionExit.c
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include <klee/klee.h>
+
 void start(int x) {
   printf("START\n");
   if (x == 53)

--- a/test/Feature/AliasFunctionExit.c
+++ b/test/Feature/AliasFunctionExit.c
@@ -1,8 +1,6 @@
 // RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out %t1.bc > %t1.log
-// RUN: grep -c START %t1.log | grep 1
-// RUN: grep -c END %t1.log | grep 2
+// RUN: %klee -search=dfs --output-dir=%t.klee-out %t1.bc | FileCheck %s
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -26,6 +24,11 @@ int main() {
   klee_make_symbolic(&x, sizeof(x), "x");
 
   klee_alias_function("exit", "end");
+  // CHECK: START
+  // First path (x != 53)
+  // CHECK: END: status = 0
+  // Second path (x == 53)
+  // CHECK: END: status = 1
   start(x);
   end(0);
 }

--- a/test/Feature/AliasFunctionRegex.c
+++ b/test/Feature/AliasFunctionRegex.c
@@ -1,0 +1,37 @@
+// RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out %t1.bc > %t1.log
+// RUN: grep -c foo %t1.log | grep 5
+// RUN: grep -c bar %t1.log | grep 4
+
+#include <stdio.h>
+#include <stdlib.h>
+
+void __attribute__ ((noinline)) fooXYZ() { printf("  foo()\n"); }
+void __attribute__ ((noinline)) bar() { printf("  bar()\n"); }
+
+int main() {
+  int x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+  // call once, so that it is not removed by optimizations
+  bar();
+
+  // no aliases
+  fooXYZ();
+
+  if (x > 10)
+  {
+    // foo -> bar
+    klee_alias_function_regex("foo.*", "bar");
+
+    if (x > 20)
+      fooXYZ();
+  }
+  
+  fooXYZ();
+
+  // undo
+  klee_alias_undo("foo.*");
+  fooXYZ();
+}

--- a/test/Feature/AliasFunctionRegex.c
+++ b/test/Feature/AliasFunctionRegex.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <klee/klee.h>
+
 void __attribute__ ((noinline)) fooXYZ() { printf("  foo()\n"); }
 void __attribute__ ((noinline)) bar() { printf("  bar()\n"); }
 

--- a/test/Feature/AliasFunctionUndo.c
+++ b/test/Feature/AliasFunctionUndo.c
@@ -1,8 +1,6 @@
 // RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out %t1.bc > %t1.log
-// RUN: grep -c foo %t1.log | grep 5
-// RUN: grep -c bar %t1.log | grep 4
+// RUN: %klee -search=dfs --output-dir=%t.klee-out %t1.bc | FileCheck %s
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,10 +13,23 @@ int main() {
   klee_make_symbolic(&x, sizeof(x), "x");
 
   // call once, so that it is not removed by optimizations
+  // CHECK: bar()
   bar();
 
   // no aliases
+  // CHECK: foo()
   foo();
+
+  // First path: (x <= 10)
+  // CHECK: foo()
+  // CHECK: foo()
+  // Second path: (x > 10 && x <= 20)
+  // CHECK: bar()
+  // CHECK: foo()
+  // Third path: (x > 20)
+  // CHECK: bar()
+  // CHECK: bar()
+  // CHECK: foo()
 
   if (x > 10)
   {
@@ -28,7 +39,7 @@ int main() {
     if (x > 20)
       foo();
   }
-  
+
   foo();
 
   // undo

--- a/test/Feature/AliasFunctionUndo.c
+++ b/test/Feature/AliasFunctionUndo.c
@@ -1,0 +1,37 @@
+// RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out %t1.bc > %t1.log
+// RUN: grep -c foo %t1.log | grep 5
+// RUN: grep -c bar %t1.log | grep 4
+
+#include <stdio.h>
+#include <stdlib.h>
+
+void __attribute__ ((noinline)) foo() { printf("  foo()\n"); }
+void __attribute__ ((noinline)) bar() { printf("  bar()\n"); }
+
+int main() {
+  int x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+  // call once, so that it is not removed by optimizations
+  bar();
+
+  // no aliases
+  foo();
+
+  if (x > 10)
+  {
+    // foo -> bar
+    klee_alias_function("foo", "bar");
+
+    if (x > 20)
+      foo();
+  }
+  
+  foo();
+
+  // undo
+  klee_alias_undo("foo");
+  foo();
+}

--- a/test/Feature/AliasFunctionUndo.c
+++ b/test/Feature/AliasFunctionUndo.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <klee/klee.h>
+
 void __attribute__ ((noinline)) foo() { printf("  foo()\n"); }
 void __attribute__ ((noinline)) bar() { printf("  bar()\n"); }
 

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -727,6 +727,8 @@ static const char *modelledExternals[] = {
   "klee_warning",
   "klee_warning_once",
   "klee_alias_function",
+  "klee_alias_function_regex",
+  "klee_alias_undo",
   "klee_stack_trace",
   "llvm.dbg.declare",
   "llvm.dbg.value",


### PR DESCRIPTION
Small, self-contained feature I needed while using KLEE to verify a real-world library, i.e. code that cannot be modified without weakening the verification claim; it may be useful to others

I needed to alias a function declared in a header and marked as `static`, which means that instead of there being a single instance of the function in the generated LLVM bitcode, there are a bunch of them with number suffixes, e.g. `foo`, `foo930`, `foo2370`; since those numbers change more or less every time the program's structure changes, hardcoding their names to alias means changing the names every time anything else changes.

---

This builds on the existing `klee_alias_function` infrastructure.

It adds two functions:
- `klee_alias_function_regex`, which is similar to the existing `klee_alias_function` except that the "old" name is a regex, i.e. it may match multiple functions.
- `klee_alias_undo`, which undoes an alias (both from `klee_alias_function` and from my `klee_alias_function_regex`); while technically not necessary, I believe that using the existing convention of `old == new` to delete would be confusing with a regex.

---

The implementation is rather simple: I replaced the existing map of aliases with a vector of a new struct `FunctionAlias`, which can be a "plain" alias or a regex one.

I added two new test files, which are copy/pastes of the existing `klee_alias_function` test with minor changes: one for `klee_alias_function_regex` (undone by a `klee_alias_undo`), and one for the existing `klee_alias_function` but undone by `klee_alias_undo` instead of the current way.

---

Performance could be an issue since I replace a map with a vector if there are many aliases; I don't know if  `klee_alias_function` has any performance target, or any expected usage patterns. I did some very basic benchmarking in my codebase:

- KLEE `master`, 19 `klee_function_alias` (17 of which are for said `static` function); or
- KLEE on this branch, 2 `klee_function_alias`, 1 `klee_function_alias_regex`.

The total symbex time is ~2m50s in both cases, with minor variations (2-3s) over a few runs .