### PR TITLE
Fixed error message for posix-runtime is enabled with entrypoint having less than two arguments

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -641,7 +641,7 @@ static int initEnv(Module *mainModule) {
   }
 
   if (mainFn->arg_size() < 2) {
-    klee_error("Cannot handle ""--posix-runtime"" when entry funciton '%s' has less than two arguments.\n", EntryPoint.c_str());
+    klee_error("Cannot handle ""--posix-runtime"" when entry funciton '%s' has less than two arguments.", EntryPoint.c_str());
   }
 
   Instruction *firstInst = &*(mainFn->begin()->begin());

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -641,7 +641,7 @@ static int initEnv(Module *mainModule) {
   }
 
   if (mainFn->arg_size() < 2) {
-    klee_error("Cannot handle ""--posix-runtime"" when main() has less than two arguments.\n");
+    klee_error("Cannot handle ""--posix-runtime"" when entry funciton '%s' has less than two arguments.\n", EntryPoint.c_str());
   }
 
   Instruction *firstInst = &*(mainFn->begin()->begin());


### PR DESCRIPTION
It was saying "`main()`" should have at least two arguments, instead of saying the name of the real entry function (`EntryPoint.c_str()`).