### PR TITLE
[WIP] Make read8(unsigned) flush to improve ReadExpr comparisons

### DIFF
--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -296,21 +296,22 @@ void ObjectState::fastRangeCheckOffset(ref<Expr> offset,
 
 void ObjectState::flushRangeForRead(unsigned rangeBase, 
                                     unsigned rangeSize) const {
-  if (!flushMask) flushMask = new BitArray(size, true);
+//  if (!flushMask) flushMask = new BitArray(size, true);
  
   for (unsigned offset=rangeBase; offset<rangeBase+rangeSize; offset++) {
-    if (!isByteFlushed(offset)) {
+  //  if (isByteFlushed(offset)) {
       if (isByteConcrete(offset)) {
         updates.extend(ConstantExpr::create(offset, Expr::Int32),
                        ConstantExpr::create(concreteStore[offset], Expr::Int8));
-      } else {
+      } else if(isByteKnownSymbolic(offset)) {
         assert(isByteKnownSymbolic(offset) && "invalid bit set in flushMask");
         updates.extend(ConstantExpr::create(offset, Expr::Int32),
                        knownSymbolics[offset]);
       }
 
-      flushMask->unset(offset);
-    }
+  //    if(flushMask)
+  //      flushMask->unset(offset);
+  //  }
   } 
 }
 
@@ -395,7 +396,7 @@ void ObjectState::setKnownSymbolic(unsigned offset,
 /***/
 
 ref<Expr> ObjectState::read8(unsigned offset) const {
-  flushRangeForRead(0, size);
+//  flushRangeForRead(0, size);
   if (isByteConcrete(offset)) {
     return ConstantExpr::create(concreteStore[offset], Expr::Int8);
   } else if (isByteKnownSymbolic(offset)) {

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -395,6 +395,7 @@ void ObjectState::setKnownSymbolic(unsigned offset,
 /***/
 
 ref<Expr> ObjectState::read8(unsigned offset) const {
+  flushRangeForRead(0, size);
   if (isByteConcrete(offset)) {
     return ConstantExpr::create(concreteStore[offset], Expr::Int8);
   } else if (isByteKnownSymbolic(offset)) {

--- a/test/Feature/ConstAndSymbolicRead.c
+++ b/test/Feature/ConstAndSymbolicRead.c
@@ -1,0 +1,20 @@
+// RUN: %llvmgcc %s -g -emit-llvm -O0 -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out -use-query-log=all:kquery %t1.bc  
+//FileCheck %s
+
+
+int main() {
+  char  arr[3];
+  char symbolic;
+  klee_make_symbolic(&symbolic, sizeof(symbolic), "symbolic");
+  klee_assume(symbolic >= 0 & symbolic < 3);
+  klee_make_symbolic(arr, sizeof(arr), "arr");
+  arr[1] = 0;
+
+  char a = arr[2];
+  char b = arr[symbolic];
+  if(a == b) printf("Equal!\n");
+  else printf("Not Equal!\n");
+  return 0;
+}

--- a/test/Runtime/POSIX/PrgName.c
+++ b/test/Runtime/POSIX/PrgName.c
@@ -1,6 +1,10 @@
 // RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t2.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --posix-runtime --exit-on-error %t2.bc --sym-arg 10 >%t.log
+// RUN: perf record -F 999 -a -o %t.out.data  -g -- %klee --output-dir=%t.klee-out --posix-runtime --exit-on-error %t2.bc --sym-arg 10 >%t.log
+// RUN:   perf script -i %t.out.data > %t.out.perf
+// RUN:   /data/Random/FlameGraph/stackcollapse-perf.pl %t.out.perf > %t.out.folded
+// RUN:   cat %t.out.folded | /data/Random/FlameGraph/flamegraph.pl > %t.data.svg
+
 // RUN: test -f %t.klee-out/test000001.ktest
 // RUN: test -f %t.klee-out/test000002.ktest
 // RUN: grep -q "No" %t.log


### PR DESCRIPTION
This is the root cause of @251's divergencies, but I think it should be upstreamed too. Consider the following sequence of read/write operations.

```C
arr[3];
klee_make_symbolic(arr, sizeof(arr), "arr");
arr[2] = 0;
arr[2];
arr[symbolic];
```

Currently this generates the following two read expressions:

```
(ReadExpr 2 @arr)
(ReadExpr (...)  [2=0]@arr)
```

Notice the two read expressions read from different arrays, one is `@arr` and the other one is `@arr` with index 2 changed to 0. The reason is that `read8(unsigned)` doesn't flush so the write hasn't been put into the update list yet. 

That means that KLEE can't see that the two ReadExprs read from the same array and therefore can't do caching and other things properly. For example @251 also observed redundant  constraints being added because KLEE didn't realise it's the same ReadExpr.

The downside is that flushing now happens (much) more often.