### PR TITLE
Allow lowering of LLVM intrinsics before optimization

### DIFF
--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -233,8 +233,7 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         break;
       }
       default:
-        if (LowerIntrinsics)
-          IL->LowerIntrinsicCall(ii);
+        IL->LowerIntrinsicCall(ii);
         dirty = true;
         break;
       }

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -215,11 +215,8 @@ void KModule::prepare(const Interpreter::ModuleOptions &opts,
   pm.add(createScalarizerPass());
   if (opts.CheckDivZero) pm.add(new DivCheckPass());
   if (opts.CheckOvershift) pm.add(new OvershiftCheckPass());
-  // FIXME: This false here is to work around a bug in
-  // IntrinsicLowering which caches values which may eventually be
-  // deleted (via RAUW). This can be removed once LLVM fixes this
-  // issue.
-  pm.add(new IntrinsicCleanerPass(*targetData, false));
+
+  pm.add(new IntrinsicCleanerPass(*targetData));
   pm.run(*module);
 
   if (opts.Optimize)

--- a/lib/Module/Passes.h
+++ b/lib/Module/Passes.h
@@ -59,16 +59,12 @@ class IntrinsicCleanerPass : public llvm::ModulePass {
   static char ID;
   const llvm::DataLayout &DataLayout;
   llvm::IntrinsicLowering *IL;
-  bool LowerIntrinsics;
 
   bool runOnBasicBlock(llvm::BasicBlock &b, llvm::Module &M);
 public:
-  IntrinsicCleanerPass(const llvm::DataLayout &TD,
-                       bool LI=true)
-    : llvm::ModulePass(ID),
-      DataLayout(TD),
-      IL(new llvm::IntrinsicLowering(TD)),
-      LowerIntrinsics(LI) {}
+  IntrinsicCleanerPass(const llvm::DataLayout &TD, bool LI = true)
+      : llvm::ModulePass(ID), DataLayout(TD),
+        IL(new llvm::IntrinsicLowering(TD)) {}
   ~IntrinsicCleanerPass() { delete IL; } 
   
   virtual bool runOnModule(llvm::Module &M);


### PR DESCRIPTION
This used to be workaround for older LLVM version (< 3).
Remove the old behaviour.
