### PR TITLE
Add a hack to support zero-size array types (C++ 4/6)

### DIFF
--- a/lib/Core/ExecutorUtil.cpp
+++ b/lib/Core/ExecutorUtil.cpp
@@ -59,6 +59,12 @@ namespace klee {
       } else if (isa<ConstantPointerNull>(c)) {
         return Expr::createPointer(0);
       } else if (isa<UndefValue>(c) || isa<ConstantAggregateZero>(c)) {
+        if (getWidthForLLVMType(c->getType()) == 0) {
+          if (isa<llvm::LandingPadInst>(ki->inst)) {
+            klee_warning_once(0, "Using zero size array fix for landingpad instruction filter");
+            return ConstantExpr::create(0, 1);
+          }
+        }
         return ConstantExpr::create(0, getWidthForLLVMType(c->getType()));
       } else if (const ConstantDataSequential *cds =
                  dyn_cast<ConstantDataSequential>(c)) {

--- a/test/CXX/LandingPad.cpp
+++ b/test/CXX/LandingPad.cpp
@@ -1,0 +1,19 @@
+// RUN: %llvmgxx %s -emit-llvm -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: klee --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck %s
+
+// CHECK: Using zero size array fix for landingpad instruction filter
+
+// Check that the zero size array in the landing pad filter does not crash KLEE
+int p() throw() { throw 'a'; }
+int main(int argc, char **) {
+  if (argc < 3) {
+    return 0;
+  }
+
+  try {
+    return p();
+  } catch (...) {
+    return 1;
+  }
+}


### PR DESCRIPTION
This PR is part of a chain of PRs that adds C++-support to KLEE. For more information and an overview see PR #966.

---

This PR adds a hack to make LLVM landingpads work in KLEE. These make use of a zero-sized type, which would be represented in KLEE by a zero-length `ConstantExpr`, which crashes with an assertion, as zero-length `ConstantExpr`s are not supported. Therefore, we simply use a length 1 `ConstantExpr` instead. The created expression should have no relevance for the program, but is required in KLEE.

Landingpads are usually found in C++ programs that use exceptions, but can of course also appear in other LLVM programs that use landingpads (e.g., compiled from Rust?).