### PR TITLE
Avoid Vararg non-deterministic allocation

### DIFF
--- a/test/Feature/Vararg.c
+++ b/test/Feature/Vararg.c
@@ -1,8 +1,10 @@
-// REQUIRES: not-darwin
-// RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
+// RUN: %llvmgcc %s -emit-llvm -O0 -c -g -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out %t1.bc > %t2.out
-// RUN: grep "types: (52, 37, 2.00, (9,12,15))" %t2.out
+// This test needs deterministic allocation with enough spacing between the allocations.
+// Otherwise, if by coincidence the allocated vararg memory object is directly before another valid memory object,
+// KLEE will be able to resolve the out-of-bounds access with another object and not detect the false access.
+// This will fail this test case.
+// RUN: %klee --output-dir=%t.klee-out --allocate-determ=true --allocate-determ-start-address=0x0 %t1.bc | FileCheck %s
 // RUN: test -f %t.klee-out/test000001.ptr.err
 
 #include <stdarg.h>
@@ -72,6 +74,7 @@ int va_array(int N, ...) {
 int main() {
   struct triple p = { 9, 12, 15 };
   test1(-1, 52, 37ll, 2.0, p);
+  // CHECK: types: (52, 37, 2.00, (9,12,15))
 
   assert(sum(2, 3, 4) == 11);
   assert(sum(0) == 0);


### PR DESCRIPTION
Vararg test can fail if KLEE is able to resolve the
intended out-of-bound memory address to a memory object.

To avoid this, allocate memory explicitly deterministic with
sufficient space between the allocations.

Enables support for Mac OSX again