### PR TITLE
Fixed memory error: out of bound pointer when second argument to posix-runtime utimes is NULL

### DIFF
--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -28,6 +28,7 @@
 #include <termios.h>
 #include <sys/select.h>
 #include <klee/klee.h>
+#include <sys/time.h>
 
 /* #define DEBUG */
 
@@ -261,11 +262,10 @@ int utimes(const char *path, const struct timeval times[2]) {
 
   if (dfile) {
 
-    if(!times) {
-      time_t now;
-      time(&now);
+    if (!times) {
       struct timeval newTimes[2];
-      newTimes[0].tv_sec = newTimes[1].tv_sec = now;
+      gettimeofday(&(newTimes[0]), NULL);
+      newTimes[1] = newTimes[0];
       times = newTimes;
     }
 

--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -260,6 +260,15 @@ int utimes(const char *path, const struct timeval times[2]) {
   exe_disk_file_t *dfile = __get_sym_file(path);
 
   if (dfile) {
+
+    if(!times) {
+      time_t now;
+      time(&now);
+      struct timeval newTimes[2];
+      newTimes[0].tv_sec = newTimes[1].tv_sec = now;
+      times = newTimes;
+    }
+
     /* don't bother with usecs */
     dfile->stat->st_atime = times[0].tv_sec;
     dfile->stat->st_mtime = times[1].tv_sec;


### PR DESCRIPTION
According to http://man7.org/linux/man-pages/man2/utime.2.html , when the second argument to posix-runtime `utimes` is `NULL`, the access time and modified time should be set to current time. But, before this PR, KLEE will just crash and give `memory error: out of bound pointer` while it is a valid way to invoke this function.

Thanks