### PR TITLE
Multiple fixes for the StatsTracker and Searchers

### DIFF
--- a/include/klee/Internal/Support/FileHandling.h
+++ b/include/klee/Internal/Support/FileHandling.h
@@ -9,11 +9,17 @@
 #ifndef __KLEE_FILE_HANDLING_H__
 #define __KLEE_FILE_HANDLING_H__
 #include "llvm/Support/raw_ostream.h"
+#include <memory>
 #include <string>
-
 namespace klee {
-llvm::raw_fd_ostream *klee_open_output_file(std::string &path,
-                                            std::string &error);
+/// Tries to open a file given by path for writing and returns a handle to it if
+/// successful.
+///
+/// @param path to the file
+/// @param error contains an error message if file access was not successful
+/// @return Returns file handle or nullptr if it could not be opened
+std::unique_ptr<llvm::raw_fd_ostream> klee_open_output_file(std::string &path,
+                                                            std::string &error);
 }
 
 #endif

--- a/include/klee/Internal/Support/ModuleUtil.h
+++ b/include/klee/Internal/Support/ModuleUtil.h
@@ -48,7 +48,8 @@ linkModules(std::vector<std::unique_ptr<llvm::Module>> &modules,
 /// If `moduleIsFullyLinked` is set to true it will be assumed that the
 ///  module containing the `llvm::CallSite` is fully linked. This assumption
 ///  allows resolution of functions that are marked as overridable.
-llvm::Function *getDirectCallTarget(llvm::CallSite, bool moduleIsFullyLinked);
+const llvm::Function *getDirectCallTarget(llvm::ImmutableCallSite,
+                                          bool moduleIsFullyLinked);
 
 /// Return true iff the given Function value is used in something
 /// other than a direct call (or a constant expression that

--- a/include/klee/Interpreter.h
+++ b/include/klee/Interpreter.h
@@ -82,9 +82,12 @@ public:
     /// symbolic execution on concrete programs.
     unsigned MakeConcreteSymbolic;
 
+    /// Indicator if coverage information should be generated for each
+    /// test written.
+    bool generatePerTestCoverage;
+
     InterpreterOptions()
-      : MakeConcreteSymbolic(false)
-    {}
+        : MakeConcreteSymbolic(false), generatePerTestCoverage(false) {}
   };
 
 protected:

--- a/include/klee/Interpreter.h
+++ b/include/klee/Interpreter.h
@@ -38,7 +38,9 @@ public:
   virtual llvm::raw_ostream &getInfoStream() const = 0;
 
   virtual std::string getOutputFilename(const std::string &filename) = 0;
