### PR TITLE
WIP: improve environment variable handling

### DIFF
--- a/include/klee/Interpreter.h
+++ b/include/klee/Interpreter.h
@@ -128,9 +128,8 @@ public:
   virtual void useSeeds(const std::vector<struct KTest *> *seeds) = 0;
 
   virtual void runFunctionAsMain(llvm::Function *f,
-                                 int argc,
-                                 char **argv,
-                                 char **envp) = 0;
+                                 const std::vector<std::string> &args,
+                                 const std::vector<std::string> &envs) = 0;
 
   /*** Runtime options ***/
 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -487,10 +487,9 @@ public:
     usingSeeds = seeds;
   }
 
-  virtual void runFunctionAsMain(llvm::Function *f,
-                                 int argc,
-                                 char **argv,
-                                 char **envp);
+  void runFunctionAsMain(llvm::Function *f,
+                         const std::vector<std::string> &args,
+                         const std::vector<std::string> &envs) override;
 
   /*** Runtime options ***/
   

--- a/test/Feature/EnvironmentConcrete.c
+++ b/test/Feature/EnvironmentConcrete.c
@@ -1,0 +1,24 @@
+// REQUIRES: not-darwin
+// RUN: %llvmgcc %s -emit-llvm -g -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: printf "KLEE_TEST_FLE=VA0\nKLEE_TEST_FLE=VA1" > %t_env.file
+// RUN: env "KLEE_TEST_SYS=VAL" %klee -libc=uclibc -env-system -env-file=%t_env.file -env-variable="KLEE_TEST_VAR=VA0" -env-variable="KLEE_TEST_VAR=VA1" --output-dir=%t.klee-out --exit-on-error %t1.bc
+// RUN: rm -rf env.file
+
+#include <assert.h>
+#include <string.h>
+
+unsigned file, system, variable;
+
+int main(int argc, char **argv, char **envp) {
+  for (char **env = envp; *env != 0; ++env) {
+    if (!strncmp(*env, "KLEE_TEST_FLE=VA0", 18)) ++file;
+    if (!strncmp(*env, "KLEE_TEST_FLE=VA1", 18)) ++file;
+    if (!strncmp(*env, "KLEE_TEST_SYS=VAL", 18)) ++system;
+    if (!strncmp(*env, "KLEE_TEST_VAR=VA0", 18)) ++variable;
+    if (!strncmp(*env, "KLEE_TEST_VAR=VA1", 18)) ++variable;
+  }
+
+  assert(file == 2 && system == 1 && variable == 2);
+  return 0;
+}

--- a/test/Feature/Envp.c
+++ b/test/Feature/Envp.c
@@ -1,6 +1,6 @@
 // RUN: %llvmgcc %s -emit-llvm -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --exit-on-error %t1.bc
+// RUN: %klee -env-system --output-dir=%t.klee-out --exit-on-error %t1.bc
 
 #include <assert.h>
 

--- a/test/Runtime/Uclibc/Environ.c
+++ b/test/Runtime/Uclibc/Environ.c
@@ -1,6 +1,6 @@
 // RUN: %llvmgcc %s -emit-llvm -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --libc=uclibc --exit-on-error %t1.bc
+// RUN: %klee -env-system --output-dir=%t.klee-out --libc=uclibc --exit-on-error %t1.bc
 
 #include <assert.h>
 #include <stdlib.h>


### PR DESCRIPTION
This patch adds three new command line arguments:

* `-env-system` (def: false¹, executed program has same env variables as KLEE)
* `-env-file` (use env variables from file, formerly `-environ`)
* `-env-variable` (add variable via command line)

¹ changes KLEE's default behaviour, we might use *true* here

The question is how to proceed further:

* Write env variables to ktest files?
* Add support for symbolic environment variables similar to arguments?
* Add support to replay mechanism.