### PR TITLE
Add support for newlocale and freelocale (C++ 2/6)

### DIFF
--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -12,6 +12,12 @@
 
 #include "stdint.h"
 #include "stddef.h"
+#include "locale.h"
+
+#ifdef __APPLE__
+# include <string.h>
+# include <xlocale.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -160,6 +166,11 @@ extern "C" {
 
   /* Get errno value of the current state */
   int klee_get_errno(void);
+
+  /* Intrinsic newlocale/freelocale helper */
+  locale_t klee_newlocale(int mask, const char* locale, locale_t base);
+  locale_t klee_freelocale(locale_t locobj);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -142,6 +142,8 @@ namespace klee {
     HANDLER(handleMulOverflow);
     HANDLER(handleSubOverflow);
     HANDLER(handleDivRemOverflow);
+    HANDLER(handleNewlocale);
+    HANDLER(handleFreelocale);
 #undef HANDLER
   };
 } // End klee namespace

--- a/runtime/Intrinsic/newlocale.c
+++ b/runtime/Intrinsic/newlocale.c
@@ -1,0 +1,23 @@
+#include "locale.h"
+#include "klee/klee.h"
+
+#ifdef __APPLE__
+# include <string.h>
+# include <xlocale.h>
+#endif
+
+locale_t newlocale(int category_mask, const char *locale,
+                          locale_t base){
+  return klee_newlocale(category_mask, locale, base);
+}
+
+#ifdef __APPLE__
+int freelocale(locale_t locobj){
+  klee_freelocale(locobj);
+  return 0;
+}
+#else
+void freelocale(locale_t locobj){
+  klee_freelocale(locobj);
+}
+#endif

--- a/test/Feature/Locale.c
+++ b/test/Feature/Locale.c
@@ -1,0 +1,22 @@
+// RUN: %llvmgcc -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out %t.bc > %t.log
+
+#include "klee/klee.h"
+
+int main(int argc, char **args) {
+  union locale_bytes {
+    locale_t l;
+    char *b;
+  } x;
+  x.l = newlocale(LC_ALL_MASK, "C", 0);
+  x.b[0] = 0xC2;
+  if (klee_int("x") < 10) {
+    x.b[1] = ~x.b[0];
+  }
+  for (int i = 0; i < klee_int("y") % 3; ++i) {
+    x.b[i + 2] = x.b[i + 1] ^ x.b[i];
+  }
+  freelocale(x.l);
+  return 0;
+}

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -728,6 +728,8 @@ static const char *modelledExternals[] = {
   "klee_print_expr",
   "klee_print_range",
   "klee_report_error",
+  "klee_newlocale",
+  "klee_freelocale",
   "klee_set_forking",
   "klee_silent_exit",
   "klee_warning",


### PR DESCRIPTION
This PR is part of a chain of PRs that adds C++-support to KLEE. For more information and an overview see PR #966.

---

This PR adds support for the `newlocale`/`freelocale` function pair. It forwards the calls to `klee_newlocale` and `klee_freelocale` internally, which forward the calls to the operating system inside the special function handler. This is necessary because a call to `newlocale` creates a new external object which needs to be tracked by KLEE, and which needs to be freed when `freelocale` is called.

`newlocale` and `freelocale` are required to support programs that use `cout`, but can of course also appear in regular LLVM/C programs, as they are both POSIX functions.