### PR TITLE
[clang-format] Allow longer codelines in test/

### DIFF
--- a/test/.clang-format
+++ b/test/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+ColumnLimit: 0


### PR DESCRIPTION
Code files in `test/` might contain comment lines that are longer
as they contain `// RUN` commands. clang-formatting breaks the
tests. Stop clang-formatting from doing that.