### PR TITLE
Remove requirement for sudo on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: trusty
 language: cpp
 services:


### PR DESCRIPTION
With the rewrite of the build scripts, we do not depend on `sudo` anymore.
This allows us to use container-based build infrastructure of TravisCI.

This patch removes the `sudo` requirement.

This is cherry-picked from  #955 as requested from @ccadar. Ready to be merged right away.