### PR TITLE
Minor Passes Housekeeping

### DIFF
--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -13,13 +13,13 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
-#include "llvm/IR/IRBuilder.h"
 #include "llvm/Pass.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
@@ -46,18 +46,18 @@ bool IntrinsicCleanerPass::runOnModule(Module &M) {
 bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
   bool dirty = false;
   LLVMContext &ctx = M.getContext();
-  
+
   unsigned WordSize = DataLayout.getPointerSizeInBits() / 8;
   for (BasicBlock::iterator i = b.begin(), ie = b.end(); i != ie;) {
     IntrinsicInst *ii = dyn_cast<IntrinsicInst>(&*i);
     // increment now since deletion of instructions makes iterator invalid.
     ++i;
-    if(ii) {
+    if (ii) {
       switch (ii->getIntrinsicID()) {
       case Intrinsic::vastart:
       case Intrinsic::vaend:
         break;
-        
+
         // Lower vacopy so that object resolution etc is handled by
         // normal instructions.
         //
@@ -68,24 +68,32 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         Value *src = ii->getArgOperand(1);
 
         if (WordSize == 4) {
-          Type *i8pp = PointerType::getUnqual(PointerType::getUnqual(Type::getInt8Ty(ctx)));
-          Value *castedDst = CastInst::CreatePointerCast(dst, i8pp, "vacopy.cast.dst", ii);
-          Value *castedSrc = CastInst::CreatePointerCast(src, i8pp, "vacopy.cast.src", ii);
+          Type *i8pp = PointerType::getUnqual(
+              PointerType::getUnqual(Type::getInt8Ty(ctx)));
+          Value *castedDst =
+              CastInst::CreatePointerCast(dst, i8pp, "vacopy.cast.dst", ii);
+          Value *castedSrc =
+              CastInst::CreatePointerCast(src, i8pp, "vacopy.cast.src", ii);
           Value *load = new LoadInst(castedSrc, "vacopy.read", ii);
           new StoreInst(load, castedDst, false, ii);
         } else {
           assert(WordSize == 8 && "Invalid word size!");
           Type *i64p = PointerType::getUnqual(Type::getInt64Ty(ctx));
-          Value *pDst = CastInst::CreatePointerCast(dst, i64p, "vacopy.cast.dst", ii);
-          Value *pSrc = CastInst::CreatePointerCast(src, i64p, "vacopy.cast.src", ii);
-          Value *val = new LoadInst(pSrc, std::string(), ii); new StoreInst(val, pDst, ii);
+          Value *pDst =
+              CastInst::CreatePointerCast(dst, i64p, "vacopy.cast.dst", ii);
+          Value *pSrc =
+              CastInst::CreatePointerCast(src, i64p, "vacopy.cast.src", ii);
+          Value *val = new LoadInst(pSrc, std::string(), ii);
+          new StoreInst(val, pDst, ii);
           Value *off = ConstantInt::get(Type::getInt64Ty(ctx), 1);
           pDst = GetElementPtrInst::Create(pDst, off, std::string(), ii);
           pSrc = GetElementPtrInst::Create(pSrc, off, std::string(), ii);
-          val = new LoadInst(pSrc, std::string(), ii); new StoreInst(val, pDst, ii);
+          val = new LoadInst(pSrc, std::string(), ii);
+          new StoreInst(val, pDst, ii);
           pDst = GetElementPtrInst::Create(pDst, off, std::string(), ii);
           pSrc = GetElementPtrInst::Create(pSrc, off, std::string(), ii);
-          val = new LoadInst(pSrc, std::string(), ii); new StoreInst(val, pDst, ii);
+          val = new LoadInst(pSrc, std::string(), ii);
+          new StoreInst(val, pDst, ii);
         }
         ii->eraseFromParent();
         dirty = true;
@@ -102,32 +110,32 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
 
         Value *op1 = ii->getArgOperand(0);
         Value *op2 = ii->getArgOperand(1);
-        
+
         Value *result = 0;
         Value *result_ext = 0;
         Value *overflow = 0;
 
         unsigned int bw = op1->getType()->getPrimitiveSizeInBits();
-        unsigned int bw2 = op1->getType()->getPrimitiveSizeInBits()*2;
+        unsigned int bw2 = op1->getType()->getPrimitiveSizeInBits() * 2;
 
         if ((ii->getIntrinsicID() == Intrinsic::uadd_with_overflow) ||
             (ii->getIntrinsicID() == Intrinsic::usub_with_overflow) ||
             (ii->getIntrinsicID() == Intrinsic::umul_with_overflow)) {
 
           Value *op1ext =
-            builder.CreateZExt(op1, IntegerType::get(M.getContext(), bw2));
+              builder.CreateZExt(op1, IntegerType::get(M.getContext(), bw2));
           Value *op2ext =
-            builder.CreateZExt(op2, IntegerType::get(M.getContext(), bw2));
+              builder.CreateZExt(op2, IntegerType::get(M.getContext(), bw2));
           Value *int_max_s =
-            ConstantInt::get(op1->getType(), APInt::getMaxValue(bw));
-          Value *int_max =
-            builder.CreateZExt(int_max_s, IntegerType::get(M.getContext(), bw2));
+              ConstantInt::get(op1->getType(), APInt::getMaxValue(bw));
+          Value *int_max = builder.CreateZExt(
+              int_max_s, IntegerType::get(M.getContext(), bw2));
 
-          if (ii->getIntrinsicID() == Intrinsic::uadd_with_overflow){
+          if (ii->getIntrinsicID() == Intrinsic::uadd_with_overflow) {
             result_ext = builder.CreateAdd(op1ext, op2ext);
-          } else if (ii->getIntrinsicID() == Intrinsic::usub_with_overflow){
+          } else if (ii->getIntrinsicID() == Intrinsic::usub_with_overflow) {
             result_ext = builder.CreateSub(op1ext, op2ext);
-          } else if (ii->getIntrinsicID() == Intrinsic::umul_with_overflow){
+          } else if (ii->getIntrinsicID() == Intrinsic::umul_with_overflow) {
             result_ext = builder.CreateMul(op1ext, op2ext);
           }
           overflow = builder.CreateICmpUGT(result_ext, int_max);
@@ -137,27 +145,28 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
                    (ii->getIntrinsicID() == Intrinsic::smul_with_overflow)) {
 
           Value *op1ext =
-            builder.CreateSExt(op1, IntegerType::get(M.getContext(), bw2));
+              builder.CreateSExt(op1, IntegerType::get(M.getContext(), bw2));
           Value *op2ext =
-            builder.CreateSExt(op2, IntegerType::get(M.getContext(), bw2));
+              builder.CreateSExt(op2, IntegerType::get(M.getContext(), bw2));
           Value *int_max_s =
-            ConstantInt::get(op1->getType(), APInt::getSignedMaxValue(bw));
+              ConstantInt::get(op1->getType(), APInt::getSignedMaxValue(bw));
           Value *int_min_s =
-            ConstantInt::get(op1->getType(), APInt::getSignedMinValue(bw));
-          Value *int_max =
-            builder.CreateSExt(int_max_s, IntegerType::get(M.getContext(), bw2));
-          Value *int_min =
-            builder.CreateSExt(int_min_s, IntegerType::get(M.getContext(), bw2));
+              ConstantInt::get(op1->getType(), APInt::getSignedMinValue(bw));
+          Value *int_max = builder.CreateSExt(
+              int_max_s, IntegerType::get(M.getContext(), bw2));
+          Value *int_min = builder.CreateSExt(
+              int_min_s, IntegerType::get(M.getContext(), bw2));
 
-          if (ii->getIntrinsicID() == Intrinsic::sadd_with_overflow){
+          if (ii->getIntrinsicID() == Intrinsic::sadd_with_overflow) {
             result_ext = builder.CreateAdd(op1ext, op2ext);
-          } else if (ii->getIntrinsicID() == Intrinsic::ssub_with_overflow){
+          } else if (ii->getIntrinsicID() == Intrinsic::ssub_with_overflow) {
             result_ext = builder.CreateSub(op1ext, op2ext);
-          } else if (ii->getIntrinsicID() == Intrinsic::smul_with_overflow){
+          } else if (ii->getIntrinsicID() == Intrinsic::smul_with_overflow) {
             result_ext = builder.CreateMul(op1ext, op2ext);
           }
-          overflow = builder.CreateOr(builder.CreateICmpSGT(result_ext, int_max),
-                                      builder.CreateICmpSLT(result_ext, int_min));
+          overflow =
+              builder.CreateOr(builder.CreateICmpSGT(result_ext, int_max),
+                               builder.CreateICmpSLT(result_ext, int_min));
         }
 
         // This trunc cound be replaced by a more general trunc replacement
@@ -169,10 +178,10 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         //     uint8_t = (uint8_t + uint8_t) & 0xFF;
         // before this, must check if it has side effects on other operations
         result = builder.CreateTrunc(result_ext, op1->getType());
-        Value *resultStruct =
-          builder.CreateInsertValue(UndefValue::get(ii->getType()), result, 0);
+        Value *resultStruct = builder.CreateInsertValue(
+            UndefValue::get(ii->getType()), result, 0);
         resultStruct = builder.CreateInsertValue(resultStruct, overflow, 1);
-        
+
         ii->replaceAllUsesWith(resultStruct);
         ii->eraseFromParent();
         dirty = true;
@@ -193,8 +202,7 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         // Intrisic instruction "llvm.trap" found. Directly lower it to
         // a call of the abort() function.
         Function *F = cast<Function>(
-          M.getOrInsertFunction(
-            "abort", Type::getVoidTy(ctx), NULL));
+            M.getOrInsertFunction("abort", Type::getVoidTy(ctx), NULL));
         F->setDoesNotReturn();
         F->setDoesNotThrow();
 
@@ -214,7 +222,8 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         assert(minArg && "Failed to get second argument");
         ConstantInt *minArgAsInt = dyn_cast<ConstantInt>(minArg);
         assert(minArgAsInt && "Second arg is not a ConstantInt");
-        assert(minArgAsInt->getBitWidth() == 1 && "Second argument is not an i1");
+        assert(minArgAsInt->getBitWidth() == 1 &&
+               "Second argument is not an i1");
         Value *replacement = NULL;
         IntegerType *intType = dyn_cast<IntegerType>(ii->getType());
         assert(intType && "intrinsic does not have integer return type");
@@ -240,4 +249,4 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
 
   return dirty;
 }
-}
+} // namespace klee

--- a/lib/Module/Passes.h
+++ b/lib/Module/Passes.h
@@ -20,18 +20,18 @@
 #include "llvm/Pass.h"
 
 namespace llvm {
-  class Function;
-  class Instruction;
-  class Module;
-  class DataLayout;
-  class TargetLowering;
-  class Type;
-}
+class Function;
+class Instruction;
+class Module;
+class DataLayout;
+class TargetLowering;
+class Type;
+} // namespace llvm
 
 namespace klee {
 
-  /// RaiseAsmPass - This pass raises some common occurences of inline
-  /// asm which are used by glibc into normal LLVM IR.
+/// RaiseAsmPass - This pass raises some common occurences of inline
+/// asm which are used by glibc into normal LLVM IR.
 class RaiseAsmPass : public llvm::ModulePass {
   static char ID;
 
@@ -53,35 +53,36 @@ public:
   bool runOnModule(llvm::Module &M) override;
 };
 
-  // This is a module pass because it can add and delete module
-  // variables (via intrinsic lowering).
+// This is a module pass because it can add and delete module
+// variables (via intrinsic lowering).
 class IntrinsicCleanerPass : public llvm::ModulePass {
   static char ID;
   const llvm::DataLayout &DataLayout;
   llvm::IntrinsicLowering *IL;
 
   bool runOnBasicBlock(llvm::BasicBlock &b, llvm::Module &M);
+
 public:
   IntrinsicCleanerPass(const llvm::DataLayout &TD)
       : llvm::ModulePass(ID), DataLayout(TD),
         IL(new llvm::IntrinsicLowering(TD)) {}
-  ~IntrinsicCleanerPass() { delete IL; } 
-  
+  ~IntrinsicCleanerPass() { delete IL; }
+
   bool runOnModule(llvm::Module &M) override;
 };
-  
-  // performs two transformations which make interpretation
-  // easier and faster.
-  //
-  // 1) Ensure that all the PHI nodes in a basic block have
-  //    the incoming block list in the same order. Thus the
-  //    incoming block index only needs to be computed once
-  //    for each transfer.
-  // 
-  // 2) Ensure that no PHI node result is used as an argument to
-  //    a subsequent PHI node in the same basic block. This allows
-  //    the transfer to execute the instructions in order instead
-  //    of in two passes.
+
+// performs two transformations which make interpretation
+// easier and faster.
+//
+// 1) Ensure that all the PHI nodes in a basic block have
+//    the incoming block list in the same order. Thus the
+//    incoming block index only needs to be computed once
+//    for each transfer.
+//
+// 2) Ensure that no PHI node result is used as an argument to
+//    a subsequent PHI node in the same basic block. This allows
+//    the transfer to execute the instructions in order instead
+//    of in two passes.
 class PhiCleanerPass : public llvm::FunctionPass {
   static char ID;
 
@@ -90,11 +91,12 @@ public:
 
   bool runOnFunction(llvm::Function &f) override;
 };
-  
+
 class DivCheckPass : public llvm::ModulePass {
   static char ID;
+
 public:
-  DivCheckPass(): ModulePass(ID) {}
+  DivCheckPass() : ModulePass(ID) {}
   bool runOnModule(llvm::Module &M) override;
 };
 
@@ -114,8 +116,9 @@ public:
 /// \endcode
 class OvershiftCheckPass : public llvm::ModulePass {
   static char ID;
+
 public:
-  OvershiftCheckPass(): ModulePass(ID) {}
+  OvershiftCheckPass() : ModulePass(ID) {}
   bool runOnModule(llvm::Module &M) override;
 };
 
@@ -132,20 +135,17 @@ public:
   struct SwitchCase {
     llvm ::Constant *value;
     llvm::BasicBlock *block;
-    
-    SwitchCase() : value(0), block(0) { }
-    SwitchCase(llvm::Constant *v, llvm::BasicBlock *b) :
-      value(v), block(b) { }
+
+    SwitchCase() : value(0), block(0) {}
+    SwitchCase(llvm::Constant *v, llvm::BasicBlock *b) : value(v), block(b) {}
   };
-  
-  typedef std::vector<SwitchCase>           CaseVector;
+
+  typedef std::vector<SwitchCase> CaseVector;
   typedef std::vector<SwitchCase>::iterator CaseItr;
-  
+
 private:
   void processSwitchInst(llvm::SwitchInst *SI);
-  void switchConvert(CaseItr begin,
-                     CaseItr end,
-                     llvm::Value *value,
+  void switchConvert(CaseItr begin, CaseItr end, llvm::Value *value,
                      llvm::BasicBlock *origBlock,
                      llvm::BasicBlock *defaultBlock);
 };
@@ -153,7 +153,7 @@ private:
 // This is the interface to a back-ported LLVM pass.
 // Therefore this interface is only needed for
 // LLVM 3.4.
-#if LLVM_VERSION_CODE == LLVM_VERSION(3,4)
+#if LLVM_VERSION_CODE == LLVM_VERSION(3, 4)
 llvm::FunctionPass *createScalarizerPass();
 #endif
 
@@ -173,6 +173,6 @@ public:
   bool runOnModule(llvm::Module &M) override;
   bool checkPassed() const { return instructionOperandsConform; }
 };
-}
+} // namespace klee
 
 #endif

