### PR TITLE
Fix slow Mac Travis build: wildcard is not expanded with quotes

### DIFF
--- a/scripts/build/dependencies-ubuntu.sh
+++ b/scripts/build/dependencies-ubuntu.sh
@@ -19,6 +19,7 @@ apt -y --no-install-recommends install \
   binutils \
   bison \
   cmake \
+  curl \
   flex \
   git \
   groff-base \

--- a/scripts/build/llvm.sh
+++ b/scripts/build/llvm.sh
@@ -187,7 +187,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
   # We use our own local cache if possible
   set +e
-  brew install "$HOME/Library/Caches/Homebrew/llvm\@${LLVM_VERSION}*.bottle.tar.gz"
+  brew install "$HOME"/Library/Caches/Homebrew/llvm\@${LLVM_VERSION}*.bottle.tar.gz
   RES=$?
   set -ev
   if [ ${RES} -ne 0 ]; then


### PR DESCRIPTION
@ccadar wildcard is not expanded on Mac. Therefore, the cached file could not be found.

Please merge.