### PR TITLE
Change Travis LLVM source to official LLVM apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,14 @@ addons:
   apt:
     sources:
     - sourceline: 'ppa:ubuntu-toolchain-r/test'
-    - sourceline: 'ppa:h-rayflood/llvm'
+    - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.4 main'
+      key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+    - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.5 main'
+      key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+    - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.6 main'
+      key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+    - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.7 main'
+      key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
     - sourceline: 'deb http://download.opensuse.org/repositories/home:/delcypher:/z3/xUbuntu_14.04/ /'
       key_url: 'http://download.opensuse.org/repositories/home:delcypher:z3/xUbuntu_14.04/Release.key'
     packages:


### PR DESCRIPTION
This retires the old PPA used to get llvm into travis and replaces it with the official llvm one. This way we should be able to easily support llvm versions up to at least 6.0.

Note this is partially done by #669 already, but I think it makes sense to move all the llvm versions to this repository.