### PR TITLE
Replace remaining *Inst::Create() calls with llvm::Builder

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -23,16 +23,17 @@
 #include "klee/Interpreter.h"
 #include "klee/Statistics.h"
 
+#include "llvm/Bitcode/ReaderWriter.h"
 #include "llvm/IR/Constants.h"
-#include "llvm/IR/Type.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Type.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Errno.h"
 #include "llvm/Support/FileSystem.h"
-#include "llvm/Bitcode/ReaderWriter.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -1045,6 +1046,7 @@ createLibCWrapper(std::vector<std::unique_ptr<llvm::Module>> &modules,
                        GlobalVariable::ExternalLinkage, intendedFunction,
                        libcMainFn->getParent());
   BasicBlock *bb = BasicBlock::Create(ctx, "entry", stub);
+  llvm::IRBuilder<> Builder(bb);
 
   std::vector<llvm::Value*> args;
   args.push_back(
@@ -1055,9 +1057,8 @@ createLibCWrapper(std::vector<std::unique_ptr<llvm::Module>> &modules,
   args.push_back(Constant::getNullValue(ft->getParamType(4))); // app_fini
   args.push_back(Constant::getNullValue(ft->getParamType(5))); // rtld_fini
   args.push_back(Constant::getNullValue(ft->getParamType(6))); // stack_end
-  CallInst::Create(libcMainFn, args, "", bb);
-
-  new UnreachableInst(ctx, bb);
+  Builder.CreateCall(libcMainFn, args);
+  Builder.CreateUnreachable();
 }
 
 static void


### PR DESCRIPTION
Replace the remaining occurrences of `Inst::Create()` with
`llvm::Builder` to manage metadata automatically and to fold
instructions.

C++11 it and clang-format