-  virtual llvm::raw_fd_ostream *openOutputFile(const std::string &filename) = 0;
+
+  virtual std::unique_ptr<llvm::raw_fd_ostream>
+  openOutputFile(const std::string &filename) = 0;
 
   virtual void incPathsExplored() = 0;
 

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -12,6 +12,7 @@ klee_add_component(kleeCore
   CallPathManager.cpp
   Context.cpp
   CoreStats.cpp
+  CoverageTracker.cpp
   ExecutionState.cpp
   Executor.cpp
   ExecutorTimers.cpp

--- a/lib/Core/CoreStats.cpp
+++ b/lib/Core/CoreStats.cpp
@@ -21,7 +21,6 @@ Statistic stats::instructionTime("InstructionTimes", "Itime");
 Statistic stats::instructions("Instructions", "I");
 Statistic stats::minDistToReturn("MinDistToReturn", "Rdist");
 Statistic stats::minDistToUncovered("MinDistToUncovered", "UCdist");
-Statistic stats::reachableUncovered("ReachableUncovered", "IuncovReach");
 Statistic stats::resolveTime("ResolveTime", "Rtime");
 Statistic stats::solverTime("SolverTime", "Stime");
 Statistic stats::states("States", "States");

--- a/lib/Core/CoreStats.h
+++ b/lib/Core/CoreStats.h
@@ -34,10 +34,6 @@ namespace stats {
   /// isn't normally up-to-date.
   extern Statistic states;
 
-  /// Instruction level statistic for tracking number of reachable
-  /// uncovered instructions.
-  extern Statistic reachableUncovered;
-
   /// Instruction level statistic tracking the minimum intraprocedural
   /// distance to an uncovered instruction; this is only periodically
   /// updated.
@@ -46,7 +42,6 @@ namespace stats {
   /// Instruction level statistic tracking the minimum intraprocedural
   /// distance to a function return.
   extern Statistic minDistToReturn;
-
 }
 }
 

--- a/lib/Core/CoverageTracker.cpp
+++ b/lib/Core/CoverageTracker.cpp
@@ -1,0 +1,486 @@
+//===-- CoverageTracker.cpp -------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CoverageTracker.h"
+#include "klee/Config/Version.h"
+
+#include "llvm/ADT/ilist.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/CommandLine.h"
+
+#if LLVM_VERSION_CODE < LLVM_VERSION(3, 5)
+#include "llvm/Support/CFG.h"
+#include "llvm/Support/CallSite.h"
+#else
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/CallSite.h"
+#endif
+
+#include <algorithm>
+#include <iterator>
+#include <set>
+#include <utility>
+
+#include "CoreStats.h"
+#include "Executor.h"
+#include "StatsTracker.h"
+#include "klee/ExecutionState.h"
+#include "klee/Internal/Module/InstructionInfoTable.h"
+#include "klee/Internal/Module/KInstIterator.h"
+#include "klee/Internal/Module/KInstruction.h"
+#include "klee/Internal/Module/KModule.h"
+#include "klee/Internal/Support/ModuleUtil.h"
+#include "klee/Statistic.h"
+#include "klee/Statistics.h"
+
+namespace {
+llvm::cl::OptionCategory
+    CoverageTracking("Coverage Tracking",
+                     "Controls which coverage information should be tracked");
+
+// XXX I really would like to have dynamic rate control for something like this.
+llvm::cl::opt<double> UncoveredUpdateInterval("uncovered-update-interval",
+                                              llvm::cl::init(30.),
+                                              llvm::cl::desc("(default=30.0s)"),
+                                              llvm::cl::cat(CoverageTracking));
+
+llvm::cl::opt<bool> TrackBranchCoverage(
+    "track-coverage-branch", llvm::cl::init(false),
+    llvm::cl::desc("Track coverage of branches (default: false)"),
+    llvm::cl::cat(CoverageTracking));
+} // namespace
+
+using namespace klee;
+
+class UpdateReachableTimer : public Executor::Timer {
+  CoverageTracker &coverageTracker;
+
+public:
+  UpdateReachableTimer(CoverageTracker &_coverageTracker)
+      : coverageTracker(_coverageTracker) {}
+
+  void run() { coverageTracker.computeReachableUncovered(); }
+};
+
+/// Returns a list of director successors of the provided instructions
+///
+/// The list will contain one item most of the time or multiple in case
+/// the instruction is a conditional branch or switch
+///
+/// XXX What happens with noreturn, unreachable?
+static std::vector<const llvm::Instruction *>
+getSuccs(const llvm::Instruction *i) {
+  auto ParentBasicBlock = i->getParent();
+  std::vector<const llvm::Instruction *> res;
+
+  if (i == ParentBasicBlock->getTerminator()) {
+    for (auto it = llvm::succ_begin(ParentBasicBlock),
+              ie = llvm::succ_end(ParentBasicBlock);
+         it != ie; ++it)
+      res.push_back(&*(it->begin()));
+  } else {
+    res.push_back(&*(++llvm::BasicBlock::const_iterator(i)));
+  }
+
+  return res;
+}
+
+/// Check for special cases where we statically know an instruction is
+/// uncoverable. Currently the case is an unreachable instruction
+/// following a noreturn call; the instruction is really only there to
+/// satisfy LLVM's termination requirement.
+static bool instructionIsCoverable(llvm::Instruction *i) {
+  return i->getOpcode() != llvm::Instruction::Unreachable;
+}
+
+void CoverageTracker::calculateDistanceToReturn() {
+  const llvm::Module *m = kmodule.module.get();
+  const InstructionInfoTable &infos = *kmodule.infos;
+  StatisticManager &sm = *theStatisticManager;
+
+  // Compute call targets.
+  for (auto &Func : *m) {
+    for (auto &BB : Func) {
+      for (auto &Inst : BB) {
+        if (!isa<llvm::CallInst>(Inst) && !isa<llvm::InvokeInst>(Inst))
+          continue;
+        llvm::ImmutableCallSite cs(&Inst);
+        if (isa<llvm::InlineAsm>(cs.getCalledValue())) {
+          // We can never call through here so assume no targets
+          // (which should be correct anyhow).
+          callTargets.insert(
+              std::make_pair(&Inst, std::vector<const llvm::Function *>()));
+        } else if (const llvm::Function *target =
+                       getDirectCallTarget(cs, /*moduleIsFullyLinked=*/true)) {
+          callTargets[&Inst].push_back(target);
+        } else {
+          // It would be nice to use alias information
+          // instead of assuming all indirect calls hit all escaping
+          // functions, eh?
+          callTargets[&Inst] = std::vector<const llvm::Function *>(
+              kmodule.escapingFunctions.begin(),
+              kmodule.escapingFunctions.end());
+        }
+      }
+    }
+  }
+
+  // Reflexively compute function callers for callTargets.
+  for (auto &callerCalleePair : callTargets) {
+    for (auto &callee : callerCalleePair.second) {
+      functionCallers[callee].push_back(callerCalleePair.first);
+    }
+  }
+
+  // Assign every function a shortest path value, i.e.
+  // if a function is called, what is the shortest path possible to return from
+  // it 0 marks it no shortest path to return (e.g. noreturn functions).
+  std::vector<const llvm::Instruction *> instructions;
+  for (auto &Func : *m) {
+    if (Func.isDeclaration()) {
+      if (Func.doesNotReturn()) {
+        functionShortestPath[&Func] = 0;
+      } else {
+        // Mark external calls
+        // XXX quite small value, favours external calls
+        functionShortestPath[&Func] = 1;
+      }
+    } else {
+      // We start marking a function being unreachable
+      functionShortestPath[&Func] = 0;
+
+      // there's a corner case here when a function only includes a single
+      // instruction (a ret). in that case, we MUST update
+      // functionShortestPath, or it will remain 0 (erroneously indicating
+      // that no return instructions are reachable)
+
+      // If the function immediately returns, mark it as reachable
+      if (isa<llvm::ReturnInst>(Func.getEntryBlock().getFirstNonPHI()))
+        functionShortestPath[&Func] = 1;
+    }
+
+    // Mark all the return instructions of a function to have a shortest path
+    // set to 1 (the instruction itself)
+    for (auto &BB : Func) {
+      for (auto &Inst : BB) {
+        instructions.push_back(&Inst);
+        unsigned id = infos.getInfo(&Inst).id;
+        sm.setIndexedValue(stats::minDistToReturn, id,
+                           isa<llvm::ReturnInst>(Inst) ? 1 : 0);
+      }
+    }
+  }
+
+  // propagate bottom-up, from the return instructions to the entry of the
+  // function the shortest distance to the return instruction
+  std::reverse(instructions.begin(), instructions.end());
+  bool changed;
+  do {
+    changed = false;
+    for (auto inst : instructions) {
+      unsigned bestThrough = 0;
+      if (isa<llvm::CallInst>(inst) || isa<llvm::InvokeInst>(inst)) {
+        // Check every possible callee of this instruction
+        // and take the shortest one
+        for (auto calledFunction : callTargets[inst]) {
+          uint64_t dist = functionShortestPath[calledFunction];
+          if (!dist)
+            continue;
+          dist = 1 + dist; // count call/invoke instruction itself
+          // update to the smallest or if not set yet
+          if (bestThrough == 0 || dist < bestThrough)
+            bestThrough = dist;
+        }
+      } else {
+        // one instruction, one step
+        bestThrough = 1;
+      }
+
+      // skip, if no way for this instruction found
+      if (!bestThrough)
+        continue;
+
+      // retrieve the current distance to the return value
+      unsigned id = infos.getInfo(inst).id;
+      uint64_t best,
+          oldBest = best = sm.getIndexedValue(stats::minDistToReturn, id);
+
+      // and combine it with the shortest path among all direct successors
+      for (auto successor : getSuccs(inst)) {
+        uint64_t dist = sm.getIndexedValue(stats::minDistToReturn,
+                                           infos.getInfo(successor).id);
+        if (!dist)
+          continue;
+
+        // select shortest path among the successors
+        uint64_t val = bestThrough + dist;
+        if (best == 0 || val < best)
+          best = val;
+      }
+
+      // Check if anything changed
+      if (best == oldBest)
+        continue;
+
+      // update instruction to the new best value
+      sm.setIndexedValue(stats::minDistToReturn, id, best);
+      changed = true;
+    }
+  } while (changed);
+}
+
+void CoverageTracker::computeReachableUncovered(const KModule *km) {
+  const llvm::Module *m = km->module.get();
+  const InstructionInfoTable &infos = *km->infos;
+  StatisticManager &sm = *theStatisticManager;
+
+  // Initialise the minimum distance with the information of still
+  // uncovered instructions
+  // 0 indicates the instruction is already covered
+  std::vector<const llvm::Instruction *> instructions;
+  for (auto &Func : *m) {
+    for (auto &BB : Func) {
+      for (auto &Inst : BB) {
+        unsigned id = infos.getInfo(&Inst).id;
+        instructions.push_back(&Inst);
+        sm.setIndexedValue(
+            stats::minDistToUncovered, id,
+            sm.getIndexedValue(stats::uncoveredInstructions, id));
+      }
+    }
+  }
+
+  std::reverse(instructions.begin(), instructions.end());
+  bool changed;
+  do {
+    changed = false;
+    for (auto &inst : instructions) {
+      uint64_t shortestDistToUncovered,
+          oldBest = shortestDistToUncovered = sm.getIndexedValue(
+              stats::minDistToUncovered, infos.getInfo(inst).id);
+      unsigned minDistToReturn = 0;
+
+      if (isa<llvm::CallInst>(inst) || isa<llvm::InvokeInst>(inst)) {
+        // Find shortest path to return instruction and shortest path to
+        // uncovered instruction
+        minDistToReturn =
+            sm.getIndexedValue(stats::minDistToReturn, infos.getInfo(inst).id);
+
+        // Retrieve the shortest path to the next uncovered instruction for all
+        // possibly called functions
+        for (auto fnIt : callTargets[inst]) {
+          // Get the distance of the callee
+          uint64_t calleeDist = sm.getIndexedValue(
+              stats::minDistToUncovered, infos.getFunctionInfo(fnIt).id);
+          if (!calleeDist)
+            continue;
+
+          calleeDist = 1 + calleeDist; // count instruction itself
+          if (shortestDistToUncovered == 0 ||
+              calleeDist < shortestDistToUncovered)
+            shortestDistToUncovered = calleeDist;
+        }
+      } else {
+        minDistToReturn = 1;
+      }
+
+      if (minDistToReturn) {
+        for (auto successorInt : getSuccs(inst)) {
+          uint64_t distUncoveredNext = sm.getIndexedValue(
+              stats::minDistToUncovered, infos.getInfo(successorInt).id);
+          if (!distUncoveredNext)
+            continue;
+
+          uint64_t val = minDistToReturn + distUncoveredNext;
+          if (shortestDistToUncovered == 0 || val < shortestDistToUncovered)
+            shortestDistToUncovered = val;
+        }
+      }
+
+      // if nothing changed, move on
+      if (shortestDistToUncovered == oldBest)
+        continue;
+
+      // update with the newest shortest distance to uncovered
+      sm.setIndexedValue(stats::minDistToUncovered, infos.getInfo(inst).id,
+                         shortestDistToUncovered);
+      changed = true;
+    }
+  } while (changed);
+}
+
+void CoverageTracker::updateAllStateCoverage() {
+  // Update all states
+  // XXX Do that more clever
+  for (auto &state : states) {
+    uint64_t currentFrameMinDist = 0;
+    for (auto sfIt = state->stack.begin(), sf_ie = state->stack.end();
+         sfIt != sf_ie; ++sfIt) {
+      auto next = sfIt + 1;
+      KInstIterator kii;
+      if (next == state->stack.end()) {
+        kii = state->pc;
+      } else {
+        kii = next->caller;
+        ++kii;
+      }
+      sfIt->minDistToUncoveredOnReturn = currentFrameMinDist;
+      currentFrameMinDist = computeMinDistToUncovered(kii, currentFrameMinDist);
+    }
+  }
+}
+
+uint64_t klee::computeMinDistToUncovered(const KInstruction *ki,
+                                         uint64_t minDistAtRA) {
+  StatisticManager &sm = *theStatisticManager;
+
+  if (minDistAtRA == 0) // unreachable on return, best is local
+    return sm.getIndexedValue(stats::minDistToUncovered, ki->info->id);
+
+  uint64_t minDistLocal =
+      sm.getIndexedValue(stats::minDistToUncovered, ki->info->id);
+  uint64_t distToReturn =
+      sm.getIndexedValue(stats::minDistToReturn, ki->info->id);
+
+  // return unreachable, best is local
+  if (distToReturn == 0)
+    return minDistLocal;
+
+  // if no local instruction is uncovered, go back immediately
+  if (!minDistLocal)
+    return distToReturn + minDistAtRA;
+
+  // select the shortest of either a locally reachable uncovered instruction or
+  // the one on return
+  return std::min(minDistLocal, distToReturn + minDistAtRA);
+}
+
+void CoverageTracker::computeReachableUncovered() {
+  if (!initReachableUncovered) {
+    initReachableUncovered = true;
+    calculateDistanceToReturn();
+  }
+  computeReachableUncovered(executor.kmodule.get());
+  updateAllStateCoverage();
+}
+
+
+void CoverageTracker::initializeCoverageTracking() {
+
+  // Setup the coverage-based tracking
+
+  // We need to request instruction-based tracking to make this work
+  statsTracker.doTrackByInstruction();
+
+  // Calculate uncovered instructions and uncovered branches
+  for (const auto &kf : kmodule.functions) {
+
+    // skip functions that we are not interested in covering (we assume that
+    // everything is already covered)
+    if (!kf->trackCoverage)
+      continue;
+
+    for (unsigned i = 0; i < kf->numInstructions; ++i) {
+      KInstruction *ki = kf->instructions[i];
+
+      unsigned id = ki->info->id;
+      theStatisticManager->setIndex(id);
+      if (instructionIsCoverable(ki->inst))
+        ++stats::uncoveredInstructions;
+
+      if (llvm::BranchInst *bi = dyn_cast<llvm::BranchInst>(ki->inst))
+        if (!bi->isUnconditional())
+          numBranches++;
+    }
+  }
+}
+
+void CoverageTracker::requestAutomaticDistanceCalculation() {
+  if (automaticDistanceUpdate)
+    return;
+  automaticDistanceUpdate = true;
+
+  computeReachableUncovered();
+  executor.addTimer(new UpdateReachableTimer(*this), UncoveredUpdateInterval);
+}
+
+void CoverageTracker::stepInstruction(ExecutionState &es) {
+  const InstructionInfo &ii = *es.pc->info;
+  StackFrame &sf = es.stack.back();
+
+  if (es.instsSinceCovNew)
+    ++es.instsSinceCovNew;
+
+  // Check if this covers an uncovered instruction
+  if (sf.kf->trackCoverage && instructionIsCoverable(es.pc->inst) &&
+      !theStatisticManager->getIndexedValue(stats::coveredInstructions,
+                                            ii.id)) {
+    es.coveredNew = true;
+    es.instsSinceCovNew = 1;
+    ++stats::coveredInstructions;
+    stats::uncoveredInstructions += (uint64_t)-1;
+
+    // Update list of newly covered lines
+    es.coveredLines[&ii.file].insert(ii.line);
+  }
+}
+
+bool CoverageTracker::userRequestedCoverageTracking() {
+  return TrackBranchCoverage;
+}
+
+void CoverageTracker::markBranchVisited(ExecutionState *visitedTrue,
+                                        ExecutionState *visitedFalse) {
+  if (TrackBranchCoverage)
+    return;
+  unsigned id = theStatisticManager->getIndex();
+  uint64_t hasTrue =
+      theStatisticManager->getIndexedValue(stats::trueBranches, id);
+  uint64_t hasFalse =
+      theStatisticManager->getIndexedValue(stats::falseBranches, id);
+  if (visitedTrue && !hasTrue) {
+    visitedTrue->coveredNew = true;
+    visitedTrue->instsSinceCovNew = 1;
+    ++stats::trueBranches;
+    if (hasFalse) {
+      ++fullBranches;
+      --partialBranches;
+    } else
+      ++partialBranches;
+    hasTrue = 1;
+  }
+  if (visitedFalse && !hasFalse) {
+    visitedFalse->coveredNew = true;
+    visitedFalse->instsSinceCovNew = 1;
+    ++stats::falseBranches;
+    if (hasTrue) {
+      ++fullBranches;
+      --partialBranches;
+    } else
+      ++partialBranches;
+  }
+}
+
+void CoverageTracker::updateFrameCoverage(ExecutionState &es) {
+  if (!automaticDistanceUpdate)
+    return;
+  StackFrame &sf = es.stack.back();
+
+  // Get DistanceToUncovered of parent stackframe if available
+  uint64_t minDistAtRA =
+      es.stack.size() > 1
+          ? es.stack[es.stack.size() - 2].minDistToUncoveredOnReturn
+          : 0;
+
+  sf.minDistToUncoveredOnReturn =
+      sf.caller ? computeMinDistToUncovered(sf.caller, minDistAtRA) : 0;
+}

--- a/lib/Core/CoverageTracker.h
+++ b/lib/Core/CoverageTracker.h
@@ -1,0 +1,94 @@
+//===-- CoverageTracker.h ---------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LIB_CORE_COVERAGETRACKER_H_
+#define LIB_CORE_COVERAGETRACKER_H_
+
+#include <cstdint>
+#include <map>
+#include <set>
+#include <vector>
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instruction.h"
+
+namespace klee {
+class ExecutionState;
+class Executor;
+class KInstruction;
+class KModule;
+class StatsTracker;
+
+class CoverageTracker {
+  typedef std::map<const llvm::Instruction *,
+                   std::vector<const llvm::Function *>>
+      calltargets_ty;
+
+  calltargets_ty callTargets;
+  std::map<const llvm::Function *, std::vector<const llvm::Instruction *>>
+      functionCallers;
+  std::map<const llvm::Function *, unsigned> functionShortestPath;
+
+  StatsTracker &statsTracker;
+  KModule &kmodule;
+  std::set<ExecutionState *> &states;
+
+  bool initReachableUncovered;
+
+  bool automaticDistanceUpdate;
+  Executor &executor;
+
+  void computeReachableUncovered(const KModule *km);
+
+public:
+  CoverageTracker(StatsTracker &tracker, KModule &km,
+                  std::set<ExecutionState *> &_states, Executor &ex)
+      : statsTracker(tracker), kmodule(km), states(_states),
+        initReachableUncovered(false), automaticDistanceUpdate(false),
+        executor(ex), numBranches(0), fullBranches(0), partialBranches(0){};
+
+  void initializeCoverageTracking();
+
+  /// Request different distance matrices be calculated automatically
+  ///
+  void requestAutomaticDistanceCalculation();
+
+  void calculateDistanceToReturn();
+  void computeReachableUncovered();
+
+  void updateAllStateCoverage();
+
+  void stepInstruction(ExecutionState &es);
+
+  /// Check if the user explicitly requests coverage tracking
+  /// @return true, if requested, otherwise false
+  static bool userRequestedCoverageTracking();
+
+  // For branch-based tracking
+  void markBranchVisited(ExecutionState *visitedTrue,
+                         ExecutionState *visitedFalse);
+  // Tracking on branch level
+  unsigned numBranches;
+  unsigned fullBranches, partialBranches;
+
+  void updateFrameCoverage(ExecutionState &es);
+};
+
+/// Computes the distance to the next uncovered instruction
+///
+/// @param ki the instruction to start with
+/// @param minDistAtRA minimum distance to uncovered instruction on return (i.e.
+/// the actual parent stackframe)
+/// @return distance calculated
+uint64_t computeMinDistToUncovered(const KInstruction *ki,
+                                   uint64_t minDistAtRA);
+
+} // namespace klee
+
+#endif /* LIB_CORE_COVERAGETRACKER_H_ */

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -25,10 +25,11 @@
 
 #include "llvm/ADT/Twine.h"
 
-#include <vector>
-#include <string>
 #include <map>
+#include <memory>
 #include <set>
+#include <string>
+#include <vector>
 
 struct KTest;
 
@@ -79,6 +80,7 @@ namespace klee {
   /// removedStates, and haltExecution, among others.
 
 class Executor : public Interpreter {
+  friend class CoverageTracker;
   friend class RandomPathSearcher;
   friend class OwningSearcher;
   friend class WeightedRandomSearcher;
@@ -234,6 +236,9 @@ private:
                                     ExecutionState &state);
   
   void executeInstruction(ExecutionState &state, KInstruction *ki);
+
+  /// Process updates after an instruction has been made
+  void postExecuteInstruction(ExecutionState &state);
 
   void printFileLine(ExecutionState &state, KInstruction *ki,
                      llvm::raw_ostream &file);
@@ -454,12 +459,6 @@ private:
                                     ref<Expr> e,
                                     ref<ConstantExpr> value);
 
-  /// Add a timer to be executed periodically.
-  ///
-  /// \param timer The timer object to run on firings.
-  /// \param rate The approximate delay (in seconds) between firings.
-  void addTimer(Timer *timer, double rate);
-
   void initTimers();
   void processTimers(ExecutionState *current,
                      double maxInstTime);
@@ -543,6 +542,12 @@ public:
 
   /// Returns the errno location in memory of the state
   int *getErrnoLocation(const ExecutionState &state) const;
+
+  /// Add a timer to be executed periodically.
+  ///
+  /// \param timer The timer object to run on firings.
+  /// \param rate The approximate delay (in seconds) between firings.
+  void addTimer(Timer *timer, double rate);
 };
   
 } // End klee namespace

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -127,8 +127,12 @@ private:
   ExternalDispatcher *externalDispatcher;
   TimingSolver *solver;
   MemoryManager *memory;
