### PR TITLE
Trying to make the ktest-tool's output more readable

### DIFF
--- a/lib/Module/CMakeLists.txt
+++ b/lib/Module/CMakeLists.txt
@@ -8,6 +8,7 @@
 #===------------------------------------------------------------------------===#
 klee_add_component(kleeModule
   Checks.cpp
+  ExtractTypeMetaPass.cpp
   InstructionInfoTable.cpp
   InstructionOperandTypeCheckPass.cpp
   IntrinsicCleaner.cpp

--- a/lib/Module/ExtractTypeMetaPass.cpp
+++ b/lib/Module/ExtractTypeMetaPass.cpp
@@ -5,6 +5,7 @@
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/DataLayout.h"
+#include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/Endian.h"
 
 #include <cstring>
@@ -102,11 +103,15 @@ bool klee::ExtractTypeMetaCheck::runOnModule(llvm::Module &M) {
 	if (!metaOutFile) {
 		return changed;
 	}
+	DataLayout dl = DataLayout(M.getDataLayout());
 	if (!isEndiannessWritten) {
+#if LLVM_VERSION_CODE < LLVM_VERSION(3, 5)
 		writeLine(M.getEndianness() == llvm::Module::Endianness::LittleEndian ? "little" : "big");
+#else
+		writeLine(dl.isLittleEndian() ? "little" : "big");
+#endif
 		isEndiannessWritten = true;
 	}
-	DataLayout dl = DataLayout(M.getDataLayout());
 	for (Module::iterator mi = M.begin(), me = M.end(); mi != me; ++mi) {
 		for (Function::iterator bi = mi->begin(), be = mi->end(); bi != be; ++bi) {
 			for (BasicBlock::iterator ii = bi->begin(), ie = bi->end(); ii != ie; ++ii) {

--- a/lib/Module/ExtractTypeMetaPass.cpp
+++ b/lib/Module/ExtractTypeMetaPass.cpp
@@ -1,0 +1,130 @@
+#include "Passes.h"
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Attributes.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/Support/Endian.h"
+
+#include <cstring>
+#include <iostream>
+#include <sstream>
+
+using namespace llvm;
+
+char klee::ExtractTypeMetaCheck::ID = 0;
+const char* klee::ExtractTypeMetaCheck::KLEE_META_FILENAME = "type-meta.kmeta";
+
+klee::ExtractTypeMetaCheck::ExtractTypeMetaCheck(InterpreterHandler *ih) : llvm::ModulePass(ID),
+																		   ih(ih), isEndiannessWritten(false) {
+    metaOutFile = ih->openOutputFile(KLEE_META_FILENAME);
+}
+
+klee::ExtractTypeMetaCheck::~ExtractTypeMetaCheck() {
+	delete metaOutFile;
+}
+
+void klee::ExtractTypeMetaCheck::writeLine(std::string line) {
+	if (metaOutFile) {
+		metaOutFile->write(line.c_str(), line.length());
+		metaOutFile->write("\n", 1);
+	}
+}
+
+std::string klee::ExtractTypeMetaCheck::getTypeMetaData(Type *t, const llvm::DataLayout &dl) {
+	std::stringstream ss;
+	//TODO should somehow find out if integer is signed or unsigned,
+	//however llvm does not store this information
+	if (t->isIntegerTy()) {
+		IntegerType *it = dyn_cast<IntegerType>(t);
+		if (it->getBitWidth() == 8) {
+			ss << "char:" << it->getBitWidth() / 8;
+		} else {
+			ss << "int:" << it->getBitWidth() / 8;
+		}
+	} else if (t->isArrayTy()) {
+		ArrayType *at = dyn_cast<ArrayType>(t);
+		ss << "array:" << at->getNumElements() << ":" << getTypeMetaData(at->getElementType(), dl);
+	} else if (t->isStructTy()) {
+		StructType *st = dyn_cast<StructType>(t);
+		const StructLayout *sl = dl.getStructLayout(st);
+		ss << "struct:" << (st->hasName() ? st->getName().str() : "unknown") << ":";
+		size_t i = 0;
+		//TODO currently recursively traverses the whole struct, maybe should limit the depth?
+		for (llvm::StructType::element_iterator seb = st->element_begin(), see = st->element_end(); seb != see; ++seb) {
+			Type* currentType = *seb;
+			uint64_t offset = sl->getElementOffset(i);
+			if (seb+1 < see) {
+				ss << getTypeMetaData(currentType, dl) << ":" << offset << ">>>";
+			} else {
+				ss << getTypeMetaData(currentType, dl) << ":" << offset << "###";
+			}
+			++i;
+		}
+	} else {
+		ss << "unhandled";
+	}
+	return ss.str();
+}
+
+std::string klee::ExtractTypeMetaCheck::getSymbolicName(llvm::CallInst *ci) {
+	StringRef name = "";
+	if (ci) {
+		ConstantExpr *ce = dyn_cast<ConstantExpr>(ci->getArgOperand(2));
+		if (ce) {
+			GlobalVariable *gv = dyn_cast<GlobalVariable>(ce->getOperand(0));
+			if (gv) {
+			  	ConstantDataArray *cda = dyn_cast<ConstantDataArray>(gv->getInitializer());
+			   	if (cda) {
+					name = cda->getAsString();
+			   	}
+			}
+		} // TODO could not handle the case when the third parameter of klee_make_symbolic
+		  // is a variable
+	}
+	return name.str();
+}
+
+Type* klee::ExtractTypeMetaCheck::getSymbolicType(llvm::CallInst *ci) {
+	if (ci) {
+		Value* v = ci->getArgOperand(0)->stripPointerCasts();
+		PointerType *pt = dyn_cast<PointerType>(v->getType());
+		if (pt) {
+			return pt->getElementType();
+		}
+	}
+	return nullptr;
+}
+
+bool klee::ExtractTypeMetaCheck::runOnModule(llvm::Module &M) {
+	bool changed = false;
+	if (!metaOutFile) {
+		return changed;
+	}
+	if (!isEndiannessWritten) {
+		writeLine(M.getEndianness() == llvm::Module::Endianness::LittleEndian ? "little" : "big");
+		isEndiannessWritten = true;
+	}
+	DataLayout dl = DataLayout(M.getDataLayout());
+	for (Module::iterator mi = M.begin(), me = M.end(); mi != me; ++mi) {
+		for (Function::iterator bi = mi->begin(), be = mi->end(); bi != be; ++bi) {
+			for (BasicBlock::iterator ii = bi->begin(), ie = bi->end(); ii != ie; ++ii) {
+				if (strcmp(ii->getOpcodeName(), "call") == 0) {
+					CallInst *ci = cast<CallInst>(ii);
+					if (ci) {
+						Function *f = ci->getCalledFunction();
+						if (f) {
+							StringRef name = ci->getCalledFunction()->getName();
+							if (name.equals("klee_make_symbolic")) {
+								writeLine(getSymbolicName(ci));
+								writeLine(getTypeMetaData(getSymbolicType(ci), dl));
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return changed;
+}

--- a/lib/Module/ExtractTypeMetaPass.cpp
+++ b/lib/Module/ExtractTypeMetaPass.cpp
@@ -103,7 +103,11 @@ bool klee::ExtractTypeMetaCheck::runOnModule(llvm::Module &M) {
 	if (!metaOutFile) {
 		return changed;
 	}
+#if LLVM_VERSION_CODE < LLVM_VERSION(3, 5)
 	DataLayout dl = DataLayout(M.getDataLayout());
+#else
+	DataLayout dl = M.getDataLayout();
+#endif
 	if (!isEndiannessWritten) {
 #if LLVM_VERSION_CODE < LLVM_VERSION(3, 5)
 		writeLine(M.getEndianness() == llvm::Module::Endianness::LittleEndian ? "little" : "big");

--- a/lib/Module/ExtractTypeMetaPass.cpp
+++ b/lib/Module/ExtractTypeMetaPass.cpp
@@ -112,7 +112,7 @@ bool klee::ExtractTypeMetaCheck::runOnModule(llvm::Module &M) {
 #if LLVM_VERSION_CODE < LLVM_VERSION(3, 5)
 		writeLine(M.getEndianness() == llvm::Module::Endianness::LittleEndian ? "little" : "big");
 #else
-		writeLine(dl.isLittleEndian() ? "little" : "big");
+		writeLine(dl->isLittleEndian() ? "little" : "big");
 #endif
 		isEndiannessWritten = true;
 	}

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -201,6 +201,8 @@ void KModule::prepare(const Interpreter::ModuleOptions &opts,
   // optimize is seeing what is as close as possible to the final
   // module.
   LegacyLLVMPassManagerTy pm;
+  pm.add(new ExtractTypeMetaCheck(ih));
+  // This pass will save type meta datas for readable ktest-tool output.
   pm.add(new RaiseAsmPass());
   // This pass will scalarize as much code as possible so that the Executor
   // does not need to handle operands of vector type for most instructions

--- a/lib/Module/Passes.h
+++ b/lib/Module/Passes.h
@@ -11,13 +11,18 @@
 #define KLEE_PASSES_H
 
 #include "klee/Config/Version.h"
+#include "klee/Interpreter.h"
 
 #include "llvm/ADT/Triple.h"
 #include "llvm/CodeGen/IntrinsicLowering.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
 
 namespace llvm {
   class Function;
@@ -29,6 +34,27 @@ namespace llvm {
 }
 
 namespace klee {
+
+  /// ExtractTypeMetaCheck - This is a non-modifying pass that extracts
+  /// the type informations to help the ktest-tool print the test values in
+  /// a readable way.
+class ExtractTypeMetaCheck : public llvm::ModulePass {
+  static char ID;
+  static const char* KLEE_META_FILENAME;
+  InterpreterHandler *ih;
+  llvm::raw_fd_ostream *metaOutFile;
+  bool isEndiannessWritten;
+
+  std::string getTypeMetaData(llvm::Type *t, const llvm::DataLayout &dl);
+  std::string getSymbolicName(llvm::CallInst *ci);
+  llvm::Type* getSymbolicType(llvm::CallInst *ci);
+  void writeLine(std::string line);
+
+public:
+  ExtractTypeMetaCheck(InterpreterHandler *ih);
+  ~ExtractTypeMetaCheck();
+  virtual bool runOnModule(llvm::Module &M);
+};
 
   /// RaiseAsmPass - This pass raises some common occurences of inline
   /// asm which are used by glibc into normal LLVM IR.

--- a/lib/Module/Passes.h
+++ b/lib/Module/Passes.h
@@ -45,7 +45,7 @@ class ExtractTypeMetaCheck : public llvm::ModulePass {
   llvm::raw_fd_ostream *metaOutFile;
   bool isEndiannessWritten;
 
-  std::string getTypeMetaData(llvm::Type *t, const llvm::DataLayout &dl);
+  std::string getTypeMetaData(llvm::Type *t, const llvm::DataLayout *dl);
   std::string getSymbolicName(llvm::CallInst *ci);
   llvm::Type* getSymbolicType(llvm::CallInst *ci);
   void writeLine(std::string line);

--- a/tools/ktest-tool/ktest-tool
+++ b/tools/ktest-tool/ktest-tool
@@ -12,11 +12,142 @@
 import os
 import struct
 import sys
+import re
+import json
+import itertools as it
 
 version_no=3
+type_meta_filename='type-meta.kmeta'
+python_version=sys.version_info[0]
 
 class KTestError(Exception):
     pass
+
+class KMeta:
+    def __init__(self, metaInfos, byteOrder):
+        self.metaInfos = metaInfos
+        self.byteOrder = byteOrder
+
+    @staticmethod
+    def fromfile(path):
+        metaPath = os.path.join(os.path.dirname(path), type_meta_filename)
+        if not os.path.exists(metaPath):
+            return False
+        metaInfos = dict()
+        with open(metaPath, "r") as file:
+            byteOrder = file.readline()
+            if (python_version < 3):
+                file_lines_by_two = it.izip_longest(*[file]*2)
+            else:
+                file_lines_by_two = it.zip_longest(*[file]*2)
+            for name,typeMeta in file_lines_by_two:
+                if name and typeMeta:
+                    metaInfos[str(name).strip('\n\r\0')] = str(typeMeta).strip('\n\r\0')
+        kmeta = KMeta(metaInfos, byteOrder)
+        return kmeta
+
+    def getType(self, name):
+        return self.metaInfos.get(name, None)
+
+    @staticmethod
+    def getUnpackString(typeMeta, count=1, recurs=1):
+        if recurs > 3:
+            return "no deeper"
+        metas = typeMeta.split(':')
+        unpackStr = ''
+        if metas[0] == 'int':
+            bitWidth = int(metas[1])
+            # TODO could not extract sign information from llvm, that is missing currently
+            if (bitWidth == 2):
+                unpackStr = str(count) + 'h'
+            elif (bitWidth == 4):
+                unpackStr = str(count) + 'i'
+            elif (bitWidth == 8):
+                unpackStr = str(count) + 'q'
+        elif metas[0] == 'array':
+            unpackStr = KMeta.getUnpackString(typeMeta[typeMeta.find(metas[2]):],
+                                              int(metas[1]), recurs + 1)
+        elif metas[0] == 'char':
+            unpackStr = str(count) + 'c'
+        #TODO other types as well
+        elif metas[0] == 'double':
+            unpackStr = 'unhandled'
+        elif metas[0] == 'float':
+            unpackStr = 'unhandled'
+        elif metas[0] == 'unhandled':
+            return 'unhandled'
+        else:
+            return 'unhandled'
+        return unpackStr
+
+    @staticmethod
+    def formatData(type, extractedData):
+        formattedData = {}
+        typeMeta = type.split(':')
+        typeName = typeMeta[0]
+        if typeName == 'array':
+            arrayName = 'array(' + typeMeta[2] + ')[' + typeMeta[1] + ']'
+            formattedData[arrayName] = [] 
+            if (typeMeta[2] == 'char'):
+                for elem in extractedData:
+                    formattedData[arrayName].append(elem.decode('utf-8'))
+            else:
+                for elem in extractedData:
+                    formattedData[arrayName].append(elem)
+        else:
+            if typeName == 'char':
+                formattedData[typeName] = extractedData[0].decode('utf-8')
+            else:
+                formattedData[typeName] = extractedData[0]
+        return formattedData
+
+
+
+    @staticmethod
+    def extractData(typeMeta, data, byteOrder, offset=0):
+        if byteOrder == 'big':
+            byteOrder = '>'
+        else:
+            byteOrder = '<'
+        metas = typeMeta.split(':')
+        if metas[0] == 'struct':
+            currentStruct = {}
+            structName = metas[1]
+            currentStruct[structName] = []
+            typeMeta = re.sub('###$', '', typeMeta)
+            types = typeMeta[typeMeta.find(metas[1])+len(metas[1])+1:].split(">>>")
+            i = 0
+            while i < len(types):
+                typ = types[i]
+                metaChunks = typ.split(':')
+                if (metaChunks[0] == 'struct'):
+                    currOffset = offset
+                    j = -1
+                    for j in reversed(range(len(types))):
+                        if '###' in types[j]:
+                            currMetaChunks = types[j].split(':')
+                            currOffset = int(currMetaChunks[-1])
+                            break
+                    lowerTypeMeta = re.sub('[^#]+$', '', '>>>'.join(types[i:j+1]))
+                    i = j + 1
+                    currentStruct[structName].append(KMeta.extractData(lowerTypeMeta, data, byteOrder, offset + currOffset))
+                    continue
+                unpackStr = KMeta.getUnpackString(typ)
+                if (unpackStr != 'unhandled'):
+                    extractedData = struct.unpack_from(byteOrder + unpackStr,
+                                                   data, int(metaChunks[-1]) + offset)
+                    currentStruct[structName].append(KMeta.formatData(typ, extractedData))
+                else:
+                    currentStruct[structName].append('unhandled')
+                i += 1
+            return currentStruct
+        else:
+            unpackStr = KMeta.getUnpackString(typeMeta)
+            if unpackStr != 'unhandled':
+                extractedData = struct.unpack(byteOrder + unpackStr, data)
+                return KMeta.formatData(typeMeta, extractedData)
+            else:
+                return 'unhandled'
 
 class KTest:
     @staticmethod
@@ -81,6 +212,57 @@ def trimZeros(str):
         if str[i] != '\x00':
             return str[:i+1]
     return ''
+
+def printFileInfos(file, b):
+    print('ktest file : %r' % file)
+    print('args       : %r' % b.args)
+    print('num objects: %r' % len(b.objects))
+
+def printObjectRegularly(i, name, data, opts):
+    if opts.trimZeros:
+        str = trimZeros(data)
+    else:
+        str = data
+
+    print('object %4d: name: %r' % (i, name.decode('utf-8')))
+    print('object %4d: size: %r' % (i, len(data)))
+    if opts.writeInts and len(data) == 4: 
+        print('object %4d: data: %r' % (i, struct.unpack('i',str)[0]))
+    else:
+        print('object %4d: data: %r' % (i, str))
+
+
+def printRegularly(file, opts):
+    b = KTest.fromfile(file)
+    pos = 0
+    printFileInfos(file, b)
+    for i,(name,data) in enumerate(b.objects):
+        printObjectRegularly(i, name, data, opts)
+        if i < len(b.objects) - 1:
+            print('')
+
+def printBeautifully(file, opts):
+    m = KMeta.fromfile(file)
+    if not m:
+        print('Could not find type meta informations to beautify')
+        printRegularly(file, opts)
+        return
+    b = KTest.fromfile(file)
+    printFileInfos(file, b)
+    for i,(name,data) in enumerate(b.objects):
+        #TODO python 2 vs 3, currently works with python 3
+        typeMeta = m.getType(name.decode('utf-8').strip('\n\r\0'))
+        if typeMeta:
+            print('object %4d: name: %s' % (i, name.decode('utf-8')))
+            print('object %4d: size: %r' % (i, len(data)))
+            print('object %4d: data:\n%s' % (i, json.dumps(KMeta.extractData(typeMeta,
+                                                               data, m.byteOrder), indent=2)))
+        else:
+            printObjectRegularly(i, name, data, opts)
+        if i < len(b.objects) - 1:
+            print('')
+
+
     
 def main(args):
     from optparse import OptionParser
@@ -91,31 +273,21 @@ def main(args):
     op.add_option('','--write-ints', dest='writeInts', action='store_true',
                   default=False,
                   help='convert 4-byte sequences to integers')
+    op.add_option('', '--beautify', dest='beautify', action='store_true',
+                  default=False,
+                  help='try to make the output more readable ' +
+                       '(this ignores any other arguments)')
     
     opts,args = op.parse_args()
     if not args:
         op.error("incorrect number of arguments")
 
-    for file in args:
-        b = KTest.fromfile(file)
-        pos = 0
-        print('ktest file : %r' % file)
-        print('args       : %r' % b.args)
-        print('num objects: %r' % len(b.objects))
-        for i,(name,data) in enumerate(b.objects):
-            if opts.trimZeros:
-                str = trimZeros(data)
-            else:
-                str = data
-
-            print('object %4d: name: %r' % (i, name))
-            print('object %4d: size: %r' % (i, len(data)))
-            if opts.writeInts and len(data) == 4: 
-                print('object %4d: data: %r' % (i, struct.unpack('i',str)[0]))
-            else:
-                print('object %4d: data: %r' % (i, str))
-        if file != args[-1]:
-            print()
-
+    for i,file in enumerate(args):
+        if opts.beautify:
+            printBeautifully(file, opts)
+        else:
+            printRegularly(file, opts)
+        if i < len(args) - 1:
+            print('')
 if __name__=='__main__':
     main(sys.argv)

--- a/tools/ktest-tool/ktest-tool
+++ b/tools/ktest-tool/ktest-tool
@@ -224,7 +224,7 @@ def printObjectRegularly(i, name, data, opts):
     else:
         str = data
 
-    print('object %4d: name: %r' % (i, name.decode('utf-8')))
+    print('object %4d: name: %r' % (i, name))
     print('object %4d: size: %r' % (i, len(data)))
     if opts.writeInts and len(data) == 4: 
         print('object %4d: data: %r' % (i, struct.unpack('i',str)[0]))


### PR DESCRIPTION
This pull request is based on an e-mail sent to the klee-dev mailing list with the title "making the ktest-tool's output more readable".

There are three main changes:
1. A new pass (ExtractTypeMetaPass) was created. It does no changes to the bytecode itself, just analyzes it to extract the necessary type information and writes it out to the current ktest output directory in a file named "type-meta.kmeta". This pass runs before the other passes.
2. The ktest-tool was modified to read out the type information if the "--beautify" flag is turned on. The format of the "beautified" output is currently only a json dump.
3. Other code in ktest-tool were refactored to avoid code duplications: the printing from the main loop was outsourced to three methods: `printRegularly`, `printObjectRegularly` and `printFileInfos`

There are some TODOs left in code, but my main concern is extracting the sign of integral types as LLVM does not store this information.

Please note that this is my very first pull request, so I would appreciate any useful comments on it:)