### PR TITLE
Add clang-format as TravisCI check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: trusty
 language: cpp
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,19 @@ matrix:
     - os: osx
       osx_image: xcode8.3
       env: LLVM_VERSION=3.4 SOLVERS=STP:Z3 STP_VERSION=2.1.2 Z3_VERSION=4.4.1 KLEE_UCLIBC=0 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 COVERAGE=0 USE_TCMALLOC=0
+    - name: Checking Clang-Format
+      env:
+        - VALIDATE_CODE="clang-format"
+      addons:
+        apt:
+          update: true
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-6.0
+          packages:
+            - clang-6.0
+            - clang-format-6.0
+            - colordiff
 
 cache:
   ccache: true
@@ -96,16 +109,18 @@ cache:
 before_install:
     ###########################################################################
     # Set up the locations to get various packages from
-    # We assume the Travis image uses Ubuntu 14.04 LTS
+    # We assume the Travis image uses Ubuntu 16.04 LTS
     ###########################################################################
     # Update package information
     - export KLEE_SRC=`pwd`
     - export KLEE_SRC_TRAVIS=`pwd`
     - cd ../
     - export BASE=`pwd`
-    - ${KLEE_SRC_TRAVIS}/scripts/build/build-travis.sh
+    - if [[ "$VALIDATE_CODE" == "" ]]; then ${KLEE_SRC_TRAVIS}/scripts/build/build-travis.sh; fi
 script:
     # Build KLEE and run tests
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; ${KLEE_SRC_TRAVIS}/scripts/build/klee.sh; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ${KLEE_SRC_TRAVIS}/scripts/build/build-docker.sh; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" && "$VALIDATE_CODE" == "" ]]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; ${KLEE_SRC_TRAVIS}/scripts/build/klee.sh; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" && "$VALIDATE_CODE" == "" ]]; then ${KLEE_SRC_TRAVIS}/scripts/build/build-docker.sh; fi
     - if [[ "$COVERAGE" == "1" ]]; then ${KLEE_SRC_TRAVIS}/scripts/build/run-coverage.sh; fi
+    - export COMMIT_RANGE=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo "HEAD~..HEAD"; else echo $TRAVIS_COMMIT_RANGE; fi)
+    - if [[ "$VALIDATE_CODE" == "clang-format" ]]; then cd ${KLEE_SRC_TRAVIS} && ./scripts/clang-format.sh; fi

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# clang-formats the current git directory
+# Returns 1 if changes were detected and prints those changes, otherwise return 0
+#
+# Required applications are colordiff, clang-format-${LLVM_VERSION} clang-${LLVM_VERSION}
+set -e
+LLVM_VERSION=6.0
+
+git diff -U0 ${COMMIT_RANGE} |clang-format-diff-${LLVM_VERSION} -p1 > clang_format.patch
+
+if [ -s clang_format.patch ]; then
+   rm clang_format.patch
+
+   git diff -U0 ${COMMIT_RANGE} |clang-format-diff-${LLVM_VERSION} -p1 | colordiff
+   exit 1
+fi
+
+rm clang_format.patch
+exit 0


### PR DESCRIPTION
Run clang-format on the diff of the PR and fail in case clang-format made changes.

Remove sudo requirement for travis. This leads to faster turn-around times for Travis builds.