### PR TITLE
Improve ConstantExpr performance

### DIFF
--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -182,7 +182,12 @@ unsigned Expr::computeHash() {
 }
 
 unsigned ConstantExpr::computeHash() {
-  hashValue = hash_value(value) ^ (getWidth() * MAGIC_HASH_CONSTANT);
+  Expr::Width w = getWidth();
+  if (w <= 64)
+    hashValue = value.getLimitedValue() ^ (w * MAGIC_HASH_CONSTANT);
+  else
+    hashValue = hash_value(value) ^ (w * MAGIC_HASH_CONSTANT);
+
   return hashValue;
 }
 

--- a/test/Feature/DeterministicSwitch.c
+++ b/test/Feature/DeterministicSwitch.c
@@ -27,11 +27,11 @@ int main(int argc, char **argv) {
   }
 
   // CHECK-DFS: default
-  // CHECK-DFS: space
   // CHECK-DFS: tab
+  // CHECK-DFS: space
 
-  // CHECK-BFS: tab
   // CHECK-BFS: space
+  // CHECK-BFS: tab
   // CHECK-BFS: default
 
   return 0;


### PR DESCRIPTION
I did some flame graph profiling and noticed that ConstantExprs take some time, because they are computing the hash.

The reason is that `hash_value(APInt)` is quite expensive. Considering that most of our ConstantExpr, should fit in 64bits, it should be fine to just use `getLimitedValue`. If there are some ConstantExpr with more than 64bits, this still works fine, but there might be more collisions. However I don't think wide ConstantExprs are  common enough to be a problem.