### PR TITLE
Update and fix div/shift checks

### DIFF
--- a/lib/Module/Checks.cpp
+++ b/lib/Module/Checks.cpp
@@ -47,6 +47,12 @@ bool DivCheckPass::runOnModule(Module &M) {
         if (opcode != Instruction::SDiv && opcode != Instruction::UDiv &&
             opcode != Instruction::SRem && opcode != Instruction::URem)
           continue;
+
+        // Check if the operand is constant and not zero, skip in that case.
+        const auto &operand = binOp->getOperand(1);
+        if (const auto &coOp = dyn_cast<llvm::Constant>(operand)) {
+          if (!coOp->isZeroValue())
+            continue;
         }
       }
     }

--- a/lib/Module/Checks.cpp
+++ b/lib/Module/Checks.cpp
@@ -104,6 +104,16 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
         if (opcode != Instruction::Shl && opcode != Instruction::LShr &&
             opcode != Instruction::AShr)
           continue;
+
+        // Check if the operand is constant and not zero, skip in that case
+        auto operand = binOp->getOperand(1);
+        if (auto coOp = dyn_cast<llvm::ConstantInt>(operand)) {
+          auto typeWidth =
+              binOp->getOperand(0)->getType()->getScalarSizeInBits();
+          // If the constant shift is positive and smaller,equal the type width,
+          // we can ignore this instruction
+          if (!coOp->isNegative() && coOp->getZExtValue() < typeWidth)
+            continue;
         }
 
         shiftInstructions.push_back(binOp);

--- a/lib/Module/Checks.cpp
+++ b/lib/Module/Checks.cpp
@@ -12,16 +12,17 @@
 #include "klee/Config/Version.h"
 
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
-#include "llvm/IR/Module.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
-#include "llvm/IR/DataLayout.h"
 #include "llvm/Pass.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
@@ -31,50 +32,45 @@ using namespace klee;
 
 char DivCheckPass::ID;
 
-bool DivCheckPass::runOnModule(Module &M) { 
-  Function *divZeroCheckFunction = 0;
-  LLVMContext &ctx = M.getContext();
+bool DivCheckPass::runOnModule(Module &M) {
+  std::vector<llvm::BinaryOperator *> divInstruction;
 
-  bool moduleChanged = false;
-  
-  for (Module::iterator f = M.begin(), fe = M.end(); f != fe; ++f) {
-    for (Function::iterator b = f->begin(), be = f->end(); b != be; ++b) {
-      for (BasicBlock::iterator i = b->begin(), ie = b->end(); i != ie; ++i) {     
-          if (BinaryOperator* binOp = dyn_cast<BinaryOperator>(i)) {
-          // find all [s|u][div|mod] instructions
-          Instruction::BinaryOps opcode = binOp->getOpcode();
-          if (opcode == Instruction::SDiv || opcode == Instruction::UDiv ||
-              opcode == Instruction::SRem || opcode == Instruction::URem) {
-            
-            CastInst *denominator =
-              CastInst::CreateIntegerCast(i->getOperand(1),
-                                          Type::getInt64Ty(ctx),
-                                          false,  /* sign doesn't matter */
-                                          "int_cast_to_i64",
-                                          &*i);
-            
-            // Lazily bind the function to avoid always importing it.
-            if (!divZeroCheckFunction) {
-              Constant *fc = M.getOrInsertFunction("klee_div_zero_check", 
-                                                   Type::getVoidTy(ctx),
-                                                   Type::getInt64Ty(ctx),
-                                                   NULL);
-              divZeroCheckFunction = cast<Function>(fc);
-            }
+  for (auto &F : M) {
+    for (auto &BB : F) {
+      for (auto &I : BB) {
+        auto binOp = dyn_cast<BinaryOperator>(&I);
+        if (!binOp)
+          continue;
 
-            CallInst * ci = CallInst::Create(divZeroCheckFunction, denominator, "", &*i);
-
-            // Set debug location of checking call to that of the div/rem
-            // operation so error locations are reported in the correct
-            // location.
-            ci->setDebugLoc(binOp->getDebugLoc());
-            moduleChanged = true;
-          }
+        // find all [s|u][div|rem] instructions
+        auto opcode = binOp->getOpcode();
+        if (opcode != Instruction::SDiv && opcode != Instruction::UDiv &&
+            opcode != Instruction::SRem && opcode != Instruction::URem)
+          continue;
         }
       }
     }
   }
-  return moduleChanged;
+
+  // If nothing to do, return
+  if (divInstruction.empty())
+    return false;
+
+  LLVMContext &ctx = M.getContext();
+  auto divZeroCheckFunction = cast<Function>(
+      M.getOrInsertFunction("klee_div_zero_check", Type::getVoidTy(ctx),
+                            Type::getInt64Ty(ctx), NULL));
+
+  for (auto &divInst : divInstruction) {
+    llvm::IRBuilder<> Builder(divInst /* Inserts before divInst*/);
+    auto denominator =
+        Builder.CreateIntCast(divInst->getOperand(1), Type::getInt64Ty(ctx),
+                              false, /* sign doesn't matter */
+                              "int_cast_to_i64");
+    Builder.CreateCall(divZeroCheckFunction, denominator);
+  }
+
+  return true;
 }
 
 char OvershiftCheckPass::ID;

--- a/lib/Module/Checks.cpp
+++ b/lib/Module/Checks.cpp
@@ -116,6 +116,9 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
             continue;
         }
 
+        if (KleeIRMetaData::hasAnnotation(I, "klee.check.shift", "True"))
+          continue;
+
         shiftInstructions.push_back(binOp);
       }
     }
@@ -126,6 +129,7 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
 
   // Retrieve the checker function
   auto &ctx = M.getContext();
+  KleeIRMetaData md(ctx);
   auto overshiftCheckFunction = cast<Function>(M.getOrInsertFunction(
       "klee_overshift_check", Type::getVoidTy(ctx), Type::getInt64Ty(ctx),
       Type::getInt64Ty(ctx), NULL));
@@ -147,6 +151,7 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
     args.push_back(shiftValue);
 
     Builder.CreateCall(overshiftCheckFunction, args);
+    md.addAnnotation(*shiftInst, "klee.check.shift", "True");
   }
 
   return true;

