### PR TITLE
Typefix in MemoryManager

### DIFF
--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -16,6 +16,7 @@
 
 #include "llvm/ADT/StringExtras.h"
 
+#include <cstdint>
 #include <vector>
 #include <string>
 
@@ -41,7 +42,7 @@ private:
 
 public:
   unsigned id;
-  uint64_t address;
+  std::uintptr_t address;
 
   /// size in bytes
   unsigned size;
@@ -73,7 +74,7 @@ public:
 public:
   // XXX this is just a temp hack, should be removed
   explicit
-  MemoryObject(uint64_t _address) 
+  MemoryObject(std::uintptr_t _address) 
     : refCount(0),
       id(counter++), 
       address(_address),
@@ -83,7 +84,7 @@ public:
       allocSite(0) {
   }
 
-  MemoryObject(uint64_t _address, unsigned _size, 
+  MemoryObject(std::uintptr_t _address, unsigned _size, 
                bool _isLocal, bool _isGlobal, bool _isFixed,
                const llvm::Value *_allocSite,
                MemoryManager *_parent)

--- a/lib/Core/MemoryManager.h
+++ b/lib/Core/MemoryManager.h
@@ -10,8 +10,8 @@
 #ifndef KLEE_MEMORYMANAGER_H
 #define KLEE_MEMORYMANAGER_H
 
+#include <cstdint>
 #include <set>
-#include <stdint.h>
 
 namespace llvm {
 class Value;
@@ -27,9 +27,9 @@ private:
   objects_ty objects;
   ArrayCache *const arrayCache;
 
-  char *deterministicSpace;
-  char *nextFreeSlot;
-  size_t spaceSize;
+  std::uintptr_t deterministicSpace;
+  std::uintptr_t nextFreeSlot;
+  std::size_t spaceSize;
 
 public:
   MemoryManager(ArrayCache *arrayCache);
@@ -39,9 +39,9 @@ public:
    * Returns memory object which contains a handle to real virtual process
    * memory.
    */
-  MemoryObject *allocate(uint64_t size, bool isLocal, bool isGlobal,
-                         const llvm::Value *allocSite, size_t alignment);
-  MemoryObject *allocateFixed(uint64_t address, uint64_t size,
+  MemoryObject *allocate(std::size_t size, bool isLocal, bool isGlobal,
+                         const llvm::Value *allocSite, std::size_t alignment);
+  MemoryObject *allocateFixed(std::uintptr_t address, std::size_t size,
                               const llvm::Value *allocSite);
   void deallocate(const MemoryObject *mo);
   void markFreed(MemoryObject *mo);
@@ -50,9 +50,9 @@ public:
   /*
    * Returns the size used by deterministic allocation in bytes
    */
-  size_t getUsedDeterministicSize();
+  std::size_t getUsedDeterministicSize();
 };
 
-} // End klee namespace
+} // namespace klee
 
 #endif


### PR DESCRIPTION
As of now, this pull request only fixes the types discussed in #891. While it should previously have been impossible to allocate more than 4GiB of deterministic heap (a combination of [using `unsigned`](https://github.com/klee/klee/blob/33964e5d935f903b2850f6576f93ce229fb00918/lib/Core/MemoryManager.cpp#L31) to represent the size and [doing arithmetic in `unsigned` space](https://github.com/klee/klee/blob/33964e5d935f903b2850f6576f93ce229fb00918/lib/Core/MemoryManager.cpp#L59)), I could find no reason for that restriction, so it should now be lifted.

It has, however, made me aware of two further restrictions due to the use of `unsigned` as a size type:
- [Memory Object IDs wrap after 4 billion MOs have been allocated](https://github.com/klee/klee/blob/33964e5d935f903b2850f6576f93ce229fb00918/lib/Core/Memory.h#L43), which is doubly problematic, as MOs are not local to one state (plus, the initialization of the id [causes UB after 2 billion objects, as the counter it is initialized from is `int`](https://github.com/klee/klee/blob/33964e5d935f903b2850f6576f93ce229fb00918/lib/Core/Memory.h#L39))
- [Memory Object size is limited to 4GiB](https://github.com/klee/klee/blob/33964e5d935f903b2850f6576f93ce229fb00918/lib/Core/Memory.h#L47) - note that "large object allocation" gives [a warning](https://github.com/klee/klee/blob/33964e5d935f903b2850f6576f93ce229fb00918/lib/Core/MemoryManager.cpp#L98-L101), not an error

While my preliminary look at this indicates that these restrictions are really quite unnecessary, touching them would of course increase the amount of changes necessary.