### PR TITLE
runtime: fix memory error in canonicalize_file_name

### DIFF
--- a/runtime/POSIX/stubs.c
+++ b/runtime/POSIX/stubs.c
@@ -7,8 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define _XOPEN_SOURCE 700
-
 #include <errno.h>
 #include <limits.h>
 #include <signal.h>
@@ -265,7 +263,15 @@ gnu_dev_type gnu_dev_makedev(unsigned int __major, unsigned int __minor) {
 
 char *canonicalize_file_name (const char *name) __attribute__((weak));
 char *canonicalize_file_name (const char *name) {
-  return realpath(name, NULL);
+  // Although many C libraries allocate resolved_name in realpath() if it is NULL,
+  // this behaviour is implementation-defined (POSIX) and not implemented in uclibc.
+  char * resolved_name = malloc(PATH_MAX);
+  if (!resolved_name) return NULL;
+  if (!realpath(name, resolved_name)) {
+    free(resolved_name);
+    return NULL;
+  }
+  return resolved_name;
 }
 
 int getloadavg(double loadavg[], int nelem) __attribute__((weak));

--- a/test/Runtime/POSIX/CanonicalizeFileName.c
+++ b/test/Runtime/POSIX/CanonicalizeFileName.c
@@ -1,0 +1,16 @@
+// REQUIRES: not-darwin
+// RUN: %llvmgcc %s -Wall -emit-llvm -g -O0 -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --libc=uclibc --posix-runtime --exit-on-error %t.bc
+
+#define _GNU_SOURCE
+#include <limits.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char * argv[]) {
+  char cwd[PATH_MAX] = {0};
+
+  if (!getcwd(cwd, PATH_MAX)) exit(EXIT_FAILURE);
+  if (!canonicalize_file_name(cwd)) exit(EXIT_FAILURE);
+}


### PR DESCRIPTION
Fixes #46 and reverts parts of #47. As stated in #46, the solution works for musl, glibc etc. However, the code in stub.c is executed by uclibc and uclibc doesn't allocate the target buffer in `realpath`. The memory error occured while running `df` for 10min with DFS.

Weird that no-one ran into it. I have not included an `ifdef` chain for different systems (`limits.h` locations) as it seems to work now (5 years later) on Ubuntu, Arch, ...