### PR TITLE
Model memalign (C++ 1/6)

### DIFF
--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -111,6 +111,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("klee_warning_once", handleWarningOnce, false),
   add("klee_alias_function", handleAliasFunction, false),
   add("malloc", handleMalloc, true),
+  add("memalign", handleMemalign, true),
   add("realloc", handleRealloc, true),
 
   // operator delete[](void*)
@@ -425,6 +426,14 @@ void SpecialFunctionHandler::handleMalloc(ExecutionState &state,
   // XXX should type check args
   assert(arguments.size()==1 && "invalid number of arguments to malloc");
   executor.executeAlloc(state, arguments[0], false, target);
+}
+
+void SpecialFunctionHandler::handleMemalign(ExecutionState &state,
+                                  KInstruction *target,
+                                  std::vector<ref<Expr> > &arguments) {
+  assert(arguments.size()==2 && "invalid number of arguments to memalign");
+  klee_warning_once(0, "Memalign is not modelled to align the memory");
+  executor.executeAlloc(state, arguments[1], false, target);
 }
 
 void SpecialFunctionHandler::handleAssume(ExecutionState &state,

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -119,6 +119,7 @@ namespace klee {
     HANDLER(handleIsSymbolic);
     HANDLER(handleMakeSymbolic);
     HANDLER(handleMalloc);
+    HANDLER(handleMemalign);
     HANDLER(handleMarkGlobal);
     HANDLER(handleOpenMerge);
     HANDLER(handleCloseMerge);

--- a/test/Feature/Memalign.c
+++ b/test/Feature/Memalign.c
@@ -1,0 +1,12 @@
+// RUN: %llvmgcc -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out %t.bc > %t.log
+
+int main(int argc, char * argv[]) {
+  int* a = (int*) memalign(8, sizeof(int) *5);
+  for (int i = 0; i < 5; ++i){
+    a[i] = (i * 100 ) % 23;
+  }
+  free(a);
+  return 0;
+}


### PR DESCRIPTION
This PR is part of a chain of PRs that adds C++-support to KLEE. For more information and an overview see PR #966.

---

This PR adds basic support for the `memalign` function. It simply performs an allocation of the requested size without regard for the requested alignment, and outputs a warning to the user that the alignment is not guaranteed.

`memalign` is required to support programs that link against a C++ standard library (libc++), but can of course also appear in regular LLVM/C programs, as it is a POSIX function.