### PR TITLE
Show additional coverage information and enable caching for TravisCI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,6 +6,9 @@ coverage:
     project: no
     patch: yes
     changes: no
+  precision: 2
+  round: down
+  range: "70...100"
 
 fixes:
   - "home/travis/build/klee/klee::"
@@ -14,3 +17,6 @@ ignore:
   - "test/"
   - "unittests"
   - "**/test-utils"
+comment:
+  layout: "header, diff, changes, uncovered, tree"
+  behavior: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,7 @@ addons:
     - lcov
 
 cache:
+  ccache: true
   apt: true
   directories:
     - $HOME/Library/Caches/Homebrew
@@ -110,7 +111,7 @@ before_install:
     ###########################################################################
     # Update package information
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew tap klee/klee; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew tap klee/klee && brew install ccache && export PATH="/usr/local/opt/ccache/libexec:$PATH" ; fi
     ###########################################################################
     # Set up out of source build directory
     ###########################################################################


### PR DESCRIPTION
* Fixed: Generation of coverage information
* Enables caching for travis (reduces build time by 1/3 from total ~3h to ~2h)
* Mac OSX: use cached LLVM build (if available) or build brew bottle locally and cache it