### PR TITLE
stop using DEBUG macro name

### DIFF
--- a/include/klee/SolverStats.h
+++ b/include/klee/SolverStats.h
@@ -28,7 +28,7 @@ namespace stats {
   extern Statistic queryCounterexamples;
   extern Statistic queryTime;
   
-#ifdef DEBUG
+#ifdef KLEE_ARRAY_DEBUG
   extern Statistic arrayHashTime;
 #endif
 

--- a/include/klee/util/ArrayExprHash.h
+++ b/include/klee/util/ArrayExprHash.h
@@ -85,7 +85,7 @@ template<class T>
 bool ArrayExprHash<T>::lookupArrayExpr(const Array* array, T& exp) const {
   bool res = false;
   
-#ifdef DEBUG
+#ifdef KLEE_ARRAY_DEBUG
   TimerStatIncrementer t(stats::arrayHashTime);
 #endif
   
@@ -101,7 +101,7 @@ bool ArrayExprHash<T>::lookupArrayExpr(const Array* array, T& exp) const {
 template<class T>
 void ArrayExprHash<T>::hashArrayExpr(const Array* array, T& exp) {
   
-#ifdef DEBUG  
+#ifdef KLEE_ARRAY_DEBUG
    TimerStatIncrementer t(stats::arrayHashTime);
 #endif
    
@@ -114,7 +114,7 @@ bool ArrayExprHash<T>::lookupUpdateNodeExpr(const UpdateNode* un, T& exp) const
 {
   bool res = false;
   
-#ifdef DEBUG
+#ifdef KLEE_ARRAY_DEBUG
   TimerStatIncrementer t(stats::arrayHashTime);
 #endif
   
@@ -130,7 +130,7 @@ bool ArrayExprHash<T>::lookupUpdateNodeExpr(const UpdateNode* un, T& exp) const
 template<class T>
 void ArrayExprHash<T>::hashUpdateNodeExpr(const UpdateNode* un, T& exp) 
 {
-#ifdef DEBUG
+#ifdef KLEE_ARRAY_DEBUG
   TimerStatIncrementer t(stats::arrayHashTime);
 #endif
   

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -418,7 +418,7 @@ void StatsTracker::writeStatsHeader() {
              << "'ResolveTime',"
              << "'QueryCexCacheMisses',"
              << "'QueryCexCacheHits',"
-#ifdef DEBUG
+#ifdef KLEE_ARRAY_DEBUG
 	     << "'ArrayHashTime',"
 #endif
              << ")\n";
@@ -450,7 +450,7 @@ void StatsTracker::writeStatsLine() {
              << "," << stats::resolveTime / 1000000.
              << "," << stats::queryCexCacheMisses
              << "," << stats::queryCexCacheHits
-#ifdef DEBUG
+#ifdef KLEE_ARRAY_DEBUG
              << "," << stats::arrayHashTime / 1000000.
 #endif
              << ")\n";

--- a/lib/Solver/SolverStats.cpp
+++ b/lib/Solver/SolverStats.cpp
@@ -24,6 +24,6 @@ Statistic stats::queryConstructs("QueriesConstructs", "QB");
 Statistic stats::queryCounterexamples("QueriesCEX", "Qcex");
 Statistic stats::queryTime("QueryTime", "Qtime");
 
-#ifdef DEBUG
+#ifdef KLEE_ARRAY_DEBUG
 Statistic stats::arrayHashTime("ArrayHashTime", "AHtime");
 #endif


### PR DESCRIPTION
This is too generic and llvm 6.0 defines DEBUG as follows:
```
 #define DEBUG(X) DEBUG_WITH_TYPE(DEBUG_TYPE, X)
```
This then results in various build failures where once the macro is
defined, once it is not.
