### PR TITLE
Update clang-format standard of KLEE codebase to C++11

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
 ---
 BasedOnStyle:  LLVM
-Standard: Cpp03
+Standard: Cpp11
 ...


### PR DESCRIPTION
After a productive discussion (☕️) with @251 and @kren1 , we realised that clang-format should be updated.  