### PR TITLE
Fix remaining GCC8 warnings in primary KLEE code

### DIFF
--- a/include/klee/Internal/ADT/MapOfSets.h
+++ b/include/klee/Internal/ADT/MapOfSets.h
@@ -99,7 +99,7 @@ namespace klee {
     std::map<K, Node> children;
     
   public:
-    Node() : isEndOfSet(false) {}
+    Node() : value(), isEndOfSet(false) {}
   };
   
   template<class K, class V>
@@ -187,9 +187,9 @@ namespace klee {
   template<class K, class V>
   void MapOfSets<K,V>::insert(const std::set<K> &set, const V &value) {
     Node *n = &root;
-    for (typename std::set<K>::const_iterator it = set.begin(), ie = set.end();
-         it != ie; ++it)
-      n = &n->children.insert(std::make_pair(*it, Node())).first->second;
+    for (auto const& element : set) {
+      n = &n->children.insert(std::make_pair(element, Node())).first->second;
+    }
     n->isEndOfSet = true;
     n->value = value;
   }

--- a/lib/Expr/Parser.cpp
+++ b/lib/Expr/Parser.cpp
@@ -998,8 +998,11 @@ ExprResult ParserImpl::ParseParenExpr(TypeResult FIXME_UNUSED) {
   case 2:
     return ParseBinaryParenExpr(Name, ExprKind, IsFixed, ResTy);
   case 3:
-    if (ExprKind == Expr::Select)
+    if (ExprKind == Expr::Select) {
       return ParseSelectParenExpr(Name, ResTy);
+    } else {
+      assert(0 && "Invalid ternary expression kind.");
+    }
   default:
     assert(0 && "Invalid argument kind (number of args).");
     return ExprResult();


### PR DESCRIPTION
This fixes all remaining warnings that occur during compilation of the main KLEE code with GCC8. A couple of warnings remain in the runtime.

Remaining warnings in the runtime:
4x "attribute declaration must precede definition [-Wignored-attributes]" in klee/runtime/POSIX/stubs.c
1x "klee/runtime/POSIX/fd.c:554:19: warning: nonnull parameter 'path' will evaluate to 'true' on first encounter [-Wpointer-bool-conversion]"