### PR TITLE
Evaluate objectsize if possible

### DIFF
--- a/test/Intrinsics/objectsize.leq80.ll
+++ b/test/Intrinsics/objectsize.leq80.ll
@@ -20,7 +20,14 @@ continue.block:
   %2 = load i8*, i8** %a, align 8
   %3 = call i64 @llvm.objectsize.i64.p0i8(i8* %2, i1 false, i1 false)
   %cmp1 = icmp ne i64 %3, -1
-  br i1 %cmp1, label %abort.block, label %exit.block
+  br i1 %cmp1, label %abort.block, label %continue.block2
+
+continue.block2:
+; allocate one byte
+  %b = alloca i8, align 8
+  %4 = call i64 @llvm.objectsize.i64.p0i8(i8* %b, i1 false, i1 false)
+  %cmp2 = icmp ne i64 %4, 1
+  br i1 %cmp2, label %abort.block, label %exit.block
 
 exit.block:
   ret i32 0

--- a/test/Intrinsics/objectsize.ll
+++ b/test/Intrinsics/objectsize.ll
@@ -19,7 +19,14 @@ continue.block:
   %2 = load i8*, i8** %a, align 8
   %3 = call i64 @llvm.objectsize.i64.p0i8(i8* %2, i1 false, i1 false, i1 false)
   %cmp1 = icmp ne i64 %3, -1
-  br i1 %cmp1, label %abort.block, label %exit.block
+  br i1 %cmp1, label %abort.block, label %continue.block2
+
+continue.block2:
+; allocate one byte
+  %b = alloca i8, align 8
+  %4 = call i64 @llvm.objectsize.i64.p0i8(i8* %b, i1 false, i1 false, i1 false)
+  %cmp2 = icmp ne i64 %4, 1
+  br i1 %cmp2, label %abort.block, label %exit.block
 
 exit.block:
   ret i32 0


### PR DESCRIPTION
`llvm.objectsize` is used in several optimisation during compile time. Lowering
these intrinsics took a conservative approach returning always the value for
unknown. Instead, try to evaluate it to get an object's real size and use this
value instead.