--- a/lib/Module/KLEEIRMetaData.h
+++ b/lib/Module/KLEEIRMetaData.h
@@ -1,0 +1,51 @@
+//===-- KLEEIRMetaData.h ----------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LIB_MODULE_KLEEIRMETADATA_H_
+#define LIB_MODULE_KLEEIRMETADATA_H_
+
+#include "llvm/IR/MDBuilder.h"
+
+namespace klee {
+
+/// Handles KLEE-specific LLVM IR meta-data.
+class KleeIRMetaData : public llvm::MDBuilder {
+
+  llvm::LLVMContext &Context;
+
+public:
+  KleeIRMetaData(llvm::LLVMContext &context)
+      : llvm::MDBuilder(context), Context(context) {}
+
+  /// \brief Return a string node reflecting the value
+  llvm::MDNode *createStringNode(llvm::StringRef value) {
+    return llvm::MDNode::get(Context, createString(value));
+  }
+
+  void addAnnotation(llvm::Instruction &inst, llvm::StringRef key,
+                           llvm::StringRef value) {
+    inst.setMetadata(key, createStringNode(value));
+  }
+
+  /// \brief Check if the instruction has the key/value meta data
+  static bool hasAnnotation(const llvm::Instruction &inst, llvm::StringRef key,
+                             llvm::StringRef value) {
+    auto v = inst.getMetadata(key);
+    if (!v)
+      return false;
+    auto sv = llvm::dyn_cast<llvm::MDString>(v->getOperand(0));
+    if (!sv)
+      return false;
+
+    return sv->getString().equals(value);
+  }
+};
+}
+
+#endif /* LIB_MODULE_KLEEIRMETADATA_H_ */

