### PR TITLE
klee_int/klee_make_symbolic: allow NULL as name

### DIFF
--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -31,16 +31,16 @@ extern "C" {
    * \arg addr - The start of the object.
    * \arg nbytes - The number of bytes to make symbolic; currently this *must*
    * be the entire contents of the object.
-   * \arg name - An optional name, used for identifying the object in messages,
-   * output files, etc.
+   * \arg name - A name used for identifying the object in messages, output
+   * files, etc. If NULL, object is called "unnamed".
    */
   void klee_make_symbolic(void *addr, size_t nbytes, const char *name);
 
   /* klee_range - Construct a symbolic value in the signed interval
    * [begin,end).
    *
-   * \arg name - An optional name, used for identifying the object in messages,
-   * output files, etc.
+   * \arg name - A name used for identifying the object in messages, output
+   * files, etc. If NULL, object is called "unnamed".
    */
   int klee_range(int begin, int end, const char *name);
 

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -762,7 +762,7 @@ void SpecialFunctionHandler::handleMakeSymbolic(ExecutionState &state,
       klee_warning("klee_make_symbolic: deprecated number of arguments (2 instead of 3)");
       break;
     case 3:
-      name = readStringAtAddress(state, arguments[2]);
+      name = arguments[2]->isZero() ? "" : readStringAtAddress(state, arguments[2]);
       break;
     default:
       executor.terminateStateOnError(state, "illegal number of arguments to klee_make_symbolic(void*, size_t, char*)", Executor::User);

--- a/test/regression/2018-04-05-make-symbolic-null-name.c
+++ b/test/regression/2018-04-05-make-symbolic-null-name.c
@@ -1,0 +1,9 @@
+// RUN: %llvmgcc %s -emit-llvm -g -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out %t1.bc
+
+#include "klee/klee.h"
+
+int main(int argc, char * argv[]) {
+	int a = klee_int((void*)0);
+}


### PR DESCRIPTION
Make KLEE a little bit more robust against lazy users (me). With NULL as name in `klee_int` the assertion in  `klee::SpecialFunctionHandler::readStringAtAddress` (XXX out of bounds / multiple resolution unhandled) fires.