### PR TITLE
remove unnecessary LLVM 3.4 test restrictions

### DIFF
--- a/test/Feature/ConstExprWithDivZero.ll
+++ b/test/Feature/ConstExprWithDivZero.ll
@@ -1,10 +1,10 @@
+; LLVM versions starting from 3.5 replace test code with "ret undef"
+; see https://github.com/klee/klee/issues/268
 ; REQUIRES: llvm-3.4
 ; RUN: llvm-as %s -f -o %t.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: not %klee --output-dir=%t.klee-out %t.bc 2> %t.log
 ; RUN: FileCheck --input-file %t.log %s
-
-; See https://github.com/klee/klee/issues/268
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"

--- a/test/Feature/ConstExprWithOvershift.ll
+++ b/test/Feature/ConstExprWithOvershift.ll
@@ -1,3 +1,5 @@
+; LLVM versions starting from 3.5 replace test code with "ret undef"
+; see https://github.com/klee/klee/issues/268
 ; REQUIRES: llvm-3.4
 ; RUN: llvm-as %s -f -o %t.bc
 ; RUN: rm -rf %t.klee-out

--- a/test/VectorInstructions/extract_element.c
+++ b/test/VectorInstructions/extract_element.c
@@ -1,4 +1,3 @@
-// REQUIRES: geq-llvm-3.4
 // RUN: %llvmgcc %s -emit-llvm -O0 -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // NOTE: Have to pass `--optimize=false` to avoid vector operations being

--- a/test/VectorInstructions/extract_element_symbolic.c
+++ b/test/VectorInstructions/extract_element_symbolic.c
@@ -1,4 +1,3 @@
-// REQUIRES: geq-llvm-3.4
 // RUN: %llvmgcc %s -emit-llvm -O0 -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // RUN: not %klee --output-dir=%t.klee-out --exit-on-error %t1.bc > %t.log 2>&1

--- a/test/VectorInstructions/floating_point_ops_constant.c
+++ b/test/VectorInstructions/floating_point_ops_constant.c
@@ -1,4 +1,3 @@
-// REQUIRES: geq-llvm-3.4
 // RUN: %llvmgcc %s -emit-llvm -O0 -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // NOTE: Have to pass `--optimize=false` to avoid vector operations being

--- a/test/VectorInstructions/insert_element.c
+++ b/test/VectorInstructions/insert_element.c
@@ -1,4 +1,3 @@
-// REQUIRES: geq-llvm-3.4
 // RUN: %llvmgcc %s -emit-llvm -O0 -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // NOTE: Have to pass `--optimize=false` to avoid vector operations being

--- a/test/VectorInstructions/insert_element_symbolic.c
+++ b/test/VectorInstructions/insert_element_symbolic.c
@@ -1,4 +1,3 @@
-// REQUIRES: geq-llvm-3.4
 // RUN: %llvmgcc %s -emit-llvm -O0 -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // RUN: not %klee --output-dir=%t.klee-out --exit-on-error %t1.bc > %t.log 2>&1

--- a/test/VectorInstructions/integer_ops_constant.c
+++ b/test/VectorInstructions/integer_ops_constant.c
@@ -1,4 +1,3 @@
-// REQUIRES: geq-llvm-3.4
 // RUN: %llvmgcc %s -emit-llvm -O0 -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // NOTE: Have to pass `--optimize=false` to avoid vector operations being

--- a/test/VectorInstructions/integer_ops_signed_symbolic.c
+++ b/test/VectorInstructions/integer_ops_signed_symbolic.c
@@ -1,4 +1,3 @@
-// REQUIRES: geq-llvm-3.4
 // RUN: %llvmgcc %s -emit-llvm -O0 -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // NOTE: Have to pass `--optimize=false` to avoid vector operations being

--- a/test/VectorInstructions/integer_ops_unsigned_symbolic.c
+++ b/test/VectorInstructions/integer_ops_unsigned_symbolic.c
@@ -1,4 +1,3 @@
-// REQUIRES: geq-llvm-3.4
 // RUN: %llvmgcc %s -emit-llvm -O0 -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // NOTE: Have to pass `--optimize=false` to avoid vector operations being

--- a/test/VectorInstructions/shuffle_element.c
+++ b/test/VectorInstructions/shuffle_element.c
@@ -1,4 +1,3 @@
-// REQUIRES: geq-llvm-3.4
 // RUN: %llvmgcc %s -emit-llvm -O0 -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // NOTE: Have to pass `--optimize=false` to avoid vector operations being


### PR DESCRIPTION
Removing `geq-llvm-3.4`, as this is the minimum supported version anyways. Also, documenting why `ConstExprWithDivZero.ll` and `ConstExprWithOvershift.ll` require LLVM 3.4.