### PR TITLE
remove switch fallthrough in floating point comparision (and thereby fix warnings)

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2335,69 +2335,60 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     switch( fi->getPredicate() ) {
       // Predicates which only care about whether or not the operands are NaNs.
     case FCmpInst::FCMP_ORD:
-      Result = CmpRes != APFloat::cmpUnordered;
+      Result = (CmpRes != APFloat::cmpUnordered);
       break;
 
     case FCmpInst::FCMP_UNO:
-      Result = CmpRes == APFloat::cmpUnordered;
+      Result = (CmpRes == APFloat::cmpUnordered);
       break;
 
       // Ordered comparisons return false if either operand is NaN.  Unordered
       // comparisons return true if either operand is NaN.
     case FCmpInst::FCMP_UEQ:
-      if (CmpRes == APFloat::cmpUnordered) {
-        Result = true;
-        break;
-      }
+      Result = (CmpRes == APFloat::cmpUnordered || CmpRes == APFloat::cmpEqual);
+      break;
     case FCmpInst::FCMP_OEQ:
-      Result = CmpRes == APFloat::cmpEqual;
+      Result = (CmpRes != APFloat::cmpUnordered && CmpRes == APFloat::cmpEqual);
       break;
 
     case FCmpInst::FCMP_UGT:
-      if (CmpRes == APFloat::cmpUnordered) {
-        Result = true;
-        break;
-      }
+      Result = (CmpRes == APFloat::cmpUnordered || CmpRes == APFloat::cmpGreaterThan);
+      break;
     case FCmpInst::FCMP_OGT:
-      Result = CmpRes == APFloat::cmpGreaterThan;
+      Result = (CmpRes != APFloat::cmpUnordered && CmpRes == APFloat::cmpGreaterThan);
       break;
 
     case FCmpInst::FCMP_UGE:
-      if (CmpRes == APFloat::cmpUnordered) {
-        Result = true;
-        break;
-      }
+      Result = (CmpRes == APFloat::cmpUnordered || (CmpRes == APFloat::cmpGreaterThan || CmpRes == APFloat::cmpEqual));
+      break;
     case FCmpInst::FCMP_OGE:
-      Result = CmpRes == APFloat::cmpGreaterThan || CmpRes == APFloat::cmpEqual;
+      Result = (CmpRes != APFloat::cmpUnordered && (CmpRes == APFloat::cmpGreaterThan || CmpRes == APFloat::cmpEqual));
       break;
 
     case FCmpInst::FCMP_ULT:
-      if (CmpRes == APFloat::cmpUnordered) {
-        Result = true;
-        break;
-      }
+      Result = (CmpRes == APFloat::cmpUnordered || CmpRes == APFloat::cmpLessThan);
+      break;
     case FCmpInst::FCMP_OLT:
-      Result = CmpRes == APFloat::cmpLessThan;
+      Result = (CmpRes != APFloat::cmpUnordered && CmpRes == APFloat::cmpLessThan);
       break;
 
     case FCmpInst::FCMP_ULE:
-      if (CmpRes == APFloat::cmpUnordered) {
-        Result = true;
-        break;
-      }
+      Result = (CmpRes == APFloat::cmpUnordered || (CmpRes == APFloat::cmpLessThan || CmpRes == APFloat::cmpEqual));
+      break;
     case FCmpInst::FCMP_OLE:
-      Result = CmpRes == APFloat::cmpLessThan || CmpRes == APFloat::cmpEqual;
+      Result = (CmpRes != APFloat::cmpUnordered && (CmpRes == APFloat::cmpLessThan || CmpRes == APFloat::cmpEqual));
       break;
 
     case FCmpInst::FCMP_UNE:
-      Result = CmpRes == APFloat::cmpUnordered || CmpRes != APFloat::cmpEqual;
+      Result = (CmpRes == APFloat::cmpUnordered || CmpRes != APFloat::cmpEqual);
       break;
     case FCmpInst::FCMP_ONE:
-      Result = CmpRes != APFloat::cmpUnordered && CmpRes != APFloat::cmpEqual;
+      Result = (CmpRes != APFloat::cmpUnordered && CmpRes != APFloat::cmpEqual);
       break;
 
     default:
       assert(0 && "Invalid FCMP predicate!");
+      break;
     case FCmpInst::FCMP_FALSE:
       Result = false;
       break;


### PR DESCRIPTION
The switch governing floating point comparison is currently implemented as a series of fallthrough cases, which shortcut the NaN check for the ordered case, before using the unordered implementation otherwise.

Not only is this intransparent, it also causes compilation warnings on my current test system (GCC 8.1/CMake 3.11 source build on Arch):
```../lib/Core/Executor.cpp: In member function ‘void klee::Executor::executeInstruction(klee::ExecutionState&, klee::KInstruction*)’:
../lib/Core/Executor.cpp:2345:7: warning: this statement may fall through [-Wimplicit-fallthrough=]
       if (CmpRes == APFloat::cmpUnordered) {
       ^~
../lib/Core/Executor.cpp:2349:5: note: here
     case FCmpInst::FCMP_OEQ:
     ^~~~
../lib/Core/Executor.cpp:2354:7: warning: this statement may fall through [-Wimplicit-fallthrough=]
       if (CmpRes == APFloat::cmpUnordered) {
       ^~
../lib/Core/Executor.cpp:2358:5: note: here
     case FCmpInst::FCMP_OGT:
     ^~~~
../lib/Core/Executor.cpp:2363:7: warning: this statement may fall through [-Wimplicit-fallthrough=]
       if (CmpRes == APFloat::cmpUnordered) {
       ^~
../lib/Core/Executor.cpp:2367:5: note: here
     case FCmpInst::FCMP_OGE:
     ^~~~
../lib/Core/Executor.cpp:2372:7: warning: this statement may fall through [-Wimplicit-fallthrough=]
       if (CmpRes == APFloat::cmpUnordered) {
       ^~
../lib/Core/Executor.cpp:2376:5: note: here
     case FCmpInst::FCMP_OLT:
     ^~~~
../lib/Core/Executor.cpp:2381:7: warning: this statement may fall through [-Wimplicit-fallthrough=]
       if (CmpRes == APFloat::cmpUnordered) {
       ^~
../lib/Core/Executor.cpp:2385:5: note: here
     case FCmpInst::FCMP_OLE:
     ^~~~
```

With C++17 support it would have been possible to use `[[fallthrough]]` to at least annotate the intended fallthroughs (and thus squelch the warnings). I do however believe that the implementation proposed here is more readable, and thus preferable, anyway.