### PR TITLE
Change run.stats file format to sqlite3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,6 +413,16 @@ else()
 endif()
 
 ################################################################################
+# Detect SQLite3
+################################################################################
+find_package(SQLite3)
+if (SQLITE3_FOUND)
+  include_directories(${SQLITE3_INCLUDE_DIRS})
+else()
+    message( FATAL_ERROR "SQLite3 not found, please install" )
+endif()
+
+################################################################################
 # Detect libcap
 ################################################################################
 check_include_file("sys/capability.h" HAVE_SYS_CAPABILITY_H)

--- a/cmake/modules/FindSQLite3.cmake
+++ b/cmake/modules/FindSQLite3.cmake
@@ -1,0 +1,37 @@
+# Copyright (C) 2007-2009 LuaDist.
+# Created by Peter Kapec <kapecp@gmail.com>
+# Redistribution and use of this file is allowed according to the terms of the MIT license.
+# For details see the COPYRIGHT file distributed with LuaDist.
+#	Note:
+#		Searching headers and libraries is very simple and is NOT as powerful as scripts
+#		distributed with CMake, because LuaDist defines directories to search for.
+#		Everyone is encouraged to contact the author with improvements. Maybe this file
+#		becomes part of CMake distribution sometimes.
+
+# - Find sqlite3
+# Find the native SQLITE3 headers and libraries.
+#
+# SQLITE3_INCLUDE_DIRS	- where to find sqlite3.h, etc.
+# SQLITE3_LIBRARIES	- List of libraries when using sqlite.
+# SQLITE3_FOUND	- True if sqlite found.
+
+# Look for the header file.
+FIND_PATH(SQLITE3_INCLUDE_DIR NAMES sqlite3.h)
+
+# Look for the library.
+FIND_LIBRARY(SQLITE3_LIBRARY NAMES sqlite3)
+
+# Handle the QUIETLY and REQUIRED arguments and set SQLITE3_FOUND to TRUE if all listed variables are TRUE.
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SQLITE3 DEFAULT_MSG SQLITE3_LIBRARY SQLITE3_INCLUDE_DIR)
+
+# Copy the results to the output variables.
+IF(SQLITE3_FOUND)
+	SET(SQLITE3_LIBRARIES ${SQLITE3_LIBRARY})
+	SET(SQLITE3_INCLUDE_DIRS ${SQLITE3_INCLUDE_DIR})
+ELSE(SQLITE3_FOUND)
+	SET(SQLITE3_LIBRARIES)
+	SET(SQLITE3_INCLUDE_DIRS)
+ENDIF(SQLITE3_FOUND)
+
+MARK_AS_ADVANCED(SQLITE3_INCLUDE_DIRS SQLITE3_LIBRARIES)

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 
 
 klee_get_llvm_libs(LLVM_LIBS ${LLVM_COMPONENTS})
-target_link_libraries(kleeCore PUBLIC ${LLVM_LIBS})
+target_link_libraries(kleeCore PUBLIC ${LLVM_LIBS} sqlite3)
 target_link_libraries(kleeCore PRIVATE
   kleeBasic
   kleeModule

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 
 
 klee_get_llvm_libs(LLVM_LIBS ${LLVM_COMPONENTS})
-target_link_libraries(kleeCore PUBLIC ${LLVM_LIBS} sqlite3)
+target_link_libraries(kleeCore PUBLIC ${LLVM_LIBS}  ${SQLITE3_LIBRARIES})
 target_link_libraries(kleeCore PRIVATE
   kleeBasic
   kleeModule

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -81,6 +81,11 @@ namespace {
       cl::desc("Write statistics after each n instructions, 0 to disable "
                "(default=0)"));
 
+  cl::opt<unsigned> CommitEvery(
+      "stats-commit-after", cl::init(0),
+      cl::desc("Commit the statistics every N writes. Setting to 0 commits every write in interval mode (default) or every 1000 writes in write after N instructions"
+               "(default=0)"));
+
   cl::opt<double>
   IStatsWriteInterval("istats-write-interval",
 		      cl::init(10.),
@@ -194,6 +199,13 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
         "time.");
 
   KModule *km = executor.kmodule.get();
+  if(CommitEvery > 0) {
+      commitEvery = CommitEvery.getValue();
+  } else {
+      commitEvery = StatsWriteInterval > 0 ? 1 : 1000;
+  }
+
+
 
   if (!sys::path::is_absolute(objectFilename)) {
     SmallString<128> current(objectFilename);
@@ -240,15 +252,17 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
   }
 
   if (OutputStats) {
-    statsFile = executor.interpreterHandler->openOutputFile("run.stats");
-    if (statsFile) {
+    if(sqlite3_open(executor.interpreterHandler->getOutputFilename("run.stats").c_str(), &statsFile)){
+       std::stringstream error_s;
+       error_s << "Can't open database: " << sqlite3_errmsg(statsFile);
+       sqlite3_close(statsFile);
+       klee_error("%s", error_s.str().c_str());
+    } else {
       writeStatsHeader();
       writeStatsLine();
 
       if (StatsWriteInterval > 0)
         executor.addTimer(new WriteStatsTimer(this), StatsWriteInterval);
-    } else {
-      klee_error("Unable to open statistics trace file (run.stats).");
     }
   }
 
@@ -267,6 +281,13 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
       klee_error("Unable to open instruction level stats file (run.istats).");
     }
   }
+}
+
+StatsTracker::~StatsTracker() {  
+  char *zErrMsg;
+  sqlite3_exec(statsFile, "END TRANSACTION", NULL, NULL, &zErrMsg);
+  sqlite3_finalize(insertStmt);
+  sqlite3_close(statsFile);
 }
 
 void StatsTracker::done() {
@@ -352,8 +373,10 @@ void StatsTracker::stepInstruction(ExecutionState &es) {
   }
 
   if (statsFile && StatsWriteAfterInstructions &&
-      stats::instructions % StatsWriteAfterInstructions.getValue() == 0)
+      stats::instructions % StatsWriteAfterInstructions.getValue() == 0) 
     writeStatsLine();
+  
+
 
   if (istatsFile && IStatsWriteAfterInstructions &&
       stats::instructions % IStatsWriteAfterInstructions.getValue() == 0)
