### PR TITLE
Implement handling for atomic LLVM instructions

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2573,6 +2573,15 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     // instructions.
     terminateStateOnExecError(state, "Unexpected ShuffleVector instruction");
     break;
+  case Instruction::AtomicRMW:
+    terminateStateOnExecError(state, "Unexpected Atomic instruction, should be "
+                                     "lowered by LowerAtomicInstructionPass");
+    break;
+  case Instruction::AtomicCmpXchg:
+    terminateStateOnExecError(state,
+                              "Unexpected AtomicCmpXchg instruction, should be "
+                              "lowered by LowerAtomicInstructionPass");
+    break;
   // Other instructions...
   // Unhandled
   default:

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -224,6 +224,9 @@ void KModule::instrument(const Interpreter::ModuleOptions &opts) {
   // NOTE: Must come before division/overshift checks because those passes
   // don't know how to handle vector instructions.
   pm.add(createScalarizerPass());
+
+  // This pass will replace atomic instructions with non-atomic operations
+  pm.add(createLowerAtomicPass());
   if (opts.CheckDivZero) pm.add(new DivCheckPass());
   if (opts.CheckOvershift) pm.add(new OvershiftCheckPass());
 

--- a/test/Feature/Atomic.c
+++ b/test/Feature/Atomic.c
@@ -1,0 +1,72 @@
+// REQUIRES: geq-llvm-3.7
+// RUN: %llvmgcc %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error %t.bc 2>%t.log
+// RUN: cat %t.klee-out/assembly.ll | FileCheck %s
+
+// Checks that KLEE lowers atomic instructions to non-atomic operations
+
+#include <assert.h>
+#include <stdatomic.h>
+
+void test_add() {
+  atomic_int a = 7;
+  atomic_fetch_add(&a, 7);
+  // CHECK-NOT: atomicrmw add
+  assert(a == 14);
+}
+
+void test_sub() {
+  atomic_int a = 7;
+  atomic_fetch_sub(&a, 7);
+  // CHECK-NOT: atomicrmw sub
+  assert(a == 0);
+}
+
+void test_and() {
+  atomic_int a = 0b10001;
+  atomic_fetch_and(&a, 0b00101);
+  // CHECK-NOT: atomicrmw and
+  assert(a == 0b00001);
+}
+
+void test_or() {
+  atomic_int a = 0b10001;
+  atomic_fetch_or(&a, 0b00101);
+  // CHECK-NOT: atomicrmw or
+  assert(a == 0b10101);
+}
+
+void test_xor() {
+  atomic_int a = 0b10001;
+  atomic_fetch_xor(&a, 0b00101);
+  // CHECK-NOT: atomicrmw xor
+  assert(a == 0b10100);
+}
+
+void test_xchg() {
+  atomic_int a = 7;
+  atomic_exchange(&a, 10);
+  // CHECK-NOT: atomicrmw xchg
+  assert(a == 10);
+}
+
+void test_cmp_xchg() {
+  atomic_int a = 7;
+  int b = 7;
+  atomic_compare_exchange_weak(&a, &b, 10);
+  // CHECK-NOT: cmpxchg weak
+  assert(a == 10);
+  assert(b == 7);
+}
+
+int main() {
+  test_and();
+  test_sub();
+  test_and();
+  test_or();
+  test_xor();
+  test_xchg();
+  test_cmp_xchg();
+  return 0;
+}


### PR DESCRIPTION
This PR is part of a chain of PRs that adds C++-support to KLEE. For more information and an overview see PR #966.

---

This PR implements some atomic instructions from the LLVM instruction set. The 'atomic' property of these operations is not paid special regards in the implementation, as KLEE is currently only capable of running single-threaded programs anyway. Therefore, the semantics of these instructions are implemented in a straight-forward way.

These instructions often appear in C++ programs, or at least in those linked against a libc++, but can of course also appear in regular LLVM/C programs, as they are LLVM instructions.