### PR TITLE
Enable tcmalloc by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,7 @@ endif()
 ################################################################################
 # TCMalloc support
 ################################################################################
-OPTION(ENABLE_TCMALLOC "Enable TCMalloc support" OFF)
+OPTION(ENABLE_TCMALLOC "Enable TCMalloc support" ON)
 if (ENABLE_TCMALLOC)
   message(STATUS "TCMalloc support enabled")
   set(TCMALLOC_HEADER "gperftools/malloc_extension.h")


### PR DESCRIPTION
This changes tcmalloc to be enabled by default as per discussion in #847. I've updated the build documentation in https://github.com/klee/klee.github.io/pull/129.