### PR TITLE
Fixed runtest library to handle the case of a NULL "name" argument in…

### DIFF
--- a/runtime/Runtest/intrinsics.c
+++ b/runtime/Runtest/intrinsics.c
@@ -50,6 +50,10 @@ static void report_internal_error(const char *msg, ...) {
 }
 
 void klee_make_symbolic(void *array, size_t nbytes, const char *name) {
+
+  if (!name)
+    name = "unnamed";
+
   static int rand_init = -1;
 
   if (rand_init == -1) {

--- a/test/Replay/libkleeruntest/replay_two_objects.c
+++ b/test/Replay/libkleeruntest/replay_two_objects.c
@@ -15,7 +15,7 @@ int main(int argc, char** argv) {
   int x = 0;
   int y = 0;
   klee_make_symbolic(&x, sizeof(x), "x");
-  klee_make_symbolic(&y, sizeof(x), "y");
+  klee_make_symbolic(&y, sizeof(y), NULL);
 
   klee_assume(x == 1);
   klee_assume(y == 128);


### PR DESCRIPTION
… klee_make_symbolic.  Changed a test case to check this feature. 