### PR TITLE
Fix bug introduced by subtle LLVM API change, improve valueIsOnlyCalled

### DIFF
--- a/lib/Module/ModuleUtil.cpp
+++ b/lib/Module/ModuleUtil.cpp
@@ -312,9 +312,7 @@ static bool valueIsOnlyCalled(const Value *v) {
 #else
   for (auto user : v->users()) {
 #endif
-    if (const Instruction *instr = dyn_cast<Instruction>(user)) {
-      if (instr->getOpcode()==0) continue; // XXX function numbering inst
-
+    if (const auto *instr = dyn_cast<Instruction>(user)) {
       // Make sure the instruction is a call or invoke.
       CallSite cs(const_cast<Instruction *>(instr));
       if (!cs) return false;
@@ -323,16 +321,17 @@ static bool valueIsOnlyCalled(const Value *v) {
       // not an argument.
       if (cs.hasArgument(v))
         return false;
-    } else if (const llvm::ConstantExpr *ce =
-               dyn_cast<llvm::ConstantExpr>(user)) {
-      if (ce->getOpcode()==Instruction::BitCast)
+    } else if (const auto *ce = dyn_cast<ConstantExpr>(user)) {
+      if (ce->getOpcode() == Instruction::BitCast)
         if (valueIsOnlyCalled(ce))
           continue;
       return false;
-    } else if (const GlobalAlias *ga = dyn_cast<GlobalAlias>(user)) {
-      // XXX what about v is bitcast of aliasee?
-      if (v==ga->getAliasee() && !valueIsOnlyCalled(ga))
+    } else if (const auto *ga = dyn_cast<GlobalAlias>(user)) {
+      if (v == ga->getAliasee() && !valueIsOnlyCalled(ga))
         return false;
+    } else if (isa<BlockAddress>(user)) {
+      // only valid as operand to indirectbr or comparison against null
+      continue;
     } else {
       return false;
     }

--- a/test/Feature/EscapingFunctions.c
+++ b/test/Feature/EscapingFunctions.c
@@ -1,0 +1,49 @@
+// RUN: %llvmgcc -emit-llvm -O0 -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -debug-print-escaping-functions --output-dir=%t.klee-out %t.bc 2> %t.log
+// RUN: FileCheck --input-file=%t.log %s
+
+int functionpointer(void) {
+    return 1;
+}
+
+int functionpointer_as_argument(void) {
+    return 2;
+}
+
+short bitcasted_functionpointer(void) {
+    return 3;
+}
+
+int receives_functionpointer(int (*f)(void));
+
+int blockaddress(int x) {
+    void * target = &&one;
+    switch (x) {
+        case 1: break;
+        case 2:
+            target = &&two;
+            goto *target;
+        default:
+            goto *target;
+    }
+one:
+    return 1;
+two:
+    return 2;
+}
+
+int main(int argc, char *argv[]) {
+    int (*f1)(void) = functionpointer;
+    f1();
+
+    receives_functionpointer(functionpointer_as_argument);
+
+    int (*f2)(void) =(int (*)(void))bitcasted_functionpointer;
+    f2();
+
+    blockaddress(argc);
+
+    // CHECK: KLEE: escaping functions: {{\[((functionpointer|functionpointer_as_argument|bitcasted_functionpointer), ){3}\]}}
+    return 0;
+}

--- a/test/Feature/EscapingFunctionsAlias.c
+++ b/test/Feature/EscapingFunctionsAlias.c
@@ -1,0 +1,43 @@
+// Darwin does not support strong aliases.
+// REQUIRES: not-darwin
+// RUN: %llvmgcc -emit-llvm -O0 -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -debug-print-escaping-functions --output-dir=%t.klee-out %t.bc 2> %t.log
+// RUN: FileCheck --input-file=%t.log %s
+
+void global_alias(void) __attribute__((alias("global_aliasee")));
+void global_aliasee(void) {
+    return;
+}
+
+short bitcast_of_alias(void) __attribute__((alias("bitcast_of_global_alias")));
+short bitcast_of_global_alias(void) {
+    return 1;
+}
+
+short bitcast_of_aliasee(void) __attribute__((alias("bitcast_of_global_aliasee")));
+short bitcast_of_global_aliasee(void) {
+    return 1;
+}
+
+int bitcast_in_global_alias(void) __attribute__((alias("bitcast_in_alias")));
+short bitcast_in_alias(void) {
+    return 1;
+}
+
+int main(int argc, char *argv[]) {
+    global_aliasee();
+    global_alias();
+
+    int (*f1)(void) =(int (*)(void))bitcast_of_alias;
+    f1();
+
+    int (*f2)(void) =(int (*)(void))bitcast_of_global_aliasee;
+    f2();
+
+    bitcast_in_alias();
+    bitcast_in_global_alias();
+
+    // CHECK: KLEE: escaping functions: {{\[((bitcast_of_global_alias|bitcast_of_global_aliasee), ){2}\]}}
+    return 0;
+}


### PR DESCRIPTION
A while ago, I learned the hard way about a subtle API change between LLVM 3.4 and 3.5: `use_begin()` was renamed to `user_begin()`, but a new method of the same name was added to `Value`, so existing code will still compile, but behave differently (more details in first commit).
In KLEE, this iterator is (only) invoked by `valueIsOnlyCalled()`, which is used to create the set of escaping functions, which in turn is used by both the MD2U (Min-Dist-to-Uncovered) and Coverage-New NURS searchers.

I added a test for escaping functions ~~and as a result stumbled across another bug~~ and also added handling of `BlockAddress`es.

During all of this, I discovered that function pointers of functions that have only a declaration are not considered escaping functions (as they are not part of the set of functions that `functionEscapes()` is called on). Does somebody know (I have not taken a look at the relevant code so far) whether this is the way it should be?