### PR TITLE
disable clang vectorization passes on compilation of runtime (esp. intrinsics)

### DIFF
--- a/runtime/Makefile.cmake.bitcode.rules
+++ b/runtime/Makefile.cmake.bitcode.rules
@@ -43,6 +43,10 @@ else
 LLVMCC.Flags += -O0
 endif
 
+# disable vectorization
+LLVMCC.Flags += -fno-vectorize
+LLVMCC.Flags += -fno-slp-vectorize
+
 # Handle assertion flags
 ifeq ($(ASSERTIONS_ENABLED),0)
 LLVMCC.Flags += -DNDEBUG


### PR DESCRIPTION
As suggested in #789, I added `-fno-vectorize` and `-fno-slp-vectorize` to avoid shufflevector instructions in intrinsics.