### PR TITLE
use the more modern nullptr instead of NULL

### DIFF
--- a/include/expr/Parser.h
+++ b/include/expr/Parser.h
@@ -218,7 +218,7 @@ namespace expr {
     /// ParseTopLevelDecl - Parse and return a top level declaration,
     /// which the caller assumes ownership of.
     ///
-    /// \return NULL indicates the end of the file has been reached.
+    /// \return nullptr indicates the end of the file has been reached.
     virtual Decl *ParseTopLevelDecl() = 0;
 
     /// CreateParser - Create a parser implementation for the given

--- a/include/klee/Expr.h
+++ b/include/klee/Expr.h
@@ -697,7 +697,7 @@ public:
   ref<Expr> getKid(unsigned i) const { 
     if (i == 0) return left; 
     else if (i == 1) return right;
-    else return NULL;
+    else return nullptr;
   }
 
   /// Shortcuts to create larger concats.  The chain returned is unbalanced to the right

--- a/include/klee/Internal/ADT/KTest.h
+++ b/include/klee/Internal/ADT/KTest.h
@@ -44,7 +44,7 @@ extern "C" {
   /* return true iff file at path matches KTest header */
   int   kTest_isKTestFile(const char *path);
 
-  /* returns NULL on (unspecified) error */
+  /* returns a nullptr on (unspecified) error */
   KTest* kTest_fromFile(const char *path);
 
   /* returns 1 on success, 0 on (unspecified) error */

--- a/include/klee/Internal/Module/KModule.h
+++ b/include/klee/Internal/Module/KModule.h
@@ -70,7 +70,7 @@ namespace klee {
     /// The constant ID.
     unsigned id;
 
-    /// First instruction where this constant was encountered, or NULL
+    /// First instruction where this constant was encountered, or nullptr
     /// if not applicable/unavailable.
     KInstruction *ki;
 

--- a/include/klee/SolverImpl.h
+++ b/include/klee/SolverImpl.h
@@ -100,7 +100,7 @@ namespace klee {
 
     virtual char *getConstraintLog(const Query& query)  {
         // dummy
-        return(NULL);
+        return nullptr;
     }
 
     virtual void setCoreSolverTimeout(double timeout) {};

--- a/include/klee/util/ArrayCache.h
+++ b/include/klee/util/ArrayCache.h
@@ -29,7 +29,7 @@ namespace klee {
 
 struct EquivArrayCmpFn {
   bool operator()(const Array *array1, const Array *array2) const {
-    if (array1 == NULL || array2 == NULL)
+    if (array1 == nullptr || array2 == nullptr)
       return false;
     return (array1->size == array2->size) && (array1->name == array2->name);
   }
@@ -53,10 +53,10 @@ public:
   /// \param _size The size of the array in bytes
   /// \param constantValuesBegin A pointer to the beginning of a block of
   //         memory that constains a ``ref<ConstantExpr>`` (i.e. concrete values
-  //         for the //array). This should be NULL for symbolic arrays.
+  //         for the //array). This should be a nullptr for symbolic arrays.
   /// for symbolic arrays.
   /// \param constantValuesEnd A pointer +1 pass the end of a block of memory
-  ///        that contains a ``ref<ConstantExpr>``. This should be NULL for a
+  ///        that contains a ``ref<ConstantExpr>``. This should be a nullptr for a
   ///        symbolic array.
   /// \param _domain The size of the domain (i.e. the bitvector used to index
   /// the array)

--- a/include/klee/util/Ref.h
+++ b/include/klee/util/Ref.h
@@ -31,8 +31,8 @@ class ref {
   T *ptr;
 
 public:
-  // default constructor: create a NULL reference
-  ref() : ptr(0) { }
+  // default constructor: create a nullptr reference
+  ref() : ptr(nullptr) { }
   ~ref () { dec (); }
 
 private:
@@ -96,7 +96,7 @@ public:
     return ptr;
   }
 
-  bool isNull() const { return ptr == 0; }
+  bool isNull() const { return ptr == nullptr; }
 
   // assumes non-null arguments
   int compare(const ref &rhs) const {

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -679,7 +679,7 @@ void Executor::branch(ExecutionState &state,
       if (i == next) {
         result.push_back(&state);
       } else {
-        result.push_back(NULL);
+        result.push_back(nullptr);
       }
     }
   } else {
@@ -741,7 +741,7 @@ void Executor::branch(ExecutionState &state,
       for (unsigned i=0; i<N; ++i) {
         if (result[i] && !seedMap.count(result[i])) {
           terminateState(*result[i]);
-          result[i] = NULL;
+          result[i] = nullptr;
         }
       } 
     }
@@ -2415,7 +2415,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     ref<Expr> agg = eval(ki, 0, state).value;
     ref<Expr> val = eval(ki, 1, state).value;
 
-    ref<Expr> l = NULL, r = NULL;
+    ref<Expr> l = nullptr, r = nullptr;
     unsigned lOffset = kgepi->offset*8, rOffset = kgepi->offset*8 + val->getWidth();
 
     if (lOffset > 0)
@@ -2457,7 +2457,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     ref<Expr> idx = eval(ki, 2, state).value;
 
     ConstantExpr *cIdx = dyn_cast<ConstantExpr>(idx);
-    if (cIdx == NULL) {
+    if (cIdx == nullptr) {
       terminateStateOnError(
           state, "InsertElement, support for symbolic index not implemented",
           Unhandled);
@@ -2495,7 +2495,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     ref<Expr> idx = eval(ki, 1, state).value;
 
     ConstantExpr *cIdx = dyn_cast<ConstantExpr>(idx);
-    if (cIdx == NULL) {
+    if (cIdx == nullptr) {
       terminateStateOnError(
           state, "ExtractElement, support for symbolic index not implemented",
           Unhandled);
@@ -3265,7 +3265,7 @@ void Executor::executeAlloc(ExecutionState &state,
           info << "  concretization : " << example << "\n";
           info << "  unbound example: " << tmp << "\n";
           terminateStateOnError(*hugeSize.second, "concretized symbolic size",
-                                Model, NULL, info.str());
+                                Model, nullptr, info.str());
         }
       }
     }
@@ -3292,10 +3292,10 @@ void Executor::executeFree(ExecutionState &state,
            ie = rl.end(); it != ie; ++it) {
       const MemoryObject *mo = it->first.first;
       if (mo->isLocal) {
-        terminateStateOnError(*it->second, "free of alloca", Free, NULL,
+        terminateStateOnError(*it->second, "free of alloca", Free, nullptr,
                               getAddressInfo(*it->second, address));
       } else if (mo->isGlobal) {
-        terminateStateOnError(*it->second, "free of global", Free, NULL,
+        terminateStateOnError(*it->second, "free of global", Free, nullptr,
                               getAddressInfo(*it->second, address));
       } else {
         it->second->addressSpace.unbindObject(mo);
@@ -3331,7 +3331,7 @@ void Executor::resolveExact(ExecutionState &state,
 
   if (unbound) {
     terminateStateOnError(*unbound, "memory error: invalid pointer: " + name,
-                          Ptr, NULL, getAddressInfo(*unbound, p));
+                          Ptr, nullptr, getAddressInfo(*unbound, p));
   }
 }
 
@@ -3452,7 +3452,7 @@ void Executor::executeMemoryOperation(ExecutionState &state,
       terminateStateEarly(*unbound, "Query timed out (resolve).");
     } else {
       terminateStateOnError(*unbound, "memory error: out of bound pointer", Ptr,
-                            NULL, getAddressInfo(*unbound, address));
+                            nullptr, getAddressInfo(*unbound, address));
     }
   }
 }
@@ -3602,7 +3602,7 @@ void Executor::runFunctionAsMain(Function *f,
 
     for (int i=0; i<argc+1+envc+1+1; i++) {
       if (i==argc || i>=argc+1+envc) {
-        // Write NULL pointer
+        // Write a nullptr
         argvOS->write(i * NumPtrBytes, Expr::createPointer(0));
       } else {
         char *s = i<argc ? argv[i] : envp[i-(argc+1)];
@@ -3633,7 +3633,7 @@ void Executor::runFunctionAsMain(Function *f,
 
   // hack to clear memory objects
   delete memory;
-  memory = new MemoryManager(NULL);
+  memory = new MemoryManager(nullptr);
 
   globalObjects.clear();
   globalAddresses.clear();
@@ -3789,7 +3789,7 @@ size_t Executor::getAllocationAlignment(const llvm::Value *allocSite) const {
   // and should fetch the default from elsewhere.
   const size_t forcedAlignment = 8;
   size_t alignment = 0;
-  llvm::Type *type = NULL;
+  llvm::Type *type = nullptr;
   std::string allocationSiteName(allocSite->getName().str());
   if (const GlobalValue *GV = dyn_cast<GlobalValue>(allocSite)) {
     alignment = GV->getAlignment();
@@ -3816,7 +3816,7 @@ size_t Executor::getAllocationAlignment(const llvm::Value *allocSite) const {
     if (fn)
       allocationSiteName = fn->getName().str();
 
-    klee_warning_once(fn != NULL ? fn : allocSite,
+    klee_warning_once(fn != nullptr ? fn : allocSite,
                       "Alignment of memory from call \"%s\" is not "
                       "modelled. Using alignment of %zu.",
                       allocationSiteName.c_str(), forcedAlignment);
@@ -3826,7 +3826,7 @@ size_t Executor::getAllocationAlignment(const llvm::Value *allocSite) const {
   }
 
   if (alignment == 0) {
-    assert(type != NULL);
+    assert(type != nullptr);
     // No specified alignment. Get the alignment for the type.
     if (type->isSized()) {
       alignment = kmodule->targetData->getPrefTypeAlignment(type);

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -325,7 +325,7 @@ private:
   /// Create a new state where each input condition has been added as
   /// a constraint and return the results. The input state is included
   /// as one of the results. Note that the output vector may included
-  /// NULL pointers for states which were unable to be created.
+  /// nullptrs for states which were unable to be created.
   void branch(ExecutionState &state, 
               const std::vector< ref<Expr> > &conditions,
               std::vector<ExecutionState*> &result);
@@ -368,16 +368,16 @@ private:
                     ref<Expr> value);
 
   /// Evaluates an LLVM constant expression.  The optional argument ki
-  /// is the instruction where this constant was encountered, or NULL
+  /// is the instruction where this constant was encountered, or nullptr
   /// if not applicable/unavailable.
   ref<klee::ConstantExpr> evalConstantExpr(const llvm::ConstantExpr *c,
-					   const KInstruction *ki = NULL);
+					   const KInstruction *ki = nullptr);
 
   /// Evaluates an LLVM constant.  The optional argument ki is the
-  /// instruction where this constant was encountered, or NULL if
+  /// instruction where this constant was encountered, or nullptr if
   /// not applicable/unavailable.
   ref<klee::ConstantExpr> evalConstant(const llvm::Constant *c,
-				       const KInstruction *ki = NULL);
+				       const KInstruction *ki = nullptr);
 
   /// Return a unique constant value for the given expression in the
   /// given state, if it has one (i.e. it provably only has a single
@@ -420,7 +420,7 @@ private:
   // call error handler and terminate state
   void terminateStateOnError(ExecutionState &state, const llvm::Twine &message,
                              enum TerminateReason termReason,
-                             const char *suffix = NULL,
+                             const char *suffix = nullptr,
                              const llvm::Twine &longMessage = "");
 
   // call error handler and terminate state, for execution errors
@@ -429,7 +429,7 @@ private:
   void terminateStateOnExecError(ExecutionState &state, 
                                  const llvm::Twine &message,
                                  const llvm::Twine &info="") {
-    terminateStateOnError(state, message, Exec, NULL, info);
+    terminateStateOnError(state, message, Exec, nullptr, info);
   }
 
   /// bindModuleConstants - Initialize the module constant table.

--- a/lib/Core/ExternalDispatcher.cpp
+++ b/lib/Core/ExternalDispatcher.cpp
@@ -194,7 +194,7 @@ bool ExternalDispatcherImpl::executeCall(Function *f, Instruction *i,
   }
 #endif
 
-  Module *dispatchModule = NULL;
+  Module *dispatchModule = nullptr;
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
   // The MCJIT generates whole modules at a time so for every call that we
   // haven't made before we need to create a new Module.

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -172,7 +172,7 @@ ObjectState::~ObjectState() {
 }
 
 ArrayCache *ObjectState::getArrayCache() const {
-  assert(object && "object was NULL");
+  assert(object && "object was a nullptr");
   return object->parent->getArrayCache();
 }
 

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -79,7 +79,7 @@ public:
       address(_address),
       size(0),
       isFixed(true),
-      parent(NULL),
+      parent(nullptr),
       allocSite(0) {
   }
 

--- a/lib/Core/MemoryManager.cpp
+++ b/lib/Core/MemoryManager.cpp
@@ -36,7 +36,7 @@ llvm::cl::opt<unsigned> DeterministicAllocationSize(
 
 llvm::cl::opt<bool>
     NullOnZeroMalloc("return-null-on-zero-malloc",
-                     llvm::cl::desc("Returns NULL in case malloc(size) was "
+                     llvm::cl::desc("Returns a null pointer in case malloc(size) was "
                                     "called with size 0 (default=off)."),
                      llvm::cl::init(false));
 
@@ -100,13 +100,13 @@ MemoryObject *MemoryManager::allocate(uint64_t size, bool isLocal,
                          " bytes.  KLEE may run out of memory.",
                       size);
 
-  // Return NULL if size is zero, this is equal to error during allocation
+  // Return a nullptr if size is zero, this is equal to error during allocation
   if (NullOnZeroMalloc && size == 0)
-    return 0;
+    return nullptr;
 
   if (!llvm::isPowerOf2_64(alignment)) {
     klee_warning("Only alignment of power of two is supported");
-    return 0;
+    return nullptr;
   }
 
   uint64_t address = 0;
@@ -140,7 +140,7 @@ MemoryObject *MemoryManager::allocate(uint64_t size, bool isLocal,
   }
 
   if (!address)
-    return 0;
+    return nullptr;
 
   ++stats::allocations;
   MemoryObject *res = new MemoryObject(address, size, isLocal, isGlobal, false,

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -146,8 +146,8 @@ SpecialFunctionHandler::const_iterator SpecialFunctionHandler::begin() {
 }
 
 SpecialFunctionHandler::const_iterator SpecialFunctionHandler::end() {
-  // NULL pointer is sentinel
-  return SpecialFunctionHandler::const_iterator(0);
+  // use nullptr as a sentinel
+  return SpecialFunctionHandler::const_iterator(nullptr);
 }
 
 SpecialFunctionHandler::const_iterator& SpecialFunctionHandler::const_iterator::operator++() {
@@ -706,7 +706,7 @@ void SpecialFunctionHandler::handleCheckMemoryAccess(ExecutionState &state,
     if (!state.addressSpace.resolveOne(cast<ConstantExpr>(address), op)) {
       executor.terminateStateOnError(state,
                                      "check_memory_access: memory error",
-				     Executor::Ptr, NULL,
+				     Executor::Ptr, nullptr,
                                      executor.getAddressInfo(state, address));
     } else {
       ref<Expr> chk = 
@@ -715,7 +715,7 @@ void SpecialFunctionHandler::handleCheckMemoryAccess(ExecutionState &state,
       if (!chk->isTrue()) {
         executor.terminateStateOnError(state,
                                        "check_memory_access: memory error",
-				       Executor::Ptr, NULL,
+				       Executor::Ptr, nullptr,
                                        executor.getAddressInfo(state, address));
       }
     }

--- a/lib/Core/UserSearcher.cpp
+++ b/lib/Core/UserSearcher.cpp
@@ -82,7 +82,7 @@ bool klee::userSearcherRequiresMD2U() {
 
 
 Searcher *getNewSearcher(Searcher::CoreSearchType type, Executor &executor) {
-  Searcher *searcher = NULL;
+  Searcher *searcher = nullptr;
   switch (type) {
   case Searcher::DFS: searcher = new DFSSearcher(); break;
   case Searcher::BFS: searcher = new BFSSearcher(); break;

--- a/lib/Expr/ExprPPrinter.cpp
+++ b/lib/Expr/ExprPPrinter.cpp
@@ -228,7 +228,7 @@ private:
     // right now, all Reads are byte reads but some
     // transformations might change this
     if (!base || base->getWidth() != Expr::Int8)
-      return NULL;
+      return nullptr;
     
     // Get stride expr in proper index width.
     Expr::Width idxWidth = base->index->getWidth();
@@ -241,14 +241,14 @@ private:
     while (e->getKind() == Expr::Concat) {
       offset = AddExpr::create(offset, strideExpr);
       if (!isReadExprAtOffset(e->getKid(0), base, offset))
-	return NULL;
+	return nullptr;
       
       e = e->getKid(1);
     }
     
     offset = AddExpr::create(offset, strideExpr);
     if (!isReadExprAtOffset(e, base, offset))
-      return NULL;
+      return nullptr;
     
     if (stride == -1)
       return cast<ReadExpr>(e.get());
@@ -380,7 +380,7 @@ public:
         // a declaration.
         if (PCMultibyteReads && e->getKind() == Expr::Concat) {
 	  const ReadExpr *base = hasOrderedReads(e, -1);
-	  int isLSB = (base != NULL);
+	  int isLSB = (base != nullptr);
 	  if (!isLSB)
 	    base = hasOrderedReads(e, 1);
 	  if (base) {

--- a/lib/Expr/ExprSMTLIBPrinter.cpp
+++ b/lib/Expr/ExprSMTLIBPrinter.cpp
@@ -52,10 +52,10 @@ llvm::cl::opt<klee::ExprSMTLIBPrinter::AbbreviationMode> abbreviationMode(
 namespace klee {
 
 ExprSMTLIBPrinter::ExprSMTLIBPrinter()
-    : usedArrays(), o(NULL), query(NULL), p(NULL), haveConstantArray(false),
+    : usedArrays(), o(nullptr), query(nullptr), p(nullptr), haveConstantArray(false),
       logicToUse(QF_AUFBV),
       humanReadable(ExprSMTLIBOptions::humanReadableSMTLIB),
-      smtlibBoolOptions(), arraysToCallGetValueOn(NULL) {
+      smtlibBoolOptions(), arraysToCallGetValueOn(nullptr) {
   setConstantDisplayMode(ExprSMTLIBOptions::argConstantDisplayMode);
   setAbbreviationMode(ExprSMTLIBOptions::abbreviationMode);
 }
@@ -88,10 +88,10 @@ void ExprSMTLIBPrinter::reset() {
    * We need to do this because the next query might not need the
    * (get-value) SMT-LIBv2 command.
    */
-  if (arraysToCallGetValueOn != NULL)
+  if (arraysToCallGetValueOn != nullptr)
     setSMTLIBboolOption(PRODUCE_MODELS, OPTION_DEFAULT);
 
-  arraysToCallGetValueOn = NULL;
+  arraysToCallGetValueOn = nullptr;
 }
 
 bool ExprSMTLIBPrinter::isHumanReadable() { return humanReadable; }
@@ -473,7 +473,7 @@ const char *ExprSMTLIBPrinter::getSMTLIBKeyword(const ref<Expr> &e) {
 
 void ExprSMTLIBPrinter::printUpdatesAndArray(const UpdateNode *un,
                                              const Array *root) {
-  if (un != NULL) {
+  if (un != nullptr) {
     *p << "(store ";
     p->pushIndent();
     printSeperator();
@@ -514,7 +514,7 @@ void ExprSMTLIBPrinter::scanAll() {
 }
 
 void ExprSMTLIBPrinter::generateOutput() {
-  if (p == NULL || query == NULL || o == NULL) {
+  if (p == nullptr || query == nullptr || o == nullptr) {
     llvm::errs() << "ExprSMTLIBPrinter::generateOutput() Can't print SMTLIBv2. "
                     "Output or query bad!\n";
     return;
@@ -672,7 +672,7 @@ void ExprSMTLIBPrinter::printAction() {
   /* If we have arrays to find the values of then we'll
    * ask the solver for the value of each bitvector in each array
    */
-  if (arraysToCallGetValueOn != NULL && !arraysToCallGetValueOn->empty()) {
+  if (arraysToCallGetValueOn != nullptr && !arraysToCallGetValueOn->empty()) {
 
     const Array *theArray = 0;
 
@@ -691,7 +691,7 @@ void ExprSMTLIBPrinter::printAction() {
 }
 
 void ExprSMTLIBPrinter::scan(const ref<Expr> &e) {
-  assert(!(e.isNull()) && "found NULL expression");
+  assert(!(e.isNull()) && "found null expression");
 
   if (isa<ConstantExpr>(e))
     return; // we don't need to scan simple constants
@@ -817,7 +817,7 @@ void ExprSMTLIBPrinter::scanBindingExprDeps() {
 }
 
 void ExprSMTLIBPrinter::scanUpdates(const UpdateNode *un) {
-  while (un != NULL) {
+  while (un != nullptr) {
     scan(un->index);
     scan(un->value);
     un = un->next;

--- a/lib/Expr/Parser.cpp
+++ b/lib/Expr/Parser.cpp
@@ -534,7 +534,7 @@ DeclResult ParserImpl::ParseArrayDecl() {
 
   // Create the initial version reference.
   VersionSymTab.insert(std::make_pair(Label,
-                                      UpdateList(Root, NULL)));
+                                      UpdateList(Root, nullptr)));
 
   return AD;
 }
@@ -582,7 +582,7 @@ DeclResult ParserImpl::ParseQueryCommand() {
   for (std::map<const Identifier*, const ArrayDecl*>::iterator
          it = ArraySymTab.begin(), ie = ArraySymTab.end(); it != ie; ++it) {
     VersionSymTab.insert(std::make_pair(it->second->Name,
-                                        UpdateList(it->second->Root, NULL)));
+                                        UpdateList(it->second->Root, nullptr)));
   }
 
 
@@ -1298,7 +1298,7 @@ VersionResult ParserImpl::ParseVersionSpecifier() {
       
       if (it == VersionSymTab.end()) {
         Error("invalid version reference.", LTok);
-        return VersionResult(false, UpdateList(0, NULL));
+        return VersionResult(false, UpdateList(0, nullptr));
       }
 
       return it->second;
@@ -1316,7 +1316,7 @@ VersionResult ParserImpl::ParseVersionSpecifier() {
   if (!Res.isValid()) {
     // FIXME: I'm not sure if this is right. Do we need a unique array here?
     Res =
-        VersionResult(true, UpdateList(TheArrayCache.CreateArray("", 0), NULL));
+        VersionResult(true, UpdateList(TheArrayCache.CreateArray("", 0), nullptr));
   }
   
   if (Label)
@@ -1345,7 +1345,7 @@ namespace {
 /// update-list - lhs '=' rhs [',' update-list]
 VersionResult ParserImpl::ParseVersion() {
   if (Tok.kind != Token::LSquare)
-    return VersionResult(false, UpdateList(0, NULL));
+    return VersionResult(false, UpdateList(0, nullptr));
   
   std::vector<WriteInfo> Writes;
   ConsumeLSquare();
@@ -1371,11 +1371,11 @@ VersionResult ParserImpl::ParseVersion() {
   }
   ExpectRSquare("expected close of update list");
 
-  VersionHandle Base(0, NULL);
+  VersionHandle Base(0, nullptr);
 
   if (Tok.kind != Token::At) {
     Error("expected '@'.", Tok);
-    return VersionResult(false, UpdateList(0, NULL));
+    return VersionResult(false, UpdateList(0, nullptr));
   } 
 
   ConsumeExpectedToken(Token::At);

--- a/lib/Module/Checks.cpp
+++ b/lib/Module/Checks.cpp
@@ -58,7 +58,7 @@ bool DivCheckPass::runOnModule(Module &M) {
               Constant *fc = M.getOrInsertFunction("klee_div_zero_check", 
                                                    Type::getVoidTy(ctx),
                                                    Type::getInt64Ty(ctx),
-                                                   NULL);
+                                                   nullptr);
               divZeroCheckFunction = cast<Function>(fc);
             }
 
@@ -119,7 +119,7 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
                                                    Type::getVoidTy(ctx),
                                                    Type::getInt64Ty(ctx),
                                                    Type::getInt64Ty(ctx),
-                                                   NULL);
+                                                   nullptr);
               overshiftCheckFunction = cast<Function>(fc);
             }
 

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -196,7 +196,7 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         // a call of the abort() function.
         Function *F = cast<Function>(
           M.getOrInsertFunction(
-            "abort", Type::getVoidTy(ctx), NULL));
+            "abort", Type::getVoidTy(ctx), nullptr));
         F->setDoesNotReturn();
         F->setDoesNotThrow();
 
@@ -217,7 +217,7 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         ConstantInt *minArgAsInt = dyn_cast<ConstantInt>(minArg);
         assert(minArgAsInt && "Second arg is not a ConstantInt");
         assert(minArgAsInt->getBitWidth() == 1 && "Second argument is not an i1");
-        Value *replacement = NULL;
+        Value *replacement = nullptr;
         IntegerType *intType = dyn_cast<IntegerType>(ii->getType());
         assert(intType && "intrinsic does not have integer return type");
         if (minArgAsInt->isZero()) {

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -325,7 +325,7 @@ KConstant* KModule::getKConstant(const Constant *c) {
   std::map<const llvm::Constant*, KConstant*>::iterator it = constantMap.find(c);
   if (it != constantMap.end())
     return it->second;
-  return NULL;
+  return nullptr;
 }
 
 unsigned KModule::getConstantID(Constant *c, KInstruction* ki) {

--- a/lib/Module/ModuleUtil.cpp
+++ b/lib/Module/ModuleUtil.cpp
@@ -279,7 +279,7 @@ static bool linkBCA(object::Archive* archive, Module* composite, std::string& er
       }
       else
       {
-        errorMessage="Buffer was NULL!";
+        errorMessage="Buffer was a nullptr!";
         return false;
       }
 
@@ -510,22 +510,22 @@ Function *klee::getDirectCallTarget(CallSite cs, bool moduleIsFullyLinked) {
       if (moduleIsFullyLinked || !(ga->mayBeOverridden())) {
         v = ga->getAliasee();
       } else {
-        v = NULL;
+        v = nullptr;
       }
     } else if (llvm::ConstantExpr *ce = dyn_cast<llvm::ConstantExpr>(v)) {
       viaConstantExpr = true;
       v = ce->getOperand(0)->stripPointerCasts();
     } else {
-      v = NULL;
+      v = nullptr;
     }
-  } while (v != NULL);
+  } while (v != nullptr);
 
   // NOTE: This assert may fire, it isn't necessarily a problem and
   // can be disabled, I just wanted to know when and if it happened.
   (void) viaConstantExpr;
   assert((!viaConstantExpr) &&
          "FIXME: Unresolved direct target for a constant expression");
-  return NULL;
+  return nullptr;
 }
 
 static bool valueIsOnlyCalled(const Value *v) {

--- a/lib/Solver/AssignmentValidatingSolver.cpp
+++ b/lib/Solver/AssignmentValidatingSolver.cpp
@@ -67,7 +67,7 @@ bool AssignmentValidatingSolver::computeInitialValues(
     ref<Expr> constraint = *it;
     ref<Expr> constraintEvaluated = assignment.evaluate(constraint);
     ConstantExpr *CE = dyn_cast<ConstantExpr>(constraintEvaluated);
-    if (CE == NULL) {
+    if (CE == nullptr) {
       llvm::errs() << "Constraint did not evalaute to a constant:\n";
       llvm::errs() << "Constraint:\n" << constraint << "\n";
       llvm::errs() << "Evaluated Constraint:\n" << constraintEvaluated << "\n";
@@ -88,7 +88,7 @@ bool AssignmentValidatingSolver::computeInitialValues(
 
   ref<Expr> queryExprEvaluated = assignment.evaluate(query.expr);
   ConstantExpr *CE = dyn_cast<ConstantExpr>(queryExprEvaluated);
-  if (CE == NULL) {
+  if (CE == nullptr) {
     llvm::errs() << "Query expression did not evalaute to a constant:\n";
     llvm::errs() << "Expression:\n" << query.expr << "\n";
     llvm::errs() << "Evaluated expression:\n" << queryExprEvaluated << "\n";

--- a/lib/Solver/CoreSolver.cpp
+++ b/lib/Solver/CoreSolver.cpp
@@ -27,7 +27,7 @@ Solver *createCoreSolver(CoreSolverType cst) {
     return new STPSolver(UseForkedCoreSolver, CoreSolverOptimizeDivides);
 #else
     klee_message("Not compiled with STP support");
-    return NULL;
+    return nullptr;
 #endif
   case METASMT_SOLVER:
 #ifdef ENABLE_METASMT
@@ -35,7 +35,7 @@ Solver *createCoreSolver(CoreSolverType cst) {
     return createMetaSMTSolver();
 #else
     klee_message("Not compiled with MetaSMT support");
-    return NULL;
+    return nullptr;
 #endif
   case DUMMY_SOLVER:
     return createDummySolver();
@@ -45,11 +45,11 @@ Solver *createCoreSolver(CoreSolverType cst) {
     return new Z3Solver();
 #else
     klee_message("Not compiled with Z3 support");
-    return NULL;
+    return nullptr;
 #endif
   case NO_SOLVER:
     klee_message("Invalid solver");
-    return NULL;
+    return nullptr;
   default:
     llvm_unreachable("Unsupported CoreSolverType");
   }

--- a/lib/Solver/MetaSMTSolver.cpp
+++ b/lib/Solver/MetaSMTSolver.cpp
@@ -126,9 +126,9 @@ MetaSMTSolverImpl<SolverContext>::MetaSMTSolverImpl(
     shared_memory_id =
         shmget(IPC_PRIVATE, shared_memory_size, IPC_CREAT | 0700);
     assert(shared_memory_id >= 0 && "shmget failed");
-    shared_memory_ptr = (unsigned char *)shmat(shared_memory_id, NULL, 0);
+    shared_memory_ptr = (unsigned char *)shmat(shared_memory_id, nullptr, 0);
     assert(shared_memory_ptr != (void *)-1 && "shmat failed");
-    shmctl(shared_memory_id, IPC_RMID, NULL);
+    shmctl(shared_memory_id, IPC_RMID, nullptr);
   }
 }
 
@@ -426,7 +426,7 @@ void MetaSMTSolver<SolverContext>::setCoreSolverTimeout(double timeout) {
 Solver *createMetaSMTSolver() {
   using namespace metaSMT;
 
-  Solver *coreSolver = NULL;
+  Solver *coreSolver = nullptr;
   std::string backend;
   switch (MetaSMTBackend) {
 #ifdef METASMT_HAVE_STP

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -110,10 +110,10 @@ STPSolverImpl::STPSolverImpl(bool _useForkedSTP, bool _optimizeDivides)
         shmget(IPC_PRIVATE, shared_memory_size, IPC_CREAT | 0700);
     if (shared_memory_id < 0)
       llvm::report_fatal_error("unable to allocate shared memory region");
-    shared_memory_ptr = (unsigned char *)shmat(shared_memory_id, NULL, 0);
+    shared_memory_ptr = (unsigned char *)shmat(shared_memory_id, nullptr, 0);
     if (shared_memory_ptr == (void *)-1)
       llvm::report_fatal_error("unable to attach shared memory region");
-    shmctl(shared_memory_id, IPC_RMID, NULL);
+    shmctl(shared_memory_id, IPC_RMID, nullptr);
   }
 }
 

--- a/lib/Solver/Z3Builder.h
+++ b/lib/Solver/Z3Builder.h
@@ -32,7 +32,7 @@ private:
   inline ::Z3_ast as_ast();
 
 public:
-  Z3NodeHandle() : node(NULL), context(NULL) {}
+  Z3NodeHandle() : node(nullptr), context(nullptr) {}
   Z3NodeHandle(const T _node, const ::Z3_context _context)
       : node(_node), context(_context) {
     if (node && context) {
@@ -50,15 +50,15 @@ public:
     }
   }
   Z3NodeHandle &operator=(const Z3NodeHandle &b) {
-    if (node == NULL && context == NULL) {
+    if (node == nullptr && context == nullptr) {
       // Special case for when this object was constructed
       // using the default constructor. Try to inherit a non null
       // context.
       context = b.context;
     }
     assert(context == b.context && "Mismatched Z3 contexts!");
-    // node != nullptr ==> context != NULL
-    assert((node == NULL || context) &&
+    // node != nullptr ==> context != nullptr
+    assert((node == nullptr || context) &&
            "Can't have non nullptr node with nullptr context");
 
     if (node && context) {

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -95,7 +95,7 @@ Z3SolverImpl::Z3SolverImpl()
           /*autoClearConstructCache=*/false,
           /*z3LogInteractionFileArg=*/Z3LogInteractionFile.size() > 0
               ? Z3LogInteractionFile.c_str()
-              : NULL)),
+              : nullptr)),
       timeout(0.0), runStatusCode(SOLVER_RUN_STATUS_FAILURE),
       dumpedQueriesFile(0) {
   assert(builder && "unable to create Z3Builder");
@@ -152,7 +152,7 @@ char *Z3SolverImpl::getConstraintLog(const Query &query) {
   // NOTE: The builder does not set `z3LogInteractionFile` to avoid conflicting
   // with whatever the solver's builder is set to do.
   Z3Builder temp_builder(/*autoClearConstructCache=*/false,
-                         /*z3LogInteractionFile=*/NULL);
+                         /*z3LogInteractionFile=*/nullptr);
   ConstantArrayFinder constant_arrays_in_query;
   for (auto const &constraint : query.constraints) {
     assumptions.push_back(temp_builder.construct(constraint));
@@ -178,7 +178,7 @@ char *Z3SolverImpl::getConstraintLog(const Query &query) {
     }
   }
 
-  ::Z3_ast *assumptionsArray = NULL;
+  ::Z3_ast *assumptionsArray = nullptr;
   int numAssumptions = assumptions.size();
   if (numAssumptions) {
     assumptionsArray = (::Z3_ast *)malloc(sizeof(::Z3_ast) * numAssumptions);
@@ -204,7 +204,7 @@ char *Z3SolverImpl::getConstraintLog(const Query &query) {
   // We do this indirectly by emptying `assumptions` and assigning to
   // `formula`.
   assumptions.clear();
-  formula = Z3ASTHandle(NULL, temp_builder.ctx);
+  formula = Z3ASTHandle(nullptr, temp_builder.ctx);
   // Client is responsible for freeing the returned C-string
   return strdup(result);
 }
@@ -212,7 +212,7 @@ char *Z3SolverImpl::getConstraintLog(const Query &query) {
 bool Z3SolverImpl::computeTruth(const Query &query, bool &isValid) {
   bool hasSolution;
   bool status =
-      internalRunSolver(query, /*objects=*/NULL, /*values=*/NULL, hasSolution);
+      internalRunSolver(query, /*objects=*/nullptr, /*values=*/nullptr, hasSolution);
   isValid = !hasSolution;
   return status;
 }
@@ -332,7 +332,7 @@ SolverImpl::SolverRunStatus Z3SolverImpl::handleSolverResponse(
     hasSolution = true;
     if (!objects) {
       // No assignment is needed
-      assert(values == NULL);
+      assert(values == nullptr);
       return SolverImpl::SOLVER_RUN_STATUS_SUCCESS_SOLVABLE;
     }
     assert(values && "values cannot be nullptr");

--- a/lib/Support/ErrorHandling.cpp
+++ b/lib/Support/ErrorHandling.cpp
@@ -23,8 +23,8 @@
 using namespace klee;
 using namespace llvm;
 
-FILE *klee::klee_warning_file = NULL;
-FILE *klee::klee_message_file = NULL;
+FILE *klee::klee_warning_file = nullptr;
+FILE *klee::klee_message_file = nullptr;
 
 static const char *warningPrefix = "WARNING";
 static const char *warningOncePrefix = "WARNING ONCE";
@@ -104,7 +104,7 @@ static void klee_vfmessage(FILE *fp, const char *pfx, const char *msg,
 
 /* Prints a message/warning.
 
-   If pfx is NULL, this is a regular message, and it's sent to
+   If pfx is a nullptr, this is a regular message, and it's sent to
    klee_message_file (messages.txt).  Otherwise, it is sent to
    klee_warning_file (warnings.txt).
 
@@ -125,7 +125,7 @@ static void klee_vmessage(const char *pfx, bool onlyToFile, const char *msg,
 void klee::klee_message(const char *msg, ...) {
   va_list ap;
   va_start(ap, msg);
-  klee_vmessage(NULL, false, msg, ap);
+  klee_vmessage(nullptr, false, msg, ap);
   va_end(ap);
 }
 
@@ -133,7 +133,7 @@ void klee::klee_message(const char *msg, ...) {
 void klee::klee_message_to_file(const char *msg, ...) {
   va_list ap;
   va_start(ap, msg);
-  klee_vmessage(NULL, true, msg, ap);
+  klee_vmessage(nullptr, true, msg, ap);
   va_end(ap);
 }
 

--- a/lib/Support/FileHandling.cpp
+++ b/lib/Support/FileHandling.cpp
@@ -32,7 +32,7 @@ llvm::raw_fd_ostream *klee_open_output_file(std::string &path,
 #endif
   if (!error.empty()) {
     delete f;
-    f = NULL;
+    f = nullptr;
   }
   return f;
 }

--- a/tools/gen-random-bout/gen-random-bout.cpp
+++ b/tools/gen-random-bout/gen-random-bout.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
 
   if (argc < 2) {
     fprintf(stderr, "Usage: %s <random-seed> <argument-types>\n", argv[0]);
-    fprintf(stderr, "       If <random-seed> is 0, time(NULL)*getpid() is used as a seed\n");
+    fprintf(stderr, "       If <random-seed> is 0, time(nullptr)*getpid() is used as a seed\n");
     fprintf(stderr, "       <argument-types> are the ones accepted by KLEE: --sym-args, --sym-files etc.\n");
     fprintf(stderr, "   Ex: %s 100 --sym-args 0 2 2 --sym-files 1 8\n", argv[0]);
     exit(1);
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
   unsigned seed = atoi(argv[1]);
   if (seed)
     srandom(seed);
-  else srandom(time(NULL) * getpid());
+  else srandom(time(nullptr) * getpid());
 
   KTest b;
   b.numArgs = argc;

--- a/tools/kleaver/main.cpp
+++ b/tools/kleaver/main.cpp
@@ -371,8 +371,8 @@ static bool printInputAsSMTLIBv2(const char *Filename,
 			 * query(ConstraintManager(QC->Constraints),QC->Query);
 			 *
 			 * For some reason if constructed this way the first
-			 * constraint in the constraint set is set to NULL and
-			 * will later cause a NULL pointer dereference.
+			 * constraint in the constraint set is set to a nullptr and
+			 * will later cause a nullptr dereference.
 			 */
 			ConstraintManager constraintM(QC->Constraints);
 			Query query(constraintM,QC->Query);

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -320,12 +320,12 @@ KleeHandler::KleeHandler(int argc, char **argv)
 
   // open warnings.txt
   std::string file_path = getOutputFilename("warnings.txt");
-  if ((klee_warning_file = fopen(file_path.c_str(), "w")) == NULL)
+  if ((klee_warning_file = fopen(file_path.c_str(), "w")) == nullptr)
     klee_error("cannot open file \"%s\": %s", file_path.c_str(), strerror(errno));
 
   // open messages.txt
   file_path = getOutputFilename("messages.txt");
-  if ((klee_message_file = fopen(file_path.c_str(), "w")) == NULL)
+  if ((klee_message_file = fopen(file_path.c_str(), "w")) == nullptr)
     klee_error("cannot open file \"%s\": %s", file_path.c_str(), strerror(errno));
 
   // open info
@@ -372,7 +372,7 @@ llvm::raw_fd_ostream *KleeHandler::openOutputFile(const std::string &filename) {
                  "descriptors: try to increase the maximum number of open file "
                  "descriptors by using ulimit (%s).",
                  path.c_str(), Error.c_str());
-    return NULL;
+    return nullptr;
   }
   return f;
 }
@@ -664,7 +664,7 @@ static int initEnv(Module *mainModule) {
                                                    Type::getVoidTy(ctx),
                                                    argcPtr->getType(),
                                                    argvPtr->getType(),
-                                                   NULL));
+                                                   nullptr));
   assert(initEnvFn);
   std::vector<Value*> args;
   args.push_back(argcPtr);
@@ -1024,19 +1024,19 @@ static llvm::Module *linkWithUclibc(llvm::Module *mainModule, StringRef libDir) 
                                     PointerType::getUnqual(i8Ty),
                                     PointerType::getUnqual(i8Ty),
                                     PointerType::getUnqual(i8Ty),
-                                    NULL);
+                                    nullptr);
     mainModule->getOrInsertFunction("getutent",
                                     PointerType::getUnqual(i8Ty),
-                                    NULL);
+                                    nullptr);
     mainModule->getOrInsertFunction("__fgetc_unlocked",
                                     Type::getInt32Ty(ctx),
                                     PointerType::getUnqual(i8Ty),
-                                    NULL);
+                                    nullptr);
     mainModule->getOrInsertFunction("__fputc_unlocked",
                                     Type::getInt32Ty(ctx),
                                     Type::getInt32Ty(ctx),
                                     PointerType::getUnqual(i8Ty),
-                                    NULL);
+                                    nullptr);
   }
 
   f = mainModule->getFunction("__ctype_get_mb_cur_max");
@@ -1325,7 +1325,7 @@ int main(int argc, char **argv, char **envp) {
 
   char buf[256];
   time_t t[2];
-  t[0] = time(NULL);
+  t[0] = time(nullptr);
   strftime(buf, sizeof(buf), "Started: %Y-%m-%d %H:%M:%S\n", localtime(&t[0]));
   handler->getInfoStream() << buf;
   handler->getInfoStream().flush();
@@ -1426,7 +1426,7 @@ int main(int argc, char **argv, char **envp) {
     }
   }
 
-  t[1] = time(NULL);
+  t[1] = time(nullptr);
   strftime(buf, sizeof(buf), "Finished: %Y-%m-%d %H:%M:%S\n", localtime(&t[1]));
   handler->getInfoStream() << buf;
 

--- a/unittests/Assignment/AssignmentTest.cpp
+++ b/unittests/Assignment/AssignmentTest.cpp
@@ -30,6 +30,6 @@ TEST(AssignmentTest, FoldNotOptimized)
   // Now evaluate. The OptimizedExpr should be folded
   ref<Expr> evaluated = assignment.evaluate(read);
   const ConstantExpr* asConstant = dyn_cast<ConstantExpr>(evaluated);
-  ASSERT_TRUE(asConstant != NULL);
+  ASSERT_TRUE(asConstant != nullptr);
   ASSERT_EQ(asConstant->getZExtValue(), (unsigned) 128);
 }


### PR DESCRIPTION
Basically, I went through the code (C++ only) and replaced all instances of null pointers - including `NULL` and `0` - I could find through `nullptr` literals.

Beside being the more modern way to express a null pointer literal, it also avoids some programming pitfalls by only being convertible to pointer types, not integer types.

It is a common misconception that `NULL` is a null pointer literal, but since C++11, [http://en.cppreference.com/w/cpp/types/NULL](it evaluates to either `0` or `nullptr`), choice of the implementation. If the implementation decides to use `#define NULL nullptr`, just writing `nullptr` does not actually change anything, and if `#define NULL 0`, this is a strict improvement. Note that unlike in C, `#define NULL ((void*)0)` is *not* legal (see also C++11 §C3.2.4.).