### PR TITLE
Docker image Z3 upgrade to 4.6.0 & dockerfile enhancements

### DIFF
--- a/.travis/solvers.sh
+++ b/.travis/solvers.sh
@@ -12,16 +12,19 @@ for solver in ${SOLVER_LIST}; do
     echo "STP"
     mkdir stp
     cd stp
-    ${KLEE_SRC}/.travis/stp.sh
+    CC=${STP_CC:-${CC}} CXX=${STP_CXX:-${CXX}} ${KLEE_SRC}/.travis/stp.sh
     cd ../
     ;;
   Z3)
     echo "Z3"
-    ${KLEE_SRC}/.travis/z3.sh
+    mkdir z3
+    cd z3
+    CC=${Z3_CC:-${CC}} CXX=${Z3_CXX:-${CXX}} ${KLEE_SRC}/.travis/z3.sh
+    cd ../
     ;;
   metaSMT)
     echo "metaSMT"
-    ${KLEE_SRC}/.travis/metaSMT.sh
+    CC=${METASMT_CC:-${CC}} CXX=${METASMT_CXX:-${CXX}} ${KLEE_SRC}/.travis/metaSMT.sh
     ;;
   *)
     echo "Unknown solver ${solver}"

--- a/.travis/z3.sh
+++ b/.travis/z3.sh
@@ -10,8 +10,11 @@ if [ "X${IS_SANITIZED_BUILD}" != "X0" ]; then
 fi
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  # Should we install libz3-dbg too?
-  sudo apt-get -y install libz3 libz3-dev
+  wget -qO- https://github.com/Z3Prover/z3/archive/z3-4.6.0.tar.gz | tar xz --strip-components=1
+  python scripts/mk_make.py
+  cd build
+  make -j`nproc`
+  sudo make install
 elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
   set +e
   brew install python@2

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ ENV LLVM_VERSION=3.4 \
     BUILD_DIR=/home/klee/klee_build \
     ASAN_BUILD=0 \
     UBSAN_BUILD=0 \
-    TRAVIS_OS_NAME=linux
+    TRAVIS_OS_NAME=linux \
+    DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install \
@@ -25,6 +26,8 @@ RUN apt-get update && \
         llvm-${LLVM_VERSION}-dev \
         llvm-${LLVM_VERSION}-runtime \
         llvm \
+        gcc \
+        g++ \
         libcap-dev \
         git \
         subversion \
@@ -45,8 +48,6 @@ RUN apt-get update && \
         binutils && \
     pip3 install -U lit tabulate wllvm && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 50 && \
-    ( wget -O - http://download.opensuse.org/repositories/home:delcypher:z3/xUbuntu_14.04/Release.key | apt-key add - ) && \
-    echo 'deb http://download.opensuse.org/repositories/home:/delcypher:/z3/xUbuntu_14.04/ /' >> /etc/apt/sources.list.d/z3.list && \
     apt-get update
 
 # Create ``klee`` user for container with password ``klee``.
@@ -69,7 +70,7 @@ RUN sudo chown --recursive klee: ${KLEE_SRC}
 RUN mkdir -p ${BUILD_DIR}
 
 # Build/Install SMT solvers (use TravisCI script)
-RUN cd ${BUILD_DIR} && ${KLEE_SRC}/.travis/solvers.sh
+RUN cd ${BUILD_DIR} && STP_CXX=g++ STP_CC=gcc Z3_CXX=g++ Z3_CC=gcc ${KLEE_SRC}/.travis/solvers.sh
 
 # Install testing utils (use TravisCI script)
 RUN cd ${BUILD_DIR} && mkdir test-utils && cd test-utils && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ MAINTAINER Dan Liew <daniel.liew@imperial.ac.uk>
 # squash the layers from within a Dockerfile so
 # the resulting image is unnecessarily large!
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 ENV LLVM_VERSION=3.4 \
     SOLVERS=STP:Z3 \
     STP_VERSION=2.1.2 \
@@ -16,8 +18,8 @@ ENV LLVM_VERSION=3.4 \
     BUILD_DIR=/home/klee/klee_build \
     ASAN_BUILD=0 \
     UBSAN_BUILD=0 \
-    TRAVIS_OS_NAME=linux \
-    DEBIAN_FRONTEND=noninteractive
+    TRAVIS_OS_NAME=linux
+
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install \


### PR DESCRIPTION
This PR contains the follows
- Docker image now using Z3 4.6.0
- Now we are able to specify different compilers for building different solvers
- Improved apt-get install by specifying it is an `noninteractive` environment

This resolves #870. The dockerfile was tested with all tests passed.