@@ -420,31 +443,92 @@ void StatsTracker::markBranchVisited(ExecutionState *visitedTrue,
 }
 
 void StatsTracker::writeStatsHeader() {
-  *statsFile << "('Instructions',"
-             << "'FullBranches',"
-             << "'PartialBranches',"
-             << "'NumBranches',"
-             << "'UserTime',"
-             << "'NumStates',"
-             << "'MallocUsage',"
-             << "'NumQueries',"
-             << "'NumQueryConstructs',"
-             << "'NumObjects',"
-             << "'WallTime',"
-             << "'CoveredInstructions',"
-             << "'UncoveredInstructions',"
-             << "'QueryTime',"
-             << "'SolverTime',"
-             << "'CexCacheTime',"
-             << "'ForkTime',"
-             << "'ResolveTime',"
-             << "'QueryCexCacheMisses',"
-             << "'QueryCexCacheHits',"
+  std::stringstream create,  insert;
+  create << "CREATE TABLE stats ";
+  create     << "(Instructions int,"
+             << "FullBranches int,"
+             << "PartialBranches int,"
+             << "NumBranches int,"
+             << "UserTime int,"
+             << "NumStates int,"
+             << "MallocUsage int,"
+             << "NumQueries int,"
+             << "NumQueryConstructs int,"
+             << "NumObjects int,"
+             << "WallTime int,"
+             << "CoveredInstructions int,"
+             << "UncoveredInstructions int,"
+             << "QueryTime int,"
+             << "SolverTime int,"
+             << "CexCacheTime int,"
+             << "ForkTime int,"
+             << "ResolveTime int,"
+             << "QueryCexCacheMisses int,"
 #ifdef KLEE_ARRAY_DEBUG
-	     << "'ArrayHashTime',"
+	     << "ArrayHashTime int,"
 #endif
-             << ")\n";
-  statsFile->flush();
+             << "QueryCexCacheHits int"
+             << ")";
+       char *zErrMsg = 0;
+       if(sqlite3_exec(statsFile, create.str().c_str(), NULL, NULL, &zErrMsg)) {         
+         klee_error("ERROR creating table: %s", zErrMsg);
+         return;
+       }
+       insert << "INSERT INTO stats ( "
+              << "Instructions ,"
+              << "FullBranches ,"
+              << "PartialBranches ,"
+              << "NumBranches ,"
+              << "UserTime ,"
+              << "NumStates ,"
+              << "MallocUsage ,"
+              << "NumQueries ,"
+              << "NumQueryConstructs ,"
+              << "NumObjects ,"
+              << "WallTime ,"
+              << "CoveredInstructions ,"
+              << "UncoveredInstructions ,"
+              << "QueryTime ,"
+              << "SolverTime ,"
+              << "CexCacheTime ,"
+              << "ForkTime ,"
+              << "ResolveTime ,"
+              << "QueryCexCacheMisses ,"
+#ifdef KLEE_ARRAY_DEBUG
+              << "ArrayHashTime,"
+#endif
+              << "QueryCexCacheHits "
+              << ") VALUES ( "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+              << "?, "
+#ifdef KLEE_ARRAY_DEBUG
+              << "?, "
+#endif
+              << "? "
+              << ")";
+    if(sqlite3_prepare_v2(statsFile, insert.str().c_str(), -1, &insertStmt, 0)) {
+        klee_error("Cannot create prepared statement! %s", sqlite3_errmsg(statsFile));
+        return;
+    }
+    sqlite3_exec(statsFile, "PRAGMA synchronous = OFF", NULL, NULL, &zErrMsg);
+    sqlite3_exec(statsFile, "BEGIN TRANSACTION", NULL, NULL, &zErrMsg);
 }
 
 double StatsTracker::elapsed() {
@@ -452,31 +536,37 @@ double StatsTracker::elapsed() {
 }
 
 void StatsTracker::writeStatsLine() {
-  *statsFile << "(" << stats::instructions
-             << "," << fullBranches
-             << "," << partialBranches
-             << "," << numBranches
-             << "," << util::getUserTime()
-             << "," << executor.states.size()
-             << "," << util::GetTotalMallocUsage() + executor.memory->getUsedDeterministicSize()
-             << "," << stats::queries
-             << "," << stats::queryConstructs
-             << "," << 0 // was numObjects
-             << "," << elapsed()
-             << "," << stats::coveredInstructions
-             << "," << stats::uncoveredInstructions
-             << "," << stats::queryTime / 1000000.
-             << "," << stats::solverTime / 1000000.
-             << "," << stats::cexCacheTime / 1000000.
-             << "," << stats::forkTime / 1000000.
-             << "," << stats::resolveTime / 1000000.
-             << "," << stats::queryCexCacheMisses
-             << "," << stats::queryCexCacheHits
+             sqlite3_bind_int64(insertStmt, 1, stats::instructions);
+             sqlite3_bind_int64(insertStmt, 2, fullBranches);
+             sqlite3_bind_int64(insertStmt, 3, partialBranches);
+             sqlite3_bind_int64(insertStmt, 4, numBranches);
+             sqlite3_bind_int64(insertStmt, 5, util::getUserTime());
+             sqlite3_bind_int64(insertStmt, 6, executor.states.size());
+             sqlite3_bind_int64(insertStmt, 7, util::GetTotalMallocUsage() + executor.memory->getUsedDeterministicSize());
+             sqlite3_bind_int64(insertStmt, 8, stats::queries);
+             sqlite3_bind_int64(insertStmt, 9, stats::queryConstructs);
+             sqlite3_bind_int64(insertStmt, 10, 0  ); 
+             sqlite3_bind_int64(insertStmt, 11, elapsed());
+             sqlite3_bind_int64(insertStmt, 12, stats::coveredInstructions);
+             sqlite3_bind_int64(insertStmt, 13, stats::uncoveredInstructions);
+             sqlite3_bind_int64(insertStmt, 14, stats::queryTime / 1000000.);
+             sqlite3_bind_int64(insertStmt, 15, stats::solverTime / 1000000.);
+             sqlite3_bind_int64(insertStmt, 16, stats::cexCacheTime / 1000000.);
+             sqlite3_bind_int64(insertStmt, 17, stats::forkTime / 1000000.);
+             sqlite3_bind_int64(insertStmt, 18, stats::resolveTime / 1000000.);
+             sqlite3_bind_int64(insertStmt, 19, stats::queryCexCacheMisses);
+             sqlite3_bind_int64(insertStmt, 20, stats::queryCexCacheHits);
 #ifdef KLEE_ARRAY_DEBUG
-             << "," << stats::arrayHashTime / 1000000.
+             sqlite3_bind_int64(insertStmt, 21, stats::arrayHashTime / 1000000.);
 #endif
-             << ")\n";
-  statsFile->flush();
+             sqlite3_step(insertStmt);
+             sqlite3_reset(insertStmt);
+             if(writeCount % commitEvery == 0 ) {
+               char *zErrMsg = 0;
+               sqlite3_exec(statsFile, "END TRANSACTION", NULL, NULL, &zErrMsg);
+               sqlite3_exec(statsFile, "BEGIN TRANSACTION", NULL, NULL, &zErrMsg);
+             }
+             writeCount++;
 }
 
 void StatsTracker::updateStateStatistics(uint64_t addend) {

--- a/lib/Core/StatsTracker.h
+++ b/lib/Core/StatsTracker.h
@@ -39,10 +39,10 @@ namespace klee {
     std::string objectFilename;
 
     std::unique_ptr<llvm::raw_fd_ostream> istatsFile;
-    sqlite3 *statsFile;
-    sqlite3_stmt *insertStmt;
-    unsigned writeCount;
-    unsigned commitEvery;
+    sqlite3 *statsFile = nullptr;
+    sqlite3_stmt *insertStmt = nullptr;
+    std::uint32_t statsCommitEvery;
+    std::uint32_t statsWriteCount = 0;
     double startWallTime;
 
     unsigned numBranches;

--- a/lib/Core/StatsTracker.h
+++ b/lib/Core/StatsTracker.h
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <set>
+#include <sqlite3.h>
 
 namespace llvm {
   class BranchInst;
@@ -37,7 +38,11 @@ namespace klee {
     Executor &executor;
     std::string objectFilename;
 
-    std::unique_ptr<llvm::raw_fd_ostream> statsFile, istatsFile;
+    std::unique_ptr<llvm::raw_fd_ostream> istatsFile;
+    sqlite3 *statsFile;
+    sqlite3_stmt *insertStmt;
+    unsigned writeCount;
+    unsigned commitEvery;
     double startWallTime;
 
     unsigned numBranches;
@@ -60,7 +65,7 @@ namespace klee {
   public:
     StatsTracker(Executor &_executor, std::string _objectFilename,
                  bool _updateMinDistToUncovered);
-    ~StatsTracker() = default;
+    ~StatsTracker();
 
     // called after a new StackFrame has been pushed (for callpath tracing)
     void framePushed(ExecutionState &es, StackFrame *parentFrame);

--- a/scripts/build/klee.sh
+++ b/scripts/build/klee.sh
@@ -116,6 +116,8 @@ else
   CMAKE_BUILD_TYPE="Debug"
 fi
 
+python -m pip install --user tabulate
+
 # TODO: We should support Ninja too
 # Configure KLEE
 echo "CXXFLAGS=\"${COVERAGE_FLAGS} ${SANITIZER_CXX_FLAGS}\" \

--- a/scripts/build/klee.sh
+++ b/scripts/build/klee.sh
@@ -116,7 +116,15 @@ else
   CMAKE_BUILD_TYPE="Debug"
 fi
 
-python -m pip install --user tabulate
+if [[ "$TRAVIS_OS_NAME" = "linux" ]] ; then
+  apt update -y && apt install -y libsqlite3-dev
+elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+  brew upgrade python
+else
+  echo "Unhandled TRAVIS_OS_NAME \"${TRAVIS_OS_NAME}\""
+  exit 1
+fi
+python3 -m pip install --user tabulate
 
 # TODO: We should support Ninja too
 # Configure KLEE

--- a/test/regression/2017-03-23-early-exit-log-stats.c
+++ b/test/regression/2017-03-23-early-exit-log-stats.c
@@ -1,9 +1,10 @@
 // RUN: %llvmgcc %s -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
 // Delay writing instructions so that we ensure on exit that flush happens
-// RUN: not %klee --output-dir=%t.klee-out -exit-on-error -stats-write-interval=0 -stats-write-after-instructions=999999 %t.bc 2> %t.log
+// RUN: not %klee --output-dir=%t.klee-out -exit-on-error -stats-write-interval=0 -stats-write-after-instructions=999999 -stats-commit-after=1 %t.bc 2> %t.log
+// RUN: klee-stats -to-csv %t.klee-out > %t.stats.csv
 // RUN: FileCheck -check-prefix=CHECK-KLEE -input-file=%t.log %s
-// RUN: FileCheck -check-prefix=CHECK-STATS -input-file=%t.klee-out/run.stats %s
+// RUN: FileCheck -check-prefix=CHECK-STATS -input-file=%t.stats.csv %s
 #include "klee/klee.h"
 #include <stdlib.h>
 int main(){
@@ -17,6 +18,6 @@ int main(){
   return 0;
 }
 // First check we find a line with the expected format
-// CHECK-STATS:{{^\('Instructions'}}
+// CHECK-STATS:{{^Instructions}}
 // Now check that we eventually get a line where a non zero amount of instructions were executed
-// CHECK-STATS:{{^\([ ]*([1-9]|([1-9]+)[0-9])}}
+// CHECK-STATS:{{^\([ ]*[1-9]|([1-9]+)[0-9]}}

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -118,18 +118,6 @@ def stripCommonPathPrefix(paths):
     return ['/'.join(p[i:]) for p in paths]
 
 
-def getKeyIndex(key, labels):
-    """Get the index of the specified key in labels."""
-    def normalizeKey(key):
-        return re.split('\W', key)[0]
-
-    for i, title in enumerate(labels):
-        if normalizeKey(title) == normalizeKey(key):
-            return i
-    else:
-        raise ValueError('invalid key: {0}'.format(key))
-
-
 def getKleeOutDirs(dirs):
     kleeOutDirs = []
     for dir in dirs:
@@ -323,22 +311,6 @@ def main():
                           help='Print extra information (needed when '
                           'monitoring an ongoing run).')
 
-    # arguments for comparing
-    parser.add_argument('--compare-by', dest='compBy', metavar='header',
-                        help='Key value on which to compare runs to the '
-                        'reference one (which is the first one). Must be '
-                        'chosen from the headers of the table oputputted. '
-                        'e.g., --compare-by=Instrs shows how each run '
-                        'compares to the reference run after executing the '
-                        'same number of instructions as the reference run. '
-                        "If a run hasn't executed as many instructions as "
-                        'the reference one, we simply print the statistics '
-                        'at the end of that run.')
-    parser.add_argument('--compare-at', dest='compAt', metavar='value',
-                        help='Value to compare the runs at. Can be special '
-                        "value 'last' to compare at the last point which "
-                        'makes sense. Use in conjunction with --compare-by.')
-
     args = parser.parse_args()
 
 
@@ -386,36 +358,16 @@ def main():
     rawLabels = ('Instrs', '', '', '', '', '', '', 'Queries',
                  '', '', 'Time', 'ICov', '', '', '', '', '', '')
 
-    if args.compBy:
-        # index in the record of run.stats
-        compIndex = getKeyIndex(args.compBy, rawLabels)
-        if args.compAt:
-            if args.compAt == 'last':
-                # [records][last-record][compare-by-index]
-                refValue = min(map(lambda r: r[1][-1][compIndex], data))
-            else:
-                refValue = args.compAt
-        else:
-            refValue = data[0][1][-1][compIndex]
-
     # build the main body of the table
     table = []
     totRecords = []  # accumulated records
     totStats = []    # accumulated stats
     for path, records in data:
         row = [path]
-        if args.compBy:
-            matchIndex = getMatchedRecordIndex(
-                records, itemgetter(compIndex), refValue)
-            stats = recrods.aggregateRecords() # aggregateRecords(LazyEvalList(records[:matchIndex + 1]))
-            totStats.append(stats)
-            row.extend(getRow(records[matchIndex], stats, pr))
-            totRecords.append(records[matchIndex])
-        else:
-            stats = records.aggregateRecords()
-            totStats.append(stats)
-            row.extend(getRow(records[-1], stats, pr))
-            totRecords.append(records[-1])
+        stats = records.aggregateRecords()
+        totStats.append(stats)
+        row.extend(getRow(records[-1], stats, pr))
+        totRecords.append(records[-1])
         table.append(row)
     # calculate the total
     totRecords = [sum(e) for e in zip(*totRecords)]

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -297,10 +297,6 @@ def main():
                                  'rst', 'mediawiki', 'latex', 'klee'],
                         dest='tableFormat', default='klee',
                         help='Table format for the summary.')
-    parser.add_argument('--sample-interval', dest='sampleInterv',
-                        type=isPositiveInt, default='10', metavar='n',
-                        help='Sample a data point every n lines for a '
-                        'run.stats (default: 10)')
     parser.add_argument('-to-csv',
                           action='store_true', dest='toCsv',
                           help='Dump run.stats to STDOUT in CSV format')

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -252,6 +252,71 @@ def drawLineChart(vectors, titles):
                 transparent=False)
 
 
+def grafana(dirs):
+  dr = getLogFile(dirs[0])
+  from flask import Flask, jsonify, request
+  from json import dumps
+  import datetime
+  import time
+  app = Flask(__name__)
+
+  def toepoch(date_text):
+    dt = datetime.datetime.strptime(date_text, "%Y-%m-%dT%H:%M:%S.%fZ")
+    epoch = (dt - datetime.datetime(1970, 1, 1)).total_seconds()
+    return epoch
+
+  @app.route('/')
+  def status():
+      return 'OK'
+
+  @app.route('/search', methods=['GET', 'POST'])
+  def search():
+      jsn = request.get_json()
+      conn = sqlite3.connect(dr);
+      cursor = conn.execute('SELECT * FROM stats')
+      names = [description[0] for description in cursor.description]
+      return jsonify(names)
+
+  @app.route('/query', methods=['POST'])
+  def query():
+      jsn = request.get_json()
+#      print(dumps(jsn))
+      interval = jsn["intervalMs"]
+      limit = jsn["maxDataPoints"]
+      frm = toepoch(jsn["range"]["from"])
+      to = toepoch(jsn["range"]["to"])
+      targets = [str(t["target"]) for t in jsn["targets"]]
+      startTime = os.path.getmtime(dr)
+      fromTime = frm - startTime if frm - startTime > 0 else 0
+      toTime =  to - startTime if to - startTime > fromTime else fromTime + 100
+#      print(startTime)
+      conn = sqlite3.connect(dr);
+      s = "SELECT WallTime + " + str(startTime) + ","  + ",".join(targets) + " FROM stats GROUP BY WallTime/3 LIMIT ?"
+      s = "SELECT WallTime + {startTime} , {fields} " \
+          + " FROM stats" \
+          + " WHERE WallTime >= {fromTime} AND WallTime <= {toTime}" \
+          + " GROUP BY WallTime/{intervalSeconds} LIMIT {limit}"
+      s = s.format(startTime=startTime,
+                   fields=",".join(["AVG( {0} )".format(t) for t in targets]),
+                   intervalSeconds=interval/1000,
+                   fromTime=fromTime,
+                   toTime=toTime,
+                   limit=limit)
+      cursor = conn.execute(s)
+      result = [ {"target": t, "datapoints": []} for t in targets ]
+      for line in cursor:
+          unixtimestamp = int(line[0] * 1000) #miliseconds
+          for field, datastream in zip(line[1:], result):
+              datastream["datapoints"].append([field, unixtimestamp])
+
+#      print(len(result[0]["datapoints"]))
+      ret = jsonify(result)
+#      print(result)
+      return ret
+
+  app.run()
+  return 0
+
 def main():
     # function for sanitizing arguments
     def isPositiveInt(value):
@@ -296,6 +361,9 @@ def main():
     parser.add_argument('-to-csv',
                           action='store_true', dest='toCsv',
                           help='Dump run.stats to STDOUT in CSV format')
+    parser.add_argument('-grafana',
+                          action='store_true', dest='grafana',
+                          help='Start a graphan web server')
 
     # argument group for controlling output verboseness
     pControl = parser.add_mutually_exclusive_group(required=False)
@@ -356,6 +424,8 @@ def main():
         pr = 'more'
 
     dirs = getKleeOutDirs(args.dir)
+    if args.grafana:
+      return grafana(dirs)
     if len(dirs) == 0:
         print('no klee output dir found', file=sys.stderr)
         exit(1)

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -256,18 +256,6 @@ def grafana(dirs):
   return 0
 
 def main():
-    # function for sanitizing arguments
-    def isPositiveInt(value):
-        try:
-            value = int(value)
-        except ValueError:
-            raise argparse.ArgumentTypeError(
-                'integer expected: {0}'.format(value))
-        if value <= 0:
-            raise argparse.ArgumentTypeError(
-                'positive integer expected: {0}'.format(value))
-        return value
-
     parser = argparse.ArgumentParser(
         description='output statistics logged by klee',
         epilog='LEGEND\n' + tabulate(Legend),
@@ -275,11 +263,6 @@ def main():
 
     parser.add_argument('dir', nargs='+', help='klee output directory')
 
-    parser.add_argument('--precision',
-                        dest='precision', type=isPositiveInt,
-                        default=2, metavar='n',
-                        help='Floating point numbers display precision '
-                        '(default: 2).')
     parser.add_argument('--table-format',
                         choices=['plain', 'simple', 'grid', 'pipe', 'orgtbl',
                                  'rst', 'mediawiki', 'latex', 'klee'],
@@ -383,13 +366,13 @@ def main():
         print(tabulate(
             table, headers='firstrow',
             tablefmt=args.tableFormat,
-            floatfmt='.{p}f'.format(p=args.precision),
+            floatfmt='.{p}f'.format(p=2),
             numalign='right', stralign='center'))
     else:
         stream = tabulate(
             table, headers='firstrow',
             tablefmt=KleeTable,
-            floatfmt='.{p}f'.format(p=args.precision),
+            floatfmt='.{p}f'.format(p=2),
             numalign='right', stralign='center')
         # add a line separator before the total line
         if len(data) > 1:

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -323,15 +323,6 @@ def main():
                           help='Print extra information (needed when '
                           'monitoring an ongoing run).')
 
-    # arguments for sorting
-    parser.add_argument('--sort-by', dest='sortBy', metavar='header',
-                        help='Key value to sort by. Must be chosen from '
-                        'the headers of the table outputted  (e.g., '
-                        '--sort-by=Instrs).')
-    parser.add_argument('--ascending',
-                        dest='ascending', action='store_true',
-                        help='Sort in ascending order (default: False).')
-
     # arguments for comparing
     parser.add_argument('--compare-by', dest='compBy', metavar='header',
                         help='Key value on which to compare runs to the '
@@ -431,10 +422,6 @@ def main():
     totStats = [sum(e) for e in zip(*totStats)]
     totalRow = ['Total ({0})'.format(len(table))]
     totalRow.extend(getRow(totRecords, totStats, pr))
-
-    if args.sortBy:
-        table = sorted(table, key=itemgetter(getKeyIndex(args.sortBy, labels)),
-                       reverse=(not args.ascending))
 
     if len(data) > 1:
         table.append(totalRow)

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -202,56 +202,6 @@ def getRow(record, stats, pr):
     return row
 
 
-def drawLineChart(vectors, titles):
-    """Draw a line chart based on data from vectors.
-
-    Args:
-        vectors: A list of vectors. Each vector is drawn in a separate
-                 subchart.
-        titles: A list of strings. Each string is an explanation of the
-                corresponding vector.
-    """
-    try:
-        import matplotlib
-        matplotlib.use('Agg')  # plot without X-server connection
-        import matplotlib.pyplot as plt
-    except:
-        print('Error: Package "matplotlib" required for figure plotting. '
-              'Please install it using "pip" or your package manager.',
-              file=sys.stderr)
-        exit(1)
-    from math import sqrt, ceil
-
-    nFigs = len(vectors)       # number of subfigures
-    nRow = int(sqrt(nFigs))    # number of rows in the figure
-    nCol = ceil(nFigs / nRow)  # number of columns in the figure
-
-    fig = plt.figure()
-    for i in range(nFigs):
-        ax = fig.add_subplot(nRow, nCol, i+1)
-        ax.plot(vectors[i])
-        ax.set_title(titles[i])
-        #ax.set_xlabel()
-        #ax.set_ylabel()
-
-    #fig.show()
-    #raw_input('Press any key to continue..')
-
-    def getFileName():
-        """Get a unused file name in current directory."""
-        i = 0
-        fileName = 'fig-klee-stats-{0}.png'.format(i)
-        while os.path.exists(fileName):
-            i = i + 1
-            fileName = 'fig-klee-stats-{0}.png'.format(i)
-        return fileName
-
-    plt.savefig(getFileName(),
-                dpi=150,  # dots-per-inch, default: 100
-                bbox_inches='tight',  # tighter bbox
-                transparent=False)
-
-
 def grafana(dirs):
   dr = getLogFile(dirs[0])
   from flask import Flask, jsonify, request
@@ -347,13 +297,6 @@ def main():
                                  'rst', 'mediawiki', 'latex', 'klee'],
                         dest='tableFormat', default='klee',
                         help='Table format for the summary.')
-    parser.add_argument('--draw-line-chart',
-                        dest='drawLineChart', metavar='header-list',
-                        help='Draw line chart for a list of columns. '
-                        'Columns must be chosen from the headers of the '
-                        'table outputted and separated by comma (e.g., '
-                        '--draw-line-chart=Instrs,Time). Data points '
-                        'on x-axis correspond to lines in run.stats.')
     parser.add_argument('--sample-interval', dest='sampleInterv',
                         type=isPositiveInt, default='10', metavar='n',
                         help='Sample a data point every n lines for a '
@@ -520,36 +463,6 @@ def main():
             stream = '\n'.join(stream)
         print(stream)
 
-    if args.drawLineChart:
-        if len(dirs) != 1:
-            print('--draw-line-chart only supports using a single file',
-                  file=sys.stderr)
-            exit(1)
-
-        # sample according to the given interval
-        samples = [r for i, r in enumerate(data[0][1])
-                   if i % args.sampleInterv == 0]
-        vectors = []
-        for i in range(len(samples)):
-            # aggregate all the samples upto the i-th one
-            stats = aggregateRecords(samples[:i + 1])
-            vectors.append(getRow(samples[i], stats, pr))
-
-        titles = args.drawLineChart.split(',')
-        # Index returned by getKeyIndex() against labels is starting from
-        # 'Path' column.  vectors here doesn't have the 'Path' column.
-        indices = [getKeyIndex(e, labels) - 1 for e in titles]
-        # get one more column to make sure itemgetter always return tuples
-        indices.append(0)
-        # strip columns not specified by the user
-        vectors = map(itemgetter(*indices), vectors)
-        # combine elements in the same column into the same tuple
-        vectors = list(zip(*vectors))
-        # remove the column we get but not needed
-        vectors = vectors[:-1]
-
-        drawLineChart(vectors, titles)
-
-
+   
 if __name__ == '__main__':
     main()

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 
 # ===-- klee-stats --------------------------------------------------------===##
@@ -12,24 +12,18 @@
 
 """Output statistics logged by Klee."""
 
-# use '/' to mean true division and '//' to mean floor division
-from __future__ import division
-from __future__ import print_function
-
 import os
-import re
 import sys
 import argparse
 import sqlite3
 
-from operator import itemgetter
 try:
-    from tabulate import TableFormat, Line, DataRow, tabulate
+    from tabulate import TableFormat, Line, DataRow, tabulate, _table_formats
 except:
     print('Error: Package "tabulate" required for table formatting. '
-          'Please install it using "pip" or your package manager.',
+          'Please install it using "pip" or your package manager.'
+          'You can still use -grafana and -to-csv without tabulate.',
           file=sys.stderr)
-    exit(1)
 
 Legend = [
     ('Instrs', 'number of executed instructions'),
@@ -63,35 +57,27 @@ def getLogFile(path):
     """Return the path to run.stats."""
     return os.path.join(path, 'run.stats')
 
-
 class LazyEvalList:
     """Store all the lines in run.stats and eval() when needed."""
     def __init__(self, fileName):
         # The first line in the records contains headers.
-      #  self.lines = lines[1:]
-      self.conn = sqlite3.connect(fileName);
+      self.conn = sqlite3.connect(fileName)
       self.c = self.conn.cursor()
       self.c.execute("SELECT * FROM stats ORDER BY Instructions DESC LIMIT 1")
-      self.lines = self.c.fetchone()
+      self.line = self.c.fetchone()
 
     def aggregateRecords(self):
-        memC = self.conn.cursor()
-        memC.execute("SELECT max(MallocUsage) / 1024 / 1024, avg(MallocUsage) / 1024 / 1024 from stats")
-        maxMem, avgMem = memC.fetchone()
+      memC = self.conn.cursor()
+      memC.execute("SELECT max(MallocUsage) / 1024 / 1024, avg(MallocUsage) / 1024 / 1024 from stats")
+      maxMem, avgMem = memC.fetchone()
 
-        stateC = self.conn.cursor()
-        stateC.execute("SELECT max(NumStates), avg(NumStates) from stats")
-        maxStates, avgStates = stateC.fetchone()
-        return (maxMem, avgMem, maxStates, avgStates)
+      stateC = self.conn.cursor()
+      stateC.execute("SELECT max(NumStates), avg(NumStates) from stats")
+      maxStates, avgStates = stateC.fetchone()
+      return (maxMem, avgMem, maxStates, avgStates)
 
-
-    def __getitem__(self, index):
-        return self.lines
-
-    def __len__(self):
-        return len(self.lines)
-
-
+    def getLastRecord(self):
+      return self.line
 
 def stripCommonPathPrefix(paths):
     paths = map(os.path.normpath, paths)
@@ -102,7 +88,6 @@ def stripCommonPathPrefix(paths):
         if len(set(elts)) > 1:
             break
     return ['/'.join(p[i:]) for p in paths]
-
 
 def getKleeOutDirs(dirs):
     kleeOutDirs = []
@@ -116,7 +101,6 @@ def getKleeOutDirs(dirs):
                     if os.path.exists(os.path.join(path, 'info')):
                         kleeOutDirs.append(path)
     return kleeOutDirs
-
 
 def getLabels(pr):
     if pr == 'all':
@@ -149,6 +133,7 @@ def getRow(record, stats, pr):
     if BTot == 0:
         BFull = BTot = 1
 
+    Ts, Tcex, Tf, Tr = [e / 1000000 for e in [Ts, Tcex, Tf, Tr]] #convert from microseconds
     Mem = Mem / 1024 / 1024
     AvgQC = int(QCon / max(1, QTot))
 
@@ -177,69 +162,60 @@ def getRow(record, stats, pr):
 
 
 def grafana(dirs):
-  dr = getLogFile(dirs[0])
-  from flask import Flask, jsonify, request
-  from json import dumps
-  import datetime
-  import time
-  app = Flask(__name__)
+    dr = getLogFile(dirs[0])
+    from flask import Flask, jsonify, request
+    import datetime
+    app = Flask(__name__)
 
-  def toepoch(date_text):
-    dt = datetime.datetime.strptime(date_text, "%Y-%m-%dT%H:%M:%S.%fZ")
-    epoch = (dt - datetime.datetime(1970, 1, 1)).total_seconds()
-    return epoch
+    def toEpoch(date_text):
+        dt = datetime.datetime.strptime(date_text, "%Y-%m-%dT%H:%M:%S.%fZ")
+        epoch = (dt - datetime.datetime(1970, 1, 1)).total_seconds()
+        return epoch
 
-  @app.route('/')
-  def status():
-      return 'OK'
+    @app.route('/')
+    def status():
+        return 'OK'
 
-  @app.route('/search', methods=['GET', 'POST'])
-  def search():
-      jsn = request.get_json()
-      conn = sqlite3.connect(dr);
-      cursor = conn.execute('SELECT * FROM stats')
-      names = [description[0] for description in cursor.description]
-      return jsonify(names)
+    @app.route('/search', methods=['GET', 'POST'])
+    def search():
+        conn = sqlite3.connect(dr)
+        cursor = conn.execute('SELECT * FROM stats')
+        names = [description[0] for description in cursor.description]
+        return jsonify(names)
 
-  @app.route('/query', methods=['POST'])
-  def query():
-      jsn = request.get_json()
-#      print(dumps(jsn))
-      interval = jsn["intervalMs"]
-      limit = jsn["maxDataPoints"]
-      frm = toepoch(jsn["range"]["from"])
-      to = toepoch(jsn["range"]["to"])
-      targets = [str(t["target"]) for t in jsn["targets"]]
-      startTime = os.path.getmtime(dr)
-      fromTime = frm - startTime if frm - startTime > 0 else 0
-      toTime =  to - startTime if to - startTime > fromTime else fromTime + 100
-#      print(startTime)
-      conn = sqlite3.connect(dr);
-      s = "SELECT WallTime + " + str(startTime) + ","  + ",".join(targets) + " FROM stats GROUP BY WallTime/3 LIMIT ?"
-      s = "SELECT WallTime + {startTime} , {fields} " \
-          + " FROM stats" \
-          + " WHERE WallTime >= {fromTime} AND WallTime <= {toTime}" \
-          + " GROUP BY WallTime/{intervalSeconds} LIMIT {limit}"
-      s = s.format(startTime=startTime,
-                   fields=",".join(["AVG( {0} )".format(t) for t in targets]),
-                   intervalSeconds=interval/1000,
-                   fromTime=fromTime,
-                   toTime=toTime,
-                   limit=limit)
-      cursor = conn.execute(s)
-      result = [ {"target": t, "datapoints": []} for t in targets ]
-      for line in cursor:
-          unixtimestamp = int(line[0] * 1000) #miliseconds
-          for field, datastream in zip(line[1:], result):
-              datastream["datapoints"].append([field, unixtimestamp])
+    @app.route('/query', methods=['POST'])
+    def query():
+        jsn = request.get_json()
+        interval = jsn["intervalMs"]
+        limit = jsn["maxDataPoints"]
+        frm = toEpoch(jsn["range"]["from"])
+        to = toEpoch(jsn["range"]["to"])
+        targets = [str(t["target"]) for t in jsn["targets"]]
+        startTime = os.path.getmtime(dr)
+        fromTime = frm - startTime if frm - startTime > 0 else 0
+        toTime = to - startTime if to - startTime > fromTime else fromTime + 100
+        sqlTarget = ",".join(["AVG( {0} )".format(t) for t in targets if t.isalnum()])
 
-#      print(len(result[0]["datapoints"]))
-      ret = jsonify(result)
-#      print(result)
-      return ret
+        conn = sqlite3.connect(dr)
 
-  app.run()
-  return 0
+        s = "SELECT WallTime + ? , {fields} " \
+            + " FROM stats" \
+            + " WHERE WallTime >= ? AND WallTime <= ?" \
+            + " GROUP BY WallTime/? LIMIT ?"
+        s = s.format(fields=sqlTarget) #can't use prepared staments for this one
+
+        cursor = conn.execute(s, ( startTime, fromTime, toTime, interval/1000, limit))
+        result = [ {"target": t, "datapoints": []} for t in targets ]
+        for line in cursor:
+            unixtimestamp = int(line[0]) * 1000  #miliseconds
+            for field, datastream in zip(line[1:], result):
+                datastream["datapoints"].append([field, unixtimestamp])
+
+        ret = jsonify(result)
+        return ret
+
+    app.run()
+    return 0
 
 def main():
     parser = argparse.ArgumentParser(
@@ -250,16 +226,15 @@ def main():
     parser.add_argument('dir', nargs='+', help='klee output directory')
 
     parser.add_argument('--table-format',
-                        choices=['plain', 'simple', 'grid', 'pipe', 'orgtbl',
-                                 'rst', 'mediawiki', 'latex', 'klee'],
-                        dest='tableFormat', default='klee',
-                        help='Table format for the summary.')
+                          choices=['klee'] + list(_table_formats.keys()),
+                          dest='tableFormat', default='klee',
+                          help='Table format for the summary.')
     parser.add_argument('-to-csv',
                           action='store_true', dest='toCsv',
-                          help='Dump run.stats to STDOUT in CSV format')
+                          help='Output stats as comma-separated values (CSV)')
     parser.add_argument('-grafana',
                           action='store_true', dest='grafana',
-                          help='Start a graphan web server')
+                          help='Start a grafana web server')
 
     # argument group for controlling output verboseness
     pControl = parser.add_mutually_exclusive_group(required=False)
@@ -314,18 +289,14 @@ def main():
         # write data                          
         for result in sql3_cursor:
           csv_out.writerow(result)
- 
         return
+
     if len(data) > 1:
         dirs = stripCommonPathPrefix(dirs)
     # attach the stripped path
     data = list(zip(dirs, data))
 
     labels = getLabels(pr)
-    # labels in the same order as in the run.stats file. used by --compare-by.
-    # current impl needs monotonic values, so only keep the ones making sense.
-    rawLabels = ('Instrs', '', '', '', '', '', '', 'Queries',
-                 '', '', 'Time', 'ICov', '', '', '', '', '', '')
 
     # build the main body of the table
     table = []
@@ -335,8 +306,8 @@ def main():
         row = [path]
         stats = records.aggregateRecords()
         totStats.append(stats)
-        row.extend(getRow(records[-1], stats, pr))
-        totRecords.append(records[-1])
+        row.extend(getRow(records.getLastRecord(), stats, pr))
+        totRecords.append(records.getLastRecord())
         table.append(row)
     # calculate the total
     totRecords = [sum(e) for e in zip(*totRecords)]

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -92,20 +92,6 @@ class LazyEvalList:
         return len(self.lines)
 
 
-def getMatchedRecordIndex(records, column, target):
-    """Find target from the specified column in records."""
-    target = int(target)
-    lo = 0
-    hi = len(records) - 1
-    while lo < hi:
-        mid = (lo + hi) // 2
-        if column(records[mid]) <= target:
-            lo = mid + 1
-        else:
-            hi = mid
-    return lo
-
-
 
 def stripCommonPathPrefix(paths):
     paths = map(os.path.normpath, paths)

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -20,6 +20,7 @@ import os
 import re
 import sys
 import argparse
+import sqlite3
 
 from operator import itemgetter
 try:
@@ -65,14 +66,27 @@ def getLogFile(path):
 
 class LazyEvalList:
     """Store all the lines in run.stats and eval() when needed."""
-    def __init__(self, lines):
+    def __init__(self, fileName):
         # The first line in the records contains headers.
-        self.lines = lines[1:]
+      #  self.lines = lines[1:]
+      self.conn = sqlite3.connect(fileName);
+      self.c = self.conn.cursor()
+      self.c.execute("SELECT * FROM stats ORDER BY Instructions DESC LIMIT 1")
+      self.lines = self.c.fetchone()
+
+    def aggregateRecords(self):
+        memC = self.conn.cursor()
+        memC.execute("SELECT max(MallocUsage) / 1024 / 1024, avg(MallocUsage) / 1024 / 1024 from stats")
+        maxMem, avgMem = memC.fetchone()
+
+        stateC = self.conn.cursor()
+        stateC.execute("SELECT max(NumStates), avg(NumStates) from stats")
+        maxStates, avgStates = stateC.fetchone()
+        return (maxMem, avgMem, maxStates, avgStates)
+
 
     def __getitem__(self, index):
-        if isinstance(self.lines[index], str):
-            self.lines[index] = eval(self.lines[index])
-        return self.lines[index]
+        return self.lines
 
     def __len__(self):
         return len(self.lines)
@@ -91,23 +105,6 @@ def getMatchedRecordIndex(records, column, target):
             hi = mid
     return lo
 
-
-def aggregateRecords(records):
-    # index for memUsage and stateCount in run.stats
-    memIndex = 6
-    stateIndex = 5
-
-    # maximum and average memory usage
-    memValues = list(map(itemgetter(memIndex), records))
-    maxMem = max(memValues) / 1024 / 1024
-    avgMem = sum(memValues) / len(memValues) / 1024 / 1024
-
-    # maximum and average number of states
-    stateValues = list(map(itemgetter(stateIndex), records))
-    maxStates = max(stateValues)
-    avgStates = sum(stateValues) / len(stateValues)
-
-    return (maxMem, avgMem, maxStates, avgStates)
 
 
 def stripCommonPathPrefix(paths):
@@ -296,6 +293,9 @@ def main():
                         type=isPositiveInt, default='10', metavar='n',
                         help='Sample a data point every n lines for a '
                         'run.stats (default: 10)')
+    parser.add_argument('-to-csv',
+                          action='store_true', dest='toCsv',
+                          help='Dump run.stats to STDOUT in CSV format')
 
     # argument group for controlling output verboseness
     pControl = parser.add_mutually_exclusive_group(required=False)
@@ -343,6 +343,7 @@ def main():
 
     args = parser.parse_args()
 
+
     # get print controls
     pr = 'NONE'
     if args.pAll:
@@ -359,7 +360,21 @@ def main():
         print('no klee output dir found', file=sys.stderr)
         exit(1)
     # read contents from every run.stats file into LazyEvalList
-    data = [LazyEvalList(list(open(getLogFile(d)))) for d in dirs]
+    data = [LazyEvalList(getLogFile(d)) for d in dirs]
+
+    if args.toCsv:
+        import csv
+        data = data[0]
+        c = data.conn.cursor()
+        sql3_cursor = c.execute("SELECT * FROM stats")
+        csv_out = csv.writer(sys.stdout)
+        # write header                        
+        csv_out.writerow([d[0] for d in sql3_cursor.description])
+        # write data                          
+        for result in sql3_cursor:
+          csv_out.writerow(result)
+ 
+        return
     if len(data) > 1:
         dirs = stripCommonPathPrefix(dirs)
     # attach the stripped path
@@ -392,12 +407,12 @@ def main():
         if args.compBy:
             matchIndex = getMatchedRecordIndex(
                 records, itemgetter(compIndex), refValue)
-            stats = aggregateRecords(LazyEvalList(records[:matchIndex + 1]))
+            stats = recrods.aggregateRecords() # aggregateRecords(LazyEvalList(records[:matchIndex + 1]))
             totStats.append(stats)
             row.extend(getRow(records[matchIndex], stats, pr))
             totRecords.append(records[matchIndex])
         else:
-            stats = aggregateRecords(records)
+            stats = records.aggregateRecords()
             totStats.append(stats)
             row.extend(getRow(records[-1], stats, pr))
             totRecords.append(records[-1])


### PR DESCRIPTION
This pull request changes the file format used to store run.stats file to sqlite3.

Disadvantage:
 1. *run.stats no longer human readable*: I would consider the current format to be human-non-readable, but with this you can't open it in a text editor.

Advantages:
 1. *smaller run.stats file size*: Sqlite3 is a binary format which immediately reduces filesize. Furthermore it uses variable length encoding for integers, so it can use less than `numberOfRecords * numberOfFields * widthOfFields` bytes
1. *faster writes*: In most uses cases it should write faster than the current method (see below)
1. *faster klee-stats*: `klee-stats` gets very slow in my experience when dealing with `run.stats` with a lot of records, moving to sqlite3 should enable this to be much faster. I didn't benchmark  `klee-stats` in this PR, because that is a seprate issue
1. *SQL query lagnuage*: performing ad-hoc queries is much easier. You can just run `sqlite3 klee-last/run.stats` and type whatever SQL query you have in mind
1. *Well defined fail behaviour*:  I don't think it's currently well defined what stats are written if KLEE crashes. SQLIte enables us to control this (the trade-off is performance)


## Performance

I performed a small scale benchmark, similar to what KLEE does,, where I write 13 `int` records into a table. I can get 1M writes/s, but only about 1K/s commits on my machine. That means we can have very fast writes (that is writes on every instruction), but we can't commit on every instruction. 

So I came up with the following scheme:
* If we write on interval we commit for every write 
* If we write on instructions, we commit for every 1000 writes
* User can override the above settings with whatever they want

This gives sensible (fast) defaults, but still enables slow reliable per instruction writes.

I also ran a `od.bc` dumping a concrete file with ` -stats-write-after-instructions=1 -stats-write-interval=0`, both with and without this patch. For some reason me and @MartinNowack  couldn't get KLEE to execute the same number of instructions on this benchmark, but SQLite3 seems to do more work in the same time:

CSV:
```
KLEE: done: total instructions = 4656860
KLEE: done: completed paths = 1
KLEE: done: generated tests = 1

real    0m24.402s
user    0m18.408s
sys     0m5.980s
n$ ls -lh klee-last/run.stats
-rw-r--r-- 1 tk1713 srg 648M May 27 11:51 klee-last/run.stats
```

SQLite:
```
KLEE: done: total instructions = 5361184
KLEE: done: completed paths = 1
KLEE: done: generated tests = 1

real    0m24.787s
user    0m20.428s
sys     0m4.344s
$ ls -lh klee-last/run.stats
-rw-r--r-- 1 tk1713 srg 247M May 27 11:53 klee-last/run.stats
```

## Grafana 

This was inspired by @251 talk on Grafana. Unfortunately Grafana doesn't support SQLite as datasource (yet, maybe?), but I think this gets us closer to there. We just need to implement a [simple json datasource](https://github.com/grafana/simple-json-datasource), which is a webserver that queries the database a bit. I think this is much easier to do on top of SQLite than a CSV file. There is even a [blog post](https://nbsoftsolutions.com/blog/replacing-elasticsearch-with-rust-and-sqlite) about it.

This is now implemented to an extent. You can run `klee-stats -grafana path/to/a/single/klee-out-file`

The easiest way to run grafana with docker is 

```
docker run \
  -d \
  --net=host \
  --name=grafana \
  -e "GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource" \
  grafana/grafana
```

And then create a SimpleJson datasource pointing to whatever klee-stats tells you (probably `http://localhost:5000`)

Screenshot of `od` running for a couple of minutes: 
![image](https://user-images.githubusercontent.com/310855/41111513-1077c17a-6a74-11e8-8e6b-3c0a9ae7f24b.png)


## klee-stats

I've only changed klee-stats in a minimal way to support what I think is the common use case. I don't want this to be bogged down because of `klee-stats`, so I think there are 3 options:

* Delete all the complicated code from `klee-stats` and support only the core.
* Conform to the current LazyList implementation, but this involved reading in the whole database and would give poor performance.
* Decide what nice to have features we want in `klee-stats` (without referring to the current implementation). I'm not sure what people use, but I would keep only the `--print-*` options and add some nice interface to SQL like `klee-stats -s 'SELECT * FROM stats WHERE ... ORDER BY ...'`

SQLite even support [adding custom functions](http://charlesleifer.com/blog/five-reasons-you-should-use-sqlite-in-2016/) to SQL, which could make querying in `klee-stats` even easier.