+
+public:
   std::set<ExecutionState*> states;
-  StatsTracker *statsTracker;
+  std::unique_ptr<StatsTracker> statsTracker;
+
+private:
   TreeStreamWriter *pathWriter, *symPathWriter;
   SpecialFunctionHandler *specialFunctionHandler;
   std::vector<TimerInfo*> timers;

--- a/lib/Core/ExecutorTimers.cpp
+++ b/lib/Core/ExecutorTimers.cpp
@@ -8,10 +8,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "CoreStats.h"
+#include "CoverageTracker.h"
 #include "Executor.h"
+#include "ExecutorTimerInfo.h"
 #include "PTree.h"
 #include "StatsTracker.h"
-#include "ExecutorTimerInfo.h"
 
 #include "klee/ExecutionState.h"
 #include "klee/Internal/Module/InstructionInfoTable.h"
@@ -145,13 +146,13 @@ void Executor::processTimers(ExecutionState *current,
             }
           }
           *os << "], ";
-
           StackFrame &sf = es->stack.back();
-          uint64_t md2u = computeMinDistToUncovered(es->pc,
-                                                    sf.minDistToUncoveredOnReturn);
-          uint64_t icnt = theStatisticManager->getIndexedValue(stats::instructions,
-                                                               es->pc->info->id);
-          uint64_t cpicnt = sf.callPathNode->statistics.getValue(stats::instructions);
+          uint64_t md2u =
+              computeMinDistToUncovered(es->pc, sf.minDistToUncoveredOnReturn);
+          uint64_t icnt = theStatisticManager->getIndexedValue(
+              stats::instructions, es->pc->info->id);
+          uint64_t cpicnt =
+              sf.callPathNode->statistics.getValue(stats::instructions);
 
           *os << "{";
           *os << "'depth' : " << es->depth << ", ";