--- a/test/Feature/DivCheck.c
+++ b/test/Feature/DivCheck.c
@@ -1,0 +1,48 @@
+// Check if div-instructions are correctly instrumented:
+// * unoptimized code will contain a call to klee_div_zero_check
+// * optimized code will have this check inlined
+// In both cases, the `div` instruction should have been marked with meta-data: klee.check.div
+//
+// RUN: %llvmgcc %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --check-div-zero=true %t.bc >%t.div_enabled.log
+// RUN: FileCheck %s -input-file=%t.klee-out/assembly.ll -check-prefix=DIV-ENABLED
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --check-div-zero=true --optimize %t.bc >%t.div_enabled.log
+// RUN: FileCheck %s -input-file=%t.klee-out/assembly.ll -check-prefix=DIV-ENABLED-OPT
+// Without debug information
+// RUN: %llvmgcc %s -emit-llvm -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --check-div-zero=true %t.bc >%t.div_enabled.log
+// RUN: FileCheck %s -input-file=%t.klee-out/assembly.ll -check-prefix=DIV-ENABLED
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --check-div-zero=true --optimize %t.bc >%t.div_enabled.log
+// RUN: FileCheck %s -input-file=%t.klee-out/assembly.ll -check-prefix=DIV-ENABLED-OPT
+#include "klee/klee.h"
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+  char c;
+
+  klee_make_symbolic(&c, sizeof(c), "index");
+
+  // Validate
+  if (argc / c == 5)
+    return 1;
+  // Check that div has been instrumented once
+  // DIV-ENABLED: call {{.*}}void @klee_div_zero_check({{.+}} %{{.+}})
+  // DIV-ENABLED-NOT: call {{.*}}void @klee_div_zero_check
+  // Check that div has the proper metadata
+  // DIV-ENABLED: sdiv {{.*}} !klee.check.div
+  // DIV-ENABLED-OPT: sdiv {{.*}} !klee.check.div
+
+  // Validate
+  if (argc / 5 == 5)
+    return 1;
+  // Check that div has not been instrumented
+  // DIV-ENABLED-NOT: call {{.*}}void @klee_div_zero_check(i64 5)
+  // DIV-ENABLED-NOT: sdiv {{.*}} !klee.check.div
+  // DIV-ENABLED-OPT-NOT: sdiv {{.*}} !klee.check.div
+
+  return 0;
+}

--- a/test/Feature/ShiftCheck.c
+++ b/test/Feature/ShiftCheck.c
@@ -1,0 +1,50 @@
+// Check if shift-instructions are correctly instrumented:
+// * unoptimized code will contain a call to klee_overshift_check
+// * optimized code will have this check inlined
+// In both cases, the `ashr` instruction should have been marked with meta-data: klee.check.shift
+//
+// RUN: %llvmgcc %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --check-overshift=true %t.bc >%t.shift_enabled.log
+// RUN: FileCheck %s -input-file=%t.klee-out/assembly.ll -check-prefix=SHIFT-ENABLED
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --check-overshift=true --optimize %t.bc >%t.shift_enabled.log
+// RUN: FileCheck %s -input-file=%t.klee-out/assembly.ll -check-prefix=SHIFT-ENABLED-OPT
+// Same test without debug information
+// RUN: %llvmgcc %s -emit-llvm -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --check-overshift=true %t.bc >%t.shift_enabled.log
+// RUN: FileCheck %s -input-file=%t.klee-out/assembly.ll -check-prefix=SHIFT-ENABLED
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --check-overshift=true --optimize %t.bc >%t.shift_enabled.log
+// RUN: FileCheck %s -input-file=%t.klee-out/assembly.ll -check-prefix=SHIFT-ENABLED-OPT
+
+#include "klee/klee.h"
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+  char c;
+
+  klee_make_symbolic(&c, sizeof(c), "index");
+
+  // Validate
+  if (argc >> c == 5)
+    return 1;
+  // Check for klee_overshift_check call
+  // SHIFT-ENABLED: call {{.*}}void @klee_overshift_check
+  // Check that double-instrumentation does not happen
+  // SHIFT-ENABLED-NOT: call {{.*}}void @klee_overshift_check
+  // SHIFT-ENABLED: ashr {{.*}} !klee.check.shift
+  // SHIFT-ENABLED-OPT: ashr {{.*}} !klee.check.shift
+
+  // Validate
+  uint32_t value = (uint32_t)argc;
+  if (value >> 3 == 5)
+    return 1;
+  // Check that the second shift was not instrumented
+  // SHIFT-ENABLED-NOT: call {{.*}}void @klee_overshift_check(i32 i{{.+.+}} 3)
+  // SHIFT-ENABLED-NOT: ashr {{.*}} !klee.check.shift
+  // SHIFT-ENABLED-OPT-NOT: ashr {{.*}} !klee.check.shift
+
+  return 0;
+}


### PR DESCRIPTION
This PR provides a couple of goodies:
* Use `llvm::Builder` instead of `*Inst::create()`:
  - manages metadata automatically (e.g. debug, TBAA, ...)
  - does optimisation like code folding with newly added instructions (no `bitcasts` if none needed)
* Fixes an issue introduced by the #868: checks for single instructions can be inserted multiple times: avoid this by flagging an instruction as instrumented
 - Add basic support to annotate code with KLEE
* Optimisation: Do not instrument instructions that do not need instrumentation (e.g. div by non-zero constant)
* Add tests to check the optimised and non-optimised case

Update with C++11 and clang-format.