### PR TITLE
Removed support for klee_make_symbolic with 2 arguments.  This has be…

### DIFF
--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -755,19 +755,13 @@ void SpecialFunctionHandler::handleMakeSymbolic(ExecutionState &state,
                                                 std::vector<ref<Expr> > &arguments) {
   std::string name;
 
-  // FIXME: For backwards compatibility. We should eventually enforce the
-  // correct arguments and types.
-  switch (arguments.size()) {
-    case 2:
-      klee_warning("klee_make_symbolic: deprecated number of arguments (2 instead of 3)");
-      break;
-    case 3:
-      name = arguments[2]->isZero() ? "" : readStringAtAddress(state, arguments[2]);
-      break;
-    default:
-      executor.terminateStateOnError(state, "illegal number of arguments to klee_make_symbolic(void*, size_t, char*)", Executor::User);
-      return;
+  if (arguments.size() != 3) {
+    executor.terminateStateOnError(state, "Incorrect number of arguments to klee_make_symbolic(void*, size_t, char*)", Executor::User);
+    return;
   }
+
+  name = arguments[2]->isZero() ? "" : readStringAtAddress(state, arguments[2]);
+
   if (name.length() == 0) {
     name = "unnamed";
     klee_warning("klee_make_symbolic: renamed empty name to \"unnamed\"");

--- a/test/Feature/MakeSymbolicAPI.c
+++ b/test/Feature/MakeSymbolicAPI.c
@@ -5,24 +5,25 @@
 // RUN: FileCheck %s -check-prefix=CHECK-ERR --input-file=%t.stderr.log
 
 int main() {
-  unsigned a, b, c, d, e;
+  unsigned a, b, c;
+  char* p;
   const char *invalid_pointer = 0xf;
 
   klee_make_symbolic(&a, sizeof(a), "");
   //CHECK-WRN: KLEE: WARNING: klee_make_symbolic: renamed empty name to "unnamed"
 
+  klee_make_symbolic(&p, sizeof(p), "p");
 
-  klee_make_symbolic(&b, sizeof(b));
-  //CHECK-WRN: KLEE: WARNING: klee_make_symbolic: deprecated number of arguments (2 instead of 3)
-  //CHECK-WRN: KLEE: WARNING: klee_make_symbolic: renamed empty name to "unnamed"
-
-  if(a == 2)
-    klee_make_symbolic(&d, sizeof(e), invalid_pointer);
+  if (a == 2)
+    klee_make_symbolic(&c, sizeof(c), invalid_pointer);
     //CHECK-ERR-DAG: KLEE: ERROR: {{.*}} Invalid string pointer passed to one of the klee_ functions
-  if(a == 3)
-    klee_make_symbolic(&d, sizeof(e), (char *) b);
+
+  if (a == 3)
+    klee_make_symbolic(&c, sizeof(c), p);
     //CHECK-ERR-DAG: KLEE: ERROR: {{.*}} Symbolic string pointer passed to one of the klee_ functions
 
-  klee_make_symbolic(&c);
-  //CHECK-ERR-DAG: KLEE: ERROR: {{.*}} illegal number of arguments to klee_make_symbolic(void*, size_t, char*)
+  klee_make_symbolic(&b, sizeof(b));
+  //CHECK-ERR-DAG: KLEE: ERROR: {{.*}} Incorrect number of arguments to klee_make_symbolic(void*, size_t, char*)
+
+
 }


### PR DESCRIPTION
…en deprecated for many years now and causes problems during replay.  Changed and simplified affected test case.