--- a/lib/Core/ExecutorTimers.cpp
+++ b/lib/Core/ExecutorTimers.cpp
@@ -116,18 +116,16 @@ void Executor::processTimers(ExecutionState *current,
     if (dumpPTree) {
       char name[32];
       sprintf(name, "ptree%08d.dot", (int) stats::instructions);
-      llvm::raw_ostream *os = interpreterHandler->openOutputFile(name);
+      auto os = interpreterHandler->openOutputFile(name);
       if (os) {
         processTree->dump(*os);
-        delete os;
       }
-      
       dumpPTree = 0;
     }
 
     if (dumpStates) {
-      llvm::raw_ostream *os = interpreterHandler->openOutputFile("states.txt");
-      
+      auto os = interpreterHandler->openOutputFile("states.txt");
+
       if (os) {
         for (std::set<ExecutionState*>::const_iterator it = states.begin(), 
                ie = states.end(); it != ie; ++it) {
@@ -167,8 +165,6 @@ void Executor::processTimers(ExecutionState *current,
           *os << "}";
           *os << ")\n";
         }
-        
-        delete os;
       }
 
       dumpStates = 0;

--- a/lib/Core/Searcher.h
+++ b/lib/Core/Searcher.h
@@ -27,6 +27,9 @@ namespace klee {
   template<class T> class DiscretePDF;
   class ExecutionState;
   class Executor;
+  class KInstruction;
+  class KModule;
+  class StatsTracker;
 
   class Searcher {
   public:
@@ -133,15 +136,15 @@ namespace klee {
       CoveringNew
     };
 
+    static double getWeight(WeightType type, const ExecutionState *);
+
   private:
     DiscretePDF<ExecutionState*> *states;
     WeightType type;
     bool updateWeights;
     
-    double getWeight(ExecutionState*);
-
   public:
-    WeightedRandomSearcher(WeightType type);
+    WeightedRandomSearcher(StatsTracker &statsTracker, WeightType type);
     ~WeightedRandomSearcher();
 
     ExecutionState &selectState();

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -176,8 +176,6 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
                            bool _updateMinDistToUncovered)
   : executor(_executor),
     objectFilename(_objectFilename),
-    statsFile(0),
-    istatsFile(0),
     startWallTime(util::getWallTime()),
     numBranches(0),
     fullBranches(0),
@@ -243,7 +241,9 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
 
   if (OutputStats) {
     statsFile = executor.interpreterHandler->openOutputFile("run.stats");
-    assert(statsFile && "unable to open statistics trace file");
+    if (!statsFile)
+      klee_error("Unable to open statistics log file");
+
     writeStatsHeader();
     writeStatsLine();
 
@@ -259,16 +259,12 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
 
   if (OutputIStats) {
     istatsFile = executor.interpreterHandler->openOutputFile("run.istats");
-    assert(istatsFile && "unable to open istats file");
+    if (!istatsFile)
+      klee_error("Unable to open istats file");
 
     if (IStatsWriteInterval > 0)
       executor.addTimer(new WriteIStatsTimer(this), IStatsWriteInterval);
   }
-}
-
-StatsTracker::~StatsTracker() {  
-  delete statsFile;
-  delete istatsFile;
 }
 
 void StatsTracker::done() {

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -23,6 +23,7 @@
 
 #include "CallPathManager.h"
 #include "CoreStats.h"
+#include "CoverageTracker.h"
 #include "Executor.h"
 #include "MemoryManager.h"
 #include "UserSearcher.h"
@@ -55,64 +56,49 @@ using namespace llvm;
 
 ///
 
-namespace {  
-  cl::opt<bool>
-  TrackInstructionTime("track-instruction-time",
-                       cl::init(false),
-		       cl::desc("Enable tracking of time for individual instructions (default=off)"));
+namespace {
+cl::OptionCategory StatisticsTracking("Statistics Tracking",
+                                      "Controls how to track statistics");
 
-  cl::opt<bool>
-  OutputStats("output-stats",
-              cl::init(true),
-	      cl::desc("Write running stats trace file (default=on)"));
+cl::opt<bool> TrackInstructionTime(
+    "track-instruction-time", cl::init(false),
+    cl::desc(
+        "Enable tracking of time for individual instructions (default=off)"),
+    cl::cat(StatisticsTracking));
 
-  cl::opt<bool>
-  OutputIStats("output-istats",
-	       cl::init(true),
-               cl::desc("Write instruction level statistics in callgrind format (default=on)"));
+cl::opt<double> StatsWriteInterval(
+    "stats-write-interval", cl::init(1.),
+    cl::desc("Write running stats trace file. Approximate number of seconds "
+             "between stats writes (default=1.0s)"),
+    cl::cat(StatisticsTracking));
 
-  cl::opt<double>
-  StatsWriteInterval("stats-write-interval",
-                     cl::init(1.),
-		     cl::desc("Approximate number of seconds between stats writes (default=1.0s)"));
+cl::opt<unsigned> StatsWriteAfterInstructions(
+    "stats-write-after-instructions", cl::init(0),
+    cl::desc("Write running stats trace file. Write statistics after each n "
+             "instructions, 0 to disable "
+             "(default=0)"),
+    cl::cat(StatisticsTracking));
 
-  cl::opt<unsigned> StatsWriteAfterInstructions(
-      "stats-write-after-instructions", cl::init(0),
-      cl::desc("Write statistics after each n instructions, 0 to disable "
-               "(default=0)"));
+cl::opt<double> IStatsWriteInterval(
+    "istats-write-interval", cl::init(10.),
+    cl::desc("Write instruction level statistics in callgrind format. "
+             "Approximately write every n seconds (default: 10.0s)"),
+    cl::cat(StatisticsTracking));
 
-  cl::opt<double>
-  IStatsWriteInterval("istats-write-interval",
-		      cl::init(10.),
-                      cl::desc("Approximate number of seconds between istats writes (default: 10.0s)"));
+cl::opt<unsigned> IStatsWriteAfterInstructions(
+    "istats-write-after-instructions", cl::init(0),
+    cl::desc("Write instruction level statistics in callgrind format. Write "
+             "after each n instructions, 0 to disable "
+             "(default=0)"),
+    cl::cat(StatisticsTracking));
 
-  cl::opt<unsigned> IStatsWriteAfterInstructions(
-      "istats-write-after-instructions", cl::init(0),
-      cl::desc("Write istats after each n instructions, 0 to disable "
-               "(default=0)"));
-
-  // XXX I really would like to have dynamic rate control for something like this.
-  cl::opt<double>
-  UncoveredUpdateInterval("uncovered-update-interval",
-                          cl::init(30.),
-			  cl::desc("(default=30.0s)"));
-  
-  cl::opt<bool>
-  UseCallPaths("use-call-paths",
-	       cl::init(true),
-               cl::desc("Enable calltree tracking for instruction level statistics (default=on)"));
-  
+cl::opt<bool> UseCallPaths("use-call-paths", cl::init(true),
+                           cl::desc("Enable calltree tracking for instruction "
+                                    "level statistics (default=on)"),
+                           cl::cat(StatisticsTracking));
 }
 
 ///
-
-bool StatsTracker::useStatistics() {
-  return OutputStats || OutputIStats;
-}
-
-bool StatsTracker::useIStats() {
-  return OutputIStats;
-}
 
 namespace klee {
   class WriteIStatsTimer : public Executor::Timer {
@@ -135,111 +121,39 @@ namespace klee {
     void run() { statsTracker->writeStatsLine(); }
   };
 
-  class UpdateReachableTimer : public Executor::Timer {
-    StatsTracker *statsTracker;
-    
-  public:
-    UpdateReachableTimer(StatsTracker *_statsTracker) : statsTracker(_statsTracker) {}
-    
-    void run() { statsTracker->computeReachableUncovered(); }
-  };
- 
 }
 
 //
 
-/// Check for special cases where we statically know an instruction is
-/// uncoverable. Currently the case is an unreachable instruction
-/// following a noreturn call; the instruction is really only there to
-/// satisfy LLVM's termination requirement.
-static bool instructionIsCoverable(Instruction *i) {
-  if (i->getOpcode() == Instruction::Unreachable) {
-    BasicBlock *bb = i->getParent();
-    BasicBlock::iterator it(i);
-    if (it==bb->begin()) {
-      return true;
-    } else {
-      Instruction *prev = &*(--it);
-      if (isa<CallInst>(prev) || isa<InvokeInst>(prev)) {
-        Function *target =
-            getDirectCallTarget(CallSite(prev), /*moduleIsFullyLinked=*/true);
-        if (target && target->doesNotReturn())
-          return false;
-      }
-    }
-  }
+StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename)
+    : executor(_executor), objectFilename(_objectFilename),
+      startWallTime(util::getWallTime()), instructionGranularityTracking(false),
+      codePathGranularityTracking(false) {
 
-  return true;
-}
+  // Handle and check all command line arguments before we setup the tracker
 
-StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
-                           bool _updateMinDistToUncovered)
-  : executor(_executor),
-    objectFilename(_objectFilename),
-    startWallTime(util::getWallTime()),
-    numBranches(0),
-    fullBranches(0),
-    partialBranches(0),
-    updateMinDistToUncovered(_updateMinDistToUncovered) {
+  if (StatsWriteAfterInstructions && StatsWriteInterval)
+    klee_warning("Both options --stats-write-interval and "
+                 "--stats-write-after-instructions are enabled. Consider "
+                 "disabling one.");
 
-  if (StatsWriteAfterInstructions > 0 && StatsWriteInterval > 0)
-    klee_error("Both options --stats-write-interval and "
-               "--stats-write-after-instructions cannot be enabled at the same "
-               "time.");
+  if (IStatsWriteAfterInstructions && IStatsWriteInterval)
+    klee_warning("Both options --istats-write-interval and "
+                 "--istats-write-after-instructions are enabled. Consider "
+                 "disabling one.");
 
-  if (IStatsWriteAfterInstructions > 0 && IStatsWriteInterval > 0)
-    klee_error(
-        "Both options --istats-write-interval and "
-        "--istats-write-after-instructions cannot be enabled at the same "
-        "time.");
+  // check if istats tracking is requested
+  if (IStatsWriteInterval || IStatsWriteAfterInstructions)
+    doTrackByInstruction();
 
-  KModule *km = executor.kmodule.get();
+  if (UseCallPaths)
+    doTrackCodePath();
 
-  if (!sys::path::is_absolute(objectFilename)) {
-    SmallString<128> current(objectFilename);
-    if(sys::fs::make_absolute(current)) {
-#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
-      Twine current_twine(current.str()); // requires a twine for this
-      if (!sys::fs::exists(current_twine)) {
-#elif LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
-      bool exists = false;
-      if (!sys::fs::exists(current.str(), exists)) {
-#else
-      bool exists = false;
-      error_code ec = sys::fs::exists(current.str(), exists);
-      if (ec == errc::success && exists) {
-#endif
-        objectFilename = current.c_str();
-      }
-    }
-  }
+  // Enable coverage tracking if requested by user
+  if (CoverageTracker::userRequestedCoverageTracking())
+    doTrackCoverage();
 
-  if (OutputIStats)
-    theStatisticManager->useIndexedStats(km->infos->getMaxID());
-
-  for (auto &kfp : km->functions) {
-    KFunction *kf = kfp.get();
-    kf->trackCoverage = 1;
-
-    for (unsigned i=0; i<kf->numInstructions; ++i) {
-      KInstruction *ki = kf->instructions[i];
-
-      if (OutputIStats) {
-        unsigned id = ki->info->id;
-        theStatisticManager->setIndex(id);
-        if (kf->trackCoverage && instructionIsCoverable(ki->inst))
-          ++stats::uncoveredInstructions;
-      }
-      
-      if (kf->trackCoverage) {
-        if (BranchInst *bi = dyn_cast<BranchInst>(ki->inst))
-          if (!bi->isUnconditional())
-            numBranches++;
-      }
-    }
-  }
-
-  if (OutputStats) {
+  if (StatsWriteAfterInstructions || StatsWriteInterval) {
     statsFile = executor.interpreterHandler->openOutputFile("run.stats");
     if (!statsFile)
       klee_error("Unable to open statistics log file");
@@ -251,13 +165,26 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
       executor.addTimer(new WriteStatsTimer(this), StatsWriteInterval);
   }
 
-  // Add timer to calculate uncovered instructions if needed by the solver
-  if (updateMinDistToUncovered) {
-    computeReachableUncovered();
-    executor.addTimer(new UpdateReachableTimer(this), UncoveredUpdateInterval);
-  }
+  if (IStatsWriteInterval || IStatsWriteAfterInstructions) {
+    if (!sys::path::is_absolute(objectFilename)) {
+      SmallString<128> current(objectFilename);
+      if (sys::fs::make_absolute(current)) {
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
+        Twine current_twine(current.str()); // requires a twine for this
+        if (!sys::fs::exists(current_twine)) {
+#elif LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
+        bool exists = false;
+        if (!sys::fs::exists(current.str(), exists)) {
+#else
+        bool exists = false;
+        error_code ec = sys::fs::exists(current.str(), exists);
+        if (ec == errc::success && exists) {
+#endif
+          objectFilename = current.c_str();
+        }
+      }
+    }
 
-  if (OutputIStats) {
     istatsFile = executor.interpreterHandler->openOutputFile("run.istats");
     if (!istatsFile)
       klee_error("Unable to open istats file");
@@ -271,95 +198,67 @@ void StatsTracker::done() {
   if (statsFile)
     writeStatsLine();
 
-  if (OutputIStats) {
-    if (updateMinDistToUncovered)
-      computeReachableUncovered();
+  if (istatsFile)
     writeIStats();
-  }
 }
 
 void StatsTracker::stepInstruction(ExecutionState &es) {
-  if (OutputIStats) {
-    if (TrackInstructionTime) {
-      static sys::TimeValue lastNowTime(0,0),lastUserTime(0,0);
-    
-      if (lastUserTime.seconds()==0 && lastUserTime.nanoseconds()==0) {
-        sys::TimeValue sys(0,0);
-        sys::Process::GetTimeUsage(lastNowTime,lastUserTime,sys);
-      } else {
-        sys::TimeValue now(0,0),user(0,0),sys(0,0);
-        sys::Process::GetTimeUsage(now,user,sys);
-        sys::TimeValue delta = user - lastUserTime;
-        sys::TimeValue deltaNow = now - lastNowTime;
-        stats::instructionTime += delta.usec();
-        stats::instructionRealTime += deltaNow.usec();
-        lastUserTime = user;
-        lastNowTime = now;
-      }
-    }
+  const InstructionInfo &ii = *es.pc->info;
 
-    Instruction *inst = es.pc->inst;
-    const InstructionInfo &ii = *es.pc->info;
-    StackFrame &sf = es.stack.back();
+  // Update the statistics tracker to refer to the current instruction
+  if (instructionGranularityTracking)
     theStatisticManager->setIndex(ii.id);
-    if (UseCallPaths)
-      theStatisticManager->setContext(&sf.callPathNode->statistics);
 
-    if (es.instsSinceCovNew)
-      ++es.instsSinceCovNew;
-
-    if (sf.kf->trackCoverage && instructionIsCoverable(inst)) {
-      if (!theStatisticManager->getIndexedValue(stats::coveredInstructions, ii.id)) {
-        // Checking for actual stoppoints avoids inconsistencies due
-        // to line number propogation.
-        //
-        // FIXME: This trick no longer works, we should fix this in the line
-        // number propogation.
-          es.coveredLines[&ii.file].insert(ii.line);
-	es.coveredNew = true;
-        es.instsSinceCovNew = 1;
-	++stats::coveredInstructions;
-	stats::uncoveredInstructions += (uint64_t)-1;
-      }
-    }
+  if (codePathGranularityTracking) {
+    StackFrame &sf = es.stack.back();
+    theStatisticManager->setContext(&sf.callPathNode->statistics);
   }
 
+  if (TrackInstructionTime) {
+    sys::TimeValue sys(0, 0);
+    sys::Process::GetTimeUsage(lastNowTime, lastUserTime, sys);
+  }
+
+  if (coverageTracker)
+    coverageTracker->stepInstruction(es);
+
   if (statsFile && StatsWriteAfterInstructions &&
-      stats::instructions % StatsWriteAfterInstructions.getValue() == 0)
+      (stats::instructions % StatsWriteAfterInstructions.getValue() == 0))
     writeStatsLine();
 
   if (istatsFile && IStatsWriteAfterInstructions &&
-      stats::instructions % IStatsWriteAfterInstructions.getValue() == 0)
+      (stats::instructions % IStatsWriteAfterInstructions.getValue() == 0))
     writeIStats();
+}
+
+void StatsTracker::postStepInstruction(ExecutionState &es) {
+  if (TrackInstructionTime) {
+    // Update statistic: the assumption is that statistics are still correctly
+    // referencing the state
+    sys::TimeValue now(0, 0), user(0, 0), sys(0, 0);
+    sys::Process::GetTimeUsage(now, user, sys);
+    sys::TimeValue delta = user - lastUserTime;
+    sys::TimeValue deltaNow = now - lastNowTime;
+    stats::instructionTime += delta.usec();
+    stats::instructionRealTime += deltaNow.usec();
+  }
 }
 
 ///
 
 /* Should be called _after_ the es->pushFrame() */
 void StatsTracker::framePushed(ExecutionState &es, StackFrame *parentFrame) {
-  if (OutputIStats) {
+  if (codePathGranularityTracking) {
     StackFrame &sf = es.stack.back();
-
-    if (UseCallPaths) {
-      CallPathNode *parent = parentFrame ? parentFrame->callPathNode : 0;
-      CallPathNode *cp = callPathManager.getCallPath(parent, 
-                                                     sf.caller ? sf.caller->inst : 0, 
-                                                     sf.kf->function);
-      sf.callPathNode = cp;
-      cp->count++;
-    }
+    CallPathNode *parent = parentFrame ? parentFrame->callPathNode : 0;
+    CallPathNode *cp = callPathManager.getCallPath(
+        parent, sf.caller ? sf.caller->inst : 0, sf.kf->function);
+    sf.callPathNode = cp;
+    cp->count++;
   }
 
-  if (updateMinDistToUncovered) {
-    StackFrame &sf = es.stack.back();
-
-    uint64_t minDistAtRA = 0;
-    if (parentFrame)
-      minDistAtRA = parentFrame->minDistToUncoveredOnReturn;
-
-    sf.minDistToUncoveredOnReturn =
-        sf.caller ? computeMinDistToUncovered(sf.caller, minDistAtRA) : 0;
-  }
+  if (coverageTracker)
+    coverageTracker->updateFrameCoverage(es);
 }
 
 /* Should be called _after_ the es->popFrame() */
@@ -370,26 +269,10 @@ void StatsTracker::framePopped(ExecutionState &es) {
 
 void StatsTracker::markBranchVisited(ExecutionState *visitedTrue, 
                                      ExecutionState *visitedFalse) {
-  if (OutputIStats) {
-    unsigned id = theStatisticManager->getIndex();
-    uint64_t hasTrue = theStatisticManager->getIndexedValue(stats::trueBranches, id);
-    uint64_t hasFalse = theStatisticManager->getIndexedValue(stats::falseBranches, id);
-    if (visitedTrue && !hasTrue) {
-      visitedTrue->coveredNew = true;
-      visitedTrue->instsSinceCovNew = 1;
-      ++stats::trueBranches;
-      if (hasFalse) { ++fullBranches; --partialBranches; }
-      else ++partialBranches;
-      hasTrue = 1;
-    }
-    if (visitedFalse && !hasFalse) {
-      visitedFalse->coveredNew = true;
-      visitedFalse->instsSinceCovNew = 1;
-      ++stats::falseBranches;
-      if (hasTrue) { ++fullBranches; --partialBranches; }
-      else ++partialBranches;
-    }
-  }
+  if (!coverageTracker)
+    return;
+
+  coverageTracker->markBranchVisited(visitedTrue, visitedFalse);
 }
 
 void StatsTracker::writeStatsHeader() {
@@ -425,26 +308,23 @@ double StatsTracker::elapsed() {
 }
 
 void StatsTracker::writeStatsLine() {
-  *statsFile << "(" << stats::instructions
-             << "," << fullBranches
-             << "," << partialBranches
-             << "," << numBranches
-             << "," << util::getUserTime()
-             << "," << executor.states.size()
-             << "," << util::GetTotalMallocUsage() + executor.memory->getUsedDeterministicSize()
-             << "," << stats::queries
-             << "," << stats::queryConstructs
-             << "," << 0 // was numObjects
-             << "," << elapsed()
-             << "," << stats::coveredInstructions
-             << "," << stats::uncoveredInstructions
-             << "," << stats::queryTime / 1000000.
-             << "," << stats::solverTime / 1000000.
-             << "," << stats::cexCacheTime / 1000000.
-             << "," << stats::forkTime / 1000000.
-             << "," << stats::resolveTime / 1000000.
-             << "," << stats::queryCexCacheMisses
-             << "," << stats::queryCexCacheHits
+  *statsFile << "(" << stats::instructions << ","
+             << (coverageTracker ? coverageTracker->fullBranches : 0) << ","
+             << (coverageTracker ? coverageTracker->partialBranches : 0) << ","
+             << (coverageTracker ? coverageTracker->numBranches : 0) << ","
+             << util::getUserTime() << "," << executor.states.size() << ","
+             << util::GetTotalMallocUsage() +
+                    executor.memory->getUsedDeterministicSize()
+             << "," << stats::queries << "," << stats::queryConstructs << ","
+             << 0 // was numObjects
+             << "," << elapsed() << "," << stats::coveredInstructions << ","
+             << stats::uncoveredInstructions << ","
+             << stats::queryTime / 1000000. << ","
+             << stats::solverTime / 1000000. << ","
+             << stats::cexCacheTime / 1000000. << ","
+             << stats::forkTime / 1000000. << ","
+             << stats::resolveTime / 1000000. << ","
+             << stats::queryCexCacheMisses << "," << stats::queryCexCacheHits
 #ifdef KLEE_ARRAY_DEBUG
              << "," << stats::arrayHashTime / 1000000.
 #endif
@@ -458,7 +338,7 @@ void StatsTracker::updateStateStatistics(uint64_t addend) {
     ExecutionState &state = **it;
     const InstructionInfo &ii = *state.pc->info;
     theStatisticManager->incrementIndexedValue(stats::states, ii.id, addend);
-    if (UseCallPaths)
+    if (codePathGranularityTracking)
       state.stack.back().callPathNode->statistics.incrementValue(stats::states, addend);
   }
 }
@@ -513,16 +393,17 @@ void StatsTracker::writeIStats() {
       of << sm.getStatistic(i).getShortName() << " ";
   }
   of << "\n";
-  
-  // set state counts, decremented after we process so that we don't
-  // have to zero all records each time.
+
+  // Track how many states are currently at which instruction, to do that
+  // set state counts, write the stats and decrement it after that. So we
+  // process such that we don't have to zero all records each time.
   if (istatsMask & (1<<stats::states.getID()))
     updateStateStatistics(1);
 
   std::string sourceFile = "";
 
   CallSiteSummaryTable callSiteStats;
-  if (UseCallPaths)
+  if (codePathGranularityTracking)
     callPathManager.getSummaryStatistics(callSiteStats);
 
   of << "ob=" << objectFilename << "\n";
@@ -559,7 +440,7 @@ void StatsTracker::writeIStats() {
               of << sm.getIndexedValue(sm.getStatistic(i), index) << " ";
           of << "\n";
 
-          if (UseCallPaths && 
+          if (codePathGranularityTracking &&
               (isa<CallInst>(instr) || isa<InvokeInst>(instr))) {
             CallSiteSummaryTable::iterator it = callSiteStats.find(instr);
             if (it!=callSiteStats.end()) {
@@ -616,287 +497,36 @@ void StatsTracker::writeIStats() {
   of.flush();
 }
 
-///
+void StatsTracker::doTrackByInstruction() {
+  // Check if already initialized
+  if (instructionGranularityTracking)
+    return;
 
-typedef std::map<Instruction*, std::vector<Function*> > calltargets_ty;
+  theStatisticManager->useIndexedStats(executor.kmodule->infos->getMaxID());
 
-static calltargets_ty callTargets;
-static std::map<Function*, std::vector<Instruction*> > functionCallers;
-static std::map<Function*, unsigned> functionShortestPath;
-
-static std::vector<Instruction*> getSuccs(Instruction *i) {
-  BasicBlock *bb = i->getParent();
-  std::vector<Instruction*> res;
-
-  if (i==bb->getTerminator()) {
-    for (succ_iterator it = succ_begin(bb), ie = succ_end(bb); it != ie; ++it)
-      res.push_back(&*(it->begin()));
-  } else {
-    res.push_back(&*(++BasicBlock::iterator(i)));
-  }
-
-  return res;
+  // Mark as enabled and initialized
+  instructionGranularityTracking = true;
 }
 
-uint64_t klee::computeMinDistToUncovered(const KInstruction *ki,
-                                         uint64_t minDistAtRA) {
-  StatisticManager &sm = *theStatisticManager;
-  if (minDistAtRA==0) { // unreachable on return, best is local
-    return sm.getIndexedValue(stats::minDistToUncovered,
-                              ki->info->id);
-  } else {
-    uint64_t minDistLocal = sm.getIndexedValue(stats::minDistToUncovered,
-                                               ki->info->id);
-    uint64_t distToReturn = sm.getIndexedValue(stats::minDistToReturn,
-                                               ki->info->id);
-
-    if (distToReturn==0) { // return unreachable, best is local
-      return minDistLocal;
-    } else if (!minDistLocal) { // no local reachable
-      return distToReturn + minDistAtRA;
-    } else {
-      return std::min(minDistLocal, distToReturn + minDistAtRA);
-    }
+void StatsTracker::doTrackCoverage() {
+  // Check if already initialized
+  if (coverageTracker) {
+    return;
   }
+
+  coverageTracker = std::unique_ptr<CoverageTracker>(
+      new CoverageTracker(*this, *executor.kmodule, executor.states, executor));
+  coverageTracker->initializeCoverageTracking();
 }
 
-void StatsTracker::computeReachableUncovered() {
-  KModule *km = executor.kmodule.get();
-  const auto m = km->module.get();
-  static bool init = true;
-  const InstructionInfoTable &infos = *km->infos;
-  StatisticManager &sm = *theStatisticManager;
-  
-  if (init) {
-    init = false;
+void StatsTracker::requestAutomaticDistanceMetricUpdates() {
+  coverageTracker->requestAutomaticDistanceCalculation();
+}
 
-    // Compute call targets. It would be nice to use alias information
-    // instead of assuming all indirect calls hit all escaping
-    // functions, eh?
-    for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
-         fnIt != fn_ie; ++fnIt) {
-      for (Function::iterator bbIt = fnIt->begin(), bb_ie = fnIt->end(); 
-           bbIt != bb_ie; ++bbIt) {
-        for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
-             it != ie; ++it) {
-          Instruction *inst = &*it;
-          if (isa<CallInst>(inst) || isa<InvokeInst>(inst)) {
-            CallSite cs(inst);
-            if (isa<InlineAsm>(cs.getCalledValue())) {
-              // We can never call through here so assume no targets
-              // (which should be correct anyhow).
-              callTargets.insert(std::make_pair(inst,
-                                                std::vector<Function*>()));
-            } else if (Function *target = getDirectCallTarget(
-                           cs, /*moduleIsFullyLinked=*/true)) {
-              callTargets[inst].push_back(target);
-            } else {
-              callTargets[inst] =
-                std::vector<Function*>(km->escapingFunctions.begin(),
-                                       km->escapingFunctions.end());
-            }
-          }
-        }
-      }
-    }
+void StatsTracker::doTrackCodePath() {
+  // Check if already initialized
+  if (codePathGranularityTracking)
+    return;
 
-    // Compute function callers as reflexion of callTargets.
-    for (calltargets_ty::iterator it = callTargets.begin(), 
-           ie = callTargets.end(); it != ie; ++it)
-      for (std::vector<Function*>::iterator fit = it->second.begin(), 
-             fie = it->second.end(); fit != fie; ++fit) 
-        functionCallers[*fit].push_back(it->first);
-
-    // Initialize minDistToReturn to shortest paths through
-    // functions. 0 is unreachable.
-    std::vector<Instruction *> instructions;
-    for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
-         fnIt != fn_ie; ++fnIt) {
-      Function *fn = &*fnIt;
-      if (fnIt->isDeclaration()) {
-        if (fnIt->doesNotReturn()) {
-          functionShortestPath[fn] = 0;
-        } else {
-          functionShortestPath[fn] = 1; // whatever
-        }
-      } else {
-        functionShortestPath[fn] = 0;
-      }
-
-      // Not sure if I should bother to preorder here. XXX I should.
-      for (Function::iterator bbIt = fnIt->begin(), bb_ie = fnIt->end(); 
-           bbIt != bb_ie; ++bbIt) {
-        for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
-             it != ie; ++it) {
-          Instruction *inst = &*it;
-          instructions.push_back(inst);
-          unsigned id = infos.getInfo(inst).id;
-          sm.setIndexedValue(stats::minDistToReturn, 
-                             id, 
-                             isa<ReturnInst>(inst)
-                             );
-        }
-      }
-    }
-  
-    std::reverse(instructions.begin(), instructions.end());
-    
-    // I'm so lazy it's not even worklisted.
-    bool changed;
-    do {
-      changed = false;
-      for (std::vector<Instruction*>::iterator it = instructions.begin(),
-             ie = instructions.end(); it != ie; ++it) {
-        Instruction *inst = *it;
-        unsigned bestThrough = 0;
-
-        if (isa<CallInst>(inst) || isa<InvokeInst>(inst)) {
-          std::vector<Function*> &targets = callTargets[inst];
-          for (std::vector<Function*>::iterator fnIt = targets.begin(),
-                 ie = targets.end(); fnIt != ie; ++fnIt) {
-            uint64_t dist = functionShortestPath[*fnIt];
-            if (dist) {
-              dist = 1+dist; // count instruction itself
-              if (bestThrough==0 || dist<bestThrough)
-                bestThrough = dist;
-            }
-          }
-        } else {
-          bestThrough = 1;
-        }
-       
-        if (bestThrough) {
-          unsigned id = infos.getInfo(*it).id;
-          uint64_t best, cur = best = sm.getIndexedValue(stats::minDistToReturn, id);
-          std::vector<Instruction*> succs = getSuccs(*it);
-          for (std::vector<Instruction*>::iterator it2 = succs.begin(),
-                 ie = succs.end(); it2 != ie; ++it2) {
-            uint64_t dist = sm.getIndexedValue(stats::minDistToReturn,
-                                               infos.getInfo(*it2).id);
-            if (dist) {
-              uint64_t val = bestThrough + dist;
-              if (best==0 || val<best)
-                best = val;
-            }
-          }
-          // there's a corner case here when a function only includes a single
-          // instruction (a ret). in that case, we MUST update
-          // functionShortestPath, or it will remain 0 (erroneously indicating
-          // that no return instructions are reachable)
-          Function *f = inst->getParent()->getParent();
-          if (best != cur || (inst == &*(f->begin()->begin())
-                  && functionShortestPath[f] != best)) {
-            sm.setIndexedValue(stats::minDistToReturn, id, best);
-            changed = true;
-
-            // Update shortest path if this is the entry point.
-            if (inst == &*(f->begin()->begin()))
-              functionShortestPath[f] = best;
-          }
-        }
-      }
-    } while (changed);
-  }
-
-  // compute minDistToUncovered, 0 is unreachable
-  std::vector<Instruction *> instructions;
-  for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
-       fnIt != fn_ie; ++fnIt) {
-    // Not sure if I should bother to preorder here.
-    for (Function::iterator bbIt = fnIt->begin(), bb_ie = fnIt->end(); 
-         bbIt != bb_ie; ++bbIt) {
-      for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
-           it != ie; ++it) {
-        Instruction *inst = &*it;
-        unsigned id = infos.getInfo(inst).id;
-        instructions.push_back(inst);
-        sm.setIndexedValue(stats::minDistToUncovered, 
-                           id, 
-                           sm.getIndexedValue(stats::uncoveredInstructions, id));
-      }
-    }
-  }
-  
-  std::reverse(instructions.begin(), instructions.end());
-  
-  // I'm so lazy it's not even worklisted.
-  bool changed;
-  do {
-    changed = false;
-    for (std::vector<Instruction*>::iterator it = instructions.begin(),
-           ie = instructions.end(); it != ie; ++it) {
-      Instruction *inst = *it;
-      uint64_t best, cur = best = sm.getIndexedValue(stats::minDistToUncovered, 
-                                                     infos.getInfo(inst).id);
-      unsigned bestThrough = 0;
-      
-      if (isa<CallInst>(inst) || isa<InvokeInst>(inst)) {
-        std::vector<Function*> &targets = callTargets[inst];
-        for (std::vector<Function*>::iterator fnIt = targets.begin(),
-               ie = targets.end(); fnIt != ie; ++fnIt) {
-          uint64_t dist = functionShortestPath[*fnIt];
-          if (dist) {
-            dist = 1+dist; // count instruction itself
-            if (bestThrough==0 || dist<bestThrough)
-              bestThrough = dist;
-          }
-
-          if (!(*fnIt)->isDeclaration()) {
-            uint64_t calleeDist = sm.getIndexedValue(stats::minDistToUncovered,
-                                                     infos.getFunctionInfo(*fnIt).id);
-            if (calleeDist) {
-              calleeDist = 1+calleeDist; // count instruction itself
-              if (best==0 || calleeDist<best)
-                best = calleeDist;
-            }
-          }
-        }
-      } else {
-        bestThrough = 1;
-      }
-      
-      if (bestThrough) {
-        std::vector<Instruction*> succs = getSuccs(inst);
-        for (std::vector<Instruction*>::iterator it2 = succs.begin(),
-               ie = succs.end(); it2 != ie; ++it2) {
-          uint64_t dist = sm.getIndexedValue(stats::minDistToUncovered,
-                                             infos.getInfo(*it2).id);
-          if (dist) {
-            uint64_t val = bestThrough + dist;
-            if (best==0 || val<best)
-              best = val;
-          }
-        }
-      }
-
-      if (best != cur) {
-        sm.setIndexedValue(stats::minDistToUncovered, 
-                           infos.getInfo(inst).id, 
-                           best);
-        changed = true;
-      }
-    }
-  } while (changed);
-
-  for (std::set<ExecutionState*>::iterator it = executor.states.begin(),
-         ie = executor.states.end(); it != ie; ++it) {
-    ExecutionState *es = *it;
-    uint64_t currentFrameMinDist = 0;
-    for (ExecutionState::stack_ty::iterator sfIt = es->stack.begin(),
-           sf_ie = es->stack.end(); sfIt != sf_ie; ++sfIt) {
-      ExecutionState::stack_ty::iterator next = sfIt + 1;
-      KInstIterator kii;
-
-      if (next==es->stack.end()) {
-        kii = es->pc;
-      } else {
-        kii = next->caller;
-        ++kii;
-      }
-      
-      sfIt->minDistToUncoveredOnReturn = currentFrameMinDist;
-      
-      currentFrameMinDist = computeMinDistToUncovered(kii, currentFrameMinDist);
-    }
-  }
+  codePathGranularityTracking = true;
 }

--- a/lib/Core/StatsTracker.h
+++ b/lib/Core/StatsTracker.h
@@ -12,6 +12,7 @@
 
 #include "CallPathManager.h"
 
+#include <memory>
 #include <set>
 
 namespace llvm {
@@ -36,13 +37,13 @@ namespace klee {
     Executor &executor;
     std::string objectFilename;
 
-    llvm::raw_fd_ostream *statsFile, *istatsFile;
     double startWallTime;
     
     unsigned numBranches;
     unsigned fullBranches, partialBranches;
 
     CallPathManager callPathManager;    
+  std::unique_ptr<llvm::raw_fd_ostream> statsFile, istatsFile;
 
     bool updateMinDistToUncovered;
 
@@ -59,7 +60,6 @@ namespace klee {
   public:
     StatsTracker(Executor &_executor, std::string _objectFilename,
                  bool _updateMinDistToUncovered);
-    ~StatsTracker();
 
     // called after a new StackFrame has been pushed (for callpath tracing)
     void framePushed(ExecutionState &es, StackFrame *parentFrame);

--- a/lib/Core/StatsTracker.h
+++ b/lib/Core/StatsTracker.h
@@ -12,6 +12,7 @@
 
 #include "CallPathManager.h"
 
+#include "llvm/Support/TimeValue.h"
 #include <memory>
 #include <set>
 
@@ -23,72 +24,89 @@ namespace llvm {
 }
 
 namespace klee {
-  class ExecutionState;
-  class Executor;  
-  class InstructionInfoTable;
-  class InterpreterHandler;
-  struct KInstruction;
-  struct StackFrame;
+class CoverageTracker;
+class ExecutionState;
+class Executor;
+class InstructionInfoTable;
+class InterpreterHandler;
+struct KInstruction;
+struct StackFrame;
 
-  class StatsTracker {
-    friend class WriteStatsTimer;
-    friend class WriteIStatsTimer;
+class StatsTracker {
+  friend class WriteStatsTimer;
+  friend class WriteIStatsTimer;
 
-    Executor &executor;
-    std::string objectFilename;
+  Executor &executor;
 
-    double startWallTime;
-    
-    unsigned numBranches;
-    unsigned fullBranches, partialBranches;
+  std::string objectFilename;
 
-    CallPathManager callPathManager;    
   std::unique_ptr<llvm::raw_fd_ostream> statsFile, istatsFile;
+  double startWallTime;
 
-    bool updateMinDistToUncovered;
+  llvm::sys::TimeValue lastNowTime;
+  llvm::sys::TimeValue lastUserTime;
 
-  public:
-    static bool useStatistics();
-    static bool useIStats();
+  /// Handles coverage-related tracking
+  std::unique_ptr<CoverageTracker> coverageTracker;
 
-  private:
-    void updateStateStatistics(uint64_t addend);
-    void writeStatsHeader();
-    void writeStatsLine();
-    void writeIStats();
+  /// Indicates if statistics should be tracked
+  bool instructionGranularityTracking;
 
-  public:
-    StatsTracker(Executor &_executor, std::string _objectFilename,
-                 bool _updateMinDistToUncovered);
+  /// Handles tracking of call paths per state
+  CallPathManager callPathManager;
 
-    // called after a new StackFrame has been pushed (for callpath tracing)
-    void framePushed(ExecutionState &es, StackFrame *parentFrame);
+  /// Indicates if tracking per call state is enabled
+  bool codePathGranularityTracking;
 
-    // called after a StackFrame has been popped 
-    void framePopped(ExecutionState &es);
+private:
+  /// Update state counter
+  void updateStateStatistics(uint64_t addend);
+  void writeStatsHeader();
+  void writeStatsLine();
+  void writeIStats();
 
-    // called when some side of a branch has been visited. it is
-    // imperative that this be called when the statistics index is at
-    // the index for the branch itself.
-    void markBranchVisited(ExecutionState *visitedTrue, 
-                           ExecutionState *visitedFalse);
-    
-    // called when execution is done and stats files should be flushed
-    void done();
+public:
+  ///
+  /// @param executor Executor instance
+  /// @param objectFilename for istats tracker
+  StatsTracker(Executor &executor, std::string objectFilename);
 
-    // process stats for a single instruction step, es is the state
-    // about to be stepped
-    void stepInstruction(ExecutionState &es);
+  // called after a new StackFrame has been pushed (for callpath tracing)
+  void framePushed(ExecutionState &es, StackFrame *parentFrame);
 
-    /// Return time in seconds since execution start.
-    double elapsed();
+  // called after a StackFrame has been popped
+  void framePopped(ExecutionState &es);
 
-    void computeReachableUncovered();
-  };
+  // called when some side of a branch has been visited. it is
+  // imperative that this be called when the statistics index is at
+  // the index for the branch itself.
+  void markBranchVisited(ExecutionState *visitedTrue,
+                         ExecutionState *visitedFalse);
 
-  uint64_t computeMinDistToUncovered(const KInstruction *ki,
-                                     uint64_t minDistAtRA);
+  // called when execution is done and stats files should be flushed
+  void done();
 
+  // process stats for a single instruction step, es is the state
+  // about to be stepped
+  void stepInstruction(ExecutionState &es);
+
+  // Process and update statistics after the step has been made
+  void postStepInstruction(ExecutionState &es);
+
+  /// Return time in seconds since execution start.
+  double elapsed();
+
+  /// Requests tracking of instruction granularity
+  void doTrackByInstruction();
+
+  /// Requests tracking coverage of instruction and branch level
+  void doTrackCoverage();
+
+  void requestAutomaticDistanceMetricUpdates();
+
+  /// Request tracking of code path granularity
+  void doTrackCodePath();
+};
 }
 
 #endif

--- a/lib/Core/UserSearcher.h
+++ b/lib/Core/UserSearcher.h
@@ -14,9 +14,6 @@ namespace klee {
   class Executor;
   class Searcher;
 
-  // XXX gross, should be on demand?
-  bool userSearcherRequiresMD2U();
-
   void initializeSearchOptions();
 
   Searcher *constructUserSearcher(Executor &executor);

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -260,13 +260,16 @@ void KModule::optimiseAndPrepare(
 
 void KModule::manifest(InterpreterHandler *ih, bool forceSourceOutput) {
   if (OutputSource || forceSourceOutput) {
-    std::unique_ptr<llvm::raw_fd_ostream> os(ih->openOutputFile("assembly.ll"));
-    assert(os && !os->has_error() && "unable to open source output");
+    auto os = ih->openOutputFile("assembly.ll");
+    if (!os)
+      klee_error("Unable to open output file for generated LLVM IR");
     *os << *module;
   }
 
   if (OutputModule) {
-    std::unique_ptr<llvm::raw_fd_ostream> f(ih->openOutputFile("final.bc"));
+    auto f = ih->openOutputFile("final.bc");
+    if (!f)
+      klee_error("Unable to open output file for generated LLVM IR");
     WriteBitcodeToFile(module.get(), *f);
   }
 

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1277,6 +1277,8 @@ int main(int argc, char **argv, char **envp) {
 
   Interpreter::InterpreterOptions IOpts;
   IOpts.MakeConcreteSymbolic = MakeConcreteSymbolic;
+  IOpts.generatePerTestCoverage = !NoOutput && WriteCov;
+
   KleeHandler *handler = new KleeHandler(pArgc, pArgv);
   Interpreter *interpreter =
     theInterpreter = Interpreter::create(ctx, IOpts, handler);


### PR DESCRIPTION
* fix tracking of time taken by instruction (not time between two instructions)
* fix: do not try to track functions marked as do-not-track
* fix: always track number of instructions not covered if requested before only enabled if istats were written
* fix: write coverage if requested (write-cov) even istats is not  enabled
* fix: Enable coverage searcher without using istats

General changes:
* Always have a statistics tracker enabled (but reduce its general  footprint)
* Add postStepInstruction to track different statistics objects directly after an instruction step (needed for correct instruction time tracking)
* split stats tracker into: general statistics management (StatsTracker) and coverage statistics (CoverageTracker)
* make api of executor to add timer public
* WeightedRandomSearcher: explicitly request statistics/coverage information if required by the selected search strategy
* Add help categories for statistics
* remove `write-stats` and `write-istats`: enabled automatically by either writing every n instructions or writing every n seconds