### PR TITLE
Improve klee_is_symbolic

### DIFF
--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -100,7 +100,8 @@ extern "C" {
    * and writing tests but can also be used to enable prints in replay
    * mode.
    */
-  unsigned klee_is_symbolic(uintptr_t n);
+  #define klee_is_symbolic(n) _klee_is_symbolic(n, __LINE__)
+  unsigned _klee_is_symbolic(uintptr_t n, int unused);
 
 
   /* The following intrinsics are primarily intended for internal use

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -96,6 +96,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
 #else
   add("__error", handleErrnoLocation, true),
 #endif
+  add("_klee_is_symbolic", handleIsSymbolic, true),
   add("klee_is_symbolic", handleIsSymbolic, true),
   add("klee_make_symbolic", handleMakeSymbolic, false),
   add("klee_mark_global", handleMarkGlobal, false),
@@ -456,7 +457,8 @@ void SpecialFunctionHandler::handleAssume(ExecutionState &state,
 void SpecialFunctionHandler::handleIsSymbolic(ExecutionState &state,
                                 KInstruction *target,
                                 std::vector<ref<Expr> > &arguments) {
-  assert(arguments.size()==1 && "invalid number of arguments to klee_is_symbolic");
+  assert(arguments.size() < 3 && "invalid number of arguments to klee_is_symbolic");
+  assert(arguments.size() > 0 && "invalid number of arguments to klee_is_symbolic");
 
   ref<Expr> arg0 = executor.toUnique(state, arguments[0]);
 

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -459,7 +459,6 @@ void SpecialFunctionHandler::handleIsSymbolic(ExecutionState &state,
   assert(arguments.size()==1 && "invalid number of arguments to klee_is_symbolic");
 
   ref<Expr> arg0 = executor.toUnique(state, arguments[0]);
-  
 
   executor.bindLocal(target, state, 
                      ConstantExpr::create(!isa<ConstantExpr>(arg0),

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -458,8 +458,11 @@ void SpecialFunctionHandler::handleIsSymbolic(ExecutionState &state,
                                 std::vector<ref<Expr> > &arguments) {
   assert(arguments.size()==1 && "invalid number of arguments to klee_is_symbolic");
 
+  ref<Expr> arg0 = executor.toUnique(state, arguments[0]);
+  
+
   executor.bindLocal(target, state, 
-                     ConstantExpr::create(!isa<ConstantExpr>(arguments[0]),
+                     ConstantExpr::create(!isa<ConstantExpr>(arg0),
                                           Expr::Int32));
 }
 

--- a/test/Feature/IsSymbolic.c
+++ b/test/Feature/IsSymbolic.c
@@ -6,6 +6,7 @@
 
 int main() {
   int x, y, z = 0;
+  int array[5] = {1,1,1,1,1};
   klee_make_symbolic(&x, sizeof x, "x");
   klee_make_symbolic(&y, sizeof y, "y");
   if (x) {
@@ -13,5 +14,9 @@ int main() {
   } else {
     assert(!klee_is_symbolic(z));
   }
+
+  klee_assume(y >= 0 & y <= 4);
+  assert(!klee_is_symbolic(array[y]));
+
   return 0;
 }

--- a/test/Feature/IsSymbolic.c
+++ b/test/Feature/IsSymbolic.c
@@ -12,10 +12,13 @@ int main() {
   klee_assume(y >= 0 & y <= 4);
 
   int array[5] = {1,1,x,1,1};
+  assert(klee_is_symbolic(array[2]));
   if (x == 1) {
+    assert(!klee_is_symbolic(array[2]));
     assert(klee_is_symbolic(y));
     assert(!klee_is_symbolic(array[y]));
   } else {
+    assert(klee_is_symbolic(array[2]));
     assert(!klee_is_symbolic(z));
     assert(klee_is_symbolic(array[y]));
   }

--- a/test/Feature/IsSymbolic.c
+++ b/test/Feature/IsSymbolic.c
@@ -1,22 +1,25 @@
 // RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out %t1.bc
+// RUN: %klee -exit-on-error --output-dir=%t.klee-out %t1.bc  &> %t1.log
 
 #include <assert.h>
+#include "klee/klee.h"
 
 int main() {
   int x, y, z = 0;
-  int array[5] = {1,1,1,1,1};
   klee_make_symbolic(&x, sizeof x, "x");
   klee_make_symbolic(&y, sizeof y, "y");
-  if (x) {
+  klee_assume(y >= 0 & y <= 4);
+
+  int array[5] = {1,1,x,1,1};
+  if (x == 1) {
     assert(klee_is_symbolic(y));
+    assert(!klee_is_symbolic(array[y]));
   } else {
     assert(!klee_is_symbolic(z));
+    assert(klee_is_symbolic(array[y]));
   }
 
-  klee_assume(y >= 0 & y <= 4);
-  assert(!klee_is_symbolic(array[y]));
 
   return 0;
 }

--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -414,6 +414,10 @@ unsigned klee_is_symbolic(uintptr_t x) {
   return 0;
 }
 
+unsigned _klee_is_symbolic(uintptr_t x) {
+  return 0;
+}
+
 void klee_prefer_cex(void *buffer, uintptr_t condition) {
   ;
 }


### PR DESCRIPTION
This is a tiny patch, that makes `klee_is_symbolic` a bit more expensive, but more useful too. It let's you write code like

```C
int i;
klee_make_symbolic(&i, sizeof(i), "i");
klee_assume(i >= 0 & i <= 4);

int array[5] = {1,1,1,1,1};
if(klee_is_symbolic(array[i]) == 0) {
   reachable now, unreachable before.
}
```

I needed this to implement my synthesis.