--- a/lib/Module/Passes.h
+++ b/lib/Module/Passes.h
@@ -49,8 +49,8 @@ class RaiseAsmPass : public llvm::ModulePass {
 
 public:
   RaiseAsmPass() : llvm::ModulePass(ID), TLI(0) {}
-  
-  virtual bool runOnModule(llvm::Module &M);
+
+  bool runOnModule(llvm::Module &M) override;
 };
 
   // This is a module pass because it can add and delete module
@@ -62,12 +62,12 @@ class IntrinsicCleanerPass : public llvm::ModulePass {
 
   bool runOnBasicBlock(llvm::BasicBlock &b, llvm::Module &M);
 public:
-  IntrinsicCleanerPass(const llvm::DataLayout &TD, bool LI = true)
+  IntrinsicCleanerPass(const llvm::DataLayout &TD)
       : llvm::ModulePass(ID), DataLayout(TD),
         IL(new llvm::IntrinsicLowering(TD)) {}
   ~IntrinsicCleanerPass() { delete IL; } 
   
-  virtual bool runOnModule(llvm::Module &M);
+  bool runOnModule(llvm::Module &M) override;
 };
   
   // performs two transformations which make interpretation
@@ -87,15 +87,15 @@ class PhiCleanerPass : public llvm::FunctionPass {
 
 public:
   PhiCleanerPass() : llvm::FunctionPass(ID) {}
-  
-  virtual bool runOnFunction(llvm::Function &f);
+
+  bool runOnFunction(llvm::Function &f) override;
 };
   
 class DivCheckPass : public llvm::ModulePass {
   static char ID;
 public:
   DivCheckPass(): ModulePass(ID) {}
-  virtual bool runOnModule(llvm::Module &M);
+  bool runOnModule(llvm::Module &M) override;
 };
 
 /// This pass injects checks to check for overshifting.
@@ -116,7 +116,7 @@ class OvershiftCheckPass : public llvm::ModulePass {
   static char ID;
 public:
   OvershiftCheckPass(): ModulePass(ID) {}
-  virtual bool runOnModule(llvm::Module &M);
+  bool runOnModule(llvm::Module &M) override;
 };
 
 /// LowerSwitchPass - Replace all SwitchInst instructions with chained branch
@@ -125,10 +125,10 @@ public:
 class LowerSwitchPass : public llvm::FunctionPass {
 public:
   static char ID; // Pass identification, replacement for typeid
-  LowerSwitchPass() : FunctionPass(ID) {} 
-  
-  virtual bool runOnFunction(llvm::Function &F);
-  
+  LowerSwitchPass() : FunctionPass(ID) {}
+
+  bool runOnFunction(llvm::Function &F) override;
+
   struct SwitchCase {
     llvm ::Constant *value;
     llvm::BasicBlock *block;
@@ -170,8 +170,7 @@ public:
   static char ID;
   InstructionOperandTypeCheckPass()
       : llvm::ModulePass(ID), instructionOperandsConform(true) {}
-  // TODO: Add `override` when we switch to C++11
-  bool runOnModule(llvm::Module &M);
+  bool runOnModule(llvm::Module &M) override;
   bool checkPassed() const { return instructionOperandsConform; }
 };
 }


### PR DESCRIPTION
This PR started with me noticing that #867 didn't remove `bool LI=true` (after it was already merged...).

I found some other stuff that I also want to address with this PR:

  * remove unused variables `block_split` (::runOnBasicBlock) and `LI` (::IntrinsicCleanerPass) in IntrinsicCleanerPass

  * add `dirty = true` to `Intrinsic::vacopy` case

  * use `eraseFromParent()` methods instead of `removeFromParent()` and `delete`

  * add `override` keyword to `runOn{Module,Function}` methods