### PR TITLE
Improve error messages for ReadStringAtAddress

### DIFF
--- a/test/Feature/MakeSymbolicAPI.c
+++ b/test/Feature/MakeSymbolicAPI.c
@@ -5,15 +5,24 @@
 // RUN: FileCheck %s -check-prefix=CHECK-ERR --input-file=%t.stderr.log
 
 int main() {
-  unsigned a, b, c;
+  unsigned a, b, c, d, e;
+  const char *invalid_pointer = 0xf;
 
   klee_make_symbolic(&a, sizeof(a), "");
-// CHECK-WRN: KLEE: WARNING: klee_make_symbolic: renamed empty name to "unnamed"
+  //CHECK-WRN: KLEE: WARNING: klee_make_symbolic: renamed empty name to "unnamed"
+
 
   klee_make_symbolic(&b, sizeof(b));
-// CHECK-WRN: KLEE: WARNING: klee_make_symbolic: deprecated number of arguments (2 instead of 3)
-// CHECK-WRN: KLEE: WARNING: klee_make_symbolic: renamed empty name to "unnamed"
+  //CHECK-WRN: KLEE: WARNING: klee_make_symbolic: deprecated number of arguments (2 instead of 3)
+  //CHECK-WRN: KLEE: WARNING: klee_make_symbolic: renamed empty name to "unnamed"
+
+  if(a == 2)
+    klee_make_symbolic(&d, sizeof(e), invalid_pointer);
+    //CHECK-ERR-DAG: KLEE: ERROR: {{.*}} Invalid string pointer passed to one of the klee_ functions
+  if(a == 3)
+    klee_make_symbolic(&d, sizeof(e), (char *) b);
+    //CHECK-ERR-DAG: KLEE: ERROR: {{.*}} Symbolic string pointer passed to one of the klee_ functions
 
   klee_make_symbolic(&c);
-// CHECK-ERR: KLEE: ERROR: {{.*}} illegal number of arguments to klee_make_symbolic(void*, size_t, char*)
+  //CHECK-ERR-DAG: KLEE: ERROR: {{.*}} illegal number of arguments to klee_make_symbolic(void*, size_t, char*)
 }


### PR DESCRIPTION
As discussed in #841.

I'm not sure how good returning `""` on error is, but I guess it works.