### PR TITLE
Base time API upon std::chrono

### DIFF
--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -13,6 +13,7 @@
 #include "klee/Constraints.h"
 #include "klee/Expr.h"
 #include "klee/Internal/ADT/TreeStream.h"
+#include "klee/Internal/System/Time.h"
 #include "klee/MergeHandler.h"
 
 // FIXME: We do not want to be exposing these? :(
@@ -101,7 +102,7 @@ public:
   /// Statistics and information
 
   /// @brief Costs for all queries issued for this state, in seconds
-  mutable double queryCost;
+  mutable time::Span queryCost;
 
   /// @brief Weight assigned for importance of this state.  Can be
   /// used for searchers to decide what paths to explore

--- a/include/klee/IncompleteSolver.h
+++ b/include/klee/IncompleteSolver.h
@@ -103,7 +103,7 @@ public:
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query&);
-  void setCoreSolverTimeout(double timeout);
+  void setCoreSolverTimeout(time::Span timeout);
 };
 
 }

--- a/include/klee/Internal/Support/Timer.h
+++ b/include/klee/Internal/Support/Timer.h
@@ -10,25 +10,17 @@
 #ifndef KLEE_TIMER_H
 #define KLEE_TIMER_H
 
-#include <stdint.h>
-
-#if LLVM_VERSION_CODE >= LLVM_VERSION(4, 0)
-#include <llvm/Support/Chrono.h>
-#endif
+#include "klee/Internal/System/Time.h"
 
 namespace klee {
   class WallTimer {
-#if LLVM_VERSION_CODE >= LLVM_VERSION(4, 0)
-    llvm::sys::TimePoint<> start;
-#else
-    uint64_t startMicroseconds;
-#endif
+    time::Point start;
     
   public:
     WallTimer();
 
-    /// check - Return the delta since the timer was created, in microseconds.
-    uint64_t check();
+    /// check - Return the delta since the timer was created
+    time::Span check();
   };
 }
 

--- a/include/klee/Internal/System/Time.h
+++ b/include/klee/Internal/System/Time.h
@@ -10,31 +10,108 @@
 #ifndef KLEE_UTIL_TIME_H
 #define KLEE_UTIL_TIME_H
 
-#if LLVM_VERSION_CODE >= LLVM_VERSION(4, 0)
-#include <chrono>
+#include "llvm/Support/raw_ostream.h"
 
-#include "llvm/Support/Chrono.h"
-#else
-#include "llvm/Support/TimeValue.h"
-#endif
+#include <chrono>
+#include <string>
+#include <sys/time.h>
 
 namespace klee {
-  namespace util {
+  namespace time {
 
-    /// Seconds spent by this process in user mode.
-    double getUserTime();
+    /// The klee::time namespace offers various functions to measure the time (`getWallTime`)
+    /// and to get timing information for the current KLEE process (`getUserTime`).
+    /// This implementation is based on `std::chrono` and uses time points and time spans.
+    /// For KLEE statistics, spans are converted to µs and stored in `uint64_t`.
 
-    /// Wall time in seconds.
-    double getWallTime();
+    struct Point;
+    struct Span;
 
-    /// Wall time as TimeValue object.
-#if LLVM_VERSION_CODE >= LLVM_VERSION(4, 0)
-    double durationToDouble(std::chrono::nanoseconds dur);
-    llvm::sys::TimePoint<> getWallTimeVal();
-#else
-    llvm::sys::TimeValue getWallTimeVal();
-#endif
-  }
-}
+    /// Returns information about clock
+    std::string getClockInfo();
+
+    /// Returns time spent by this process in user mode
+    Span getUserTime();
+
+    /// Returns point in time using a monotonic steady clock
+    Point getWallTime();
+
+    struct Point {
+      using SteadyTimePoint = std::chrono::steady_clock::time_point;
+
+      SteadyTimePoint point;
+
+      // ctors
+      Point() = default;
+      explicit Point(SteadyTimePoint p): point(p) {};
+
+      // operators
+      Point& operator+=(const Span&);
+      Point& operator-=(const Span&);
+    };
+
+    // operators
+    Point operator+(const Point&, const Span&);
+    Point operator+(const Span&, const Point&);
+    Point operator-(const Point&, const Span&);
+    Span operator-(const Point&, const Point&);
+    bool operator==(const Point&, const Point&);
+    bool operator!=(const Point&, const Point&);
+    bool operator<(const Point&, const Point&);
+    bool operator<=(const Point&, const Point&);
+    bool operator>(const Point&, const Point&);
+    bool operator>=(const Point&, const Point&);
+
+    namespace { using Duration = std::chrono::steady_clock::duration; }
+
+    struct Span {
+      Duration duration = Duration::zero();
+
+      // ctors
+      Span() = default;
+      explicit Span(const Duration &d): duration(d) {}
+      explicit Span(const std::string &s);
+
+      // operators
+      Span& operator=(const Duration&);
+      Span& operator+=(const Span&);
+      Span& operator-=(const Span&);
+      Span& operator*=(const Duration::rep&);
+
+      // conversions
+      explicit operator Duration() const;
+      explicit operator bool() const;
+      explicit operator timeval() const;
+
+      std::uint64_t toMicroseconds() const;
+      double toSeconds() const;
+      std::tuple<std::uint32_t, std::uint8_t, std::uint8_t> toHMS() const; // hours, minutes, seconds
+    };
+
+    Span operator+(const Span&, const Span&);
+    Span operator-(const Span&, const Span&);
+    Span operator*(const Span&, const Duration::rep&);
+    Span operator/(const Span&, const Duration::rep&);
+    Span operator*(const Duration::rep&, const Span&);
+    bool operator==(const Span&, const Span&);
+    bool operator<=(const Span&, const Span&);
+    bool operator>=(const Span&, const Span&);
+    bool operator<(const Span&, const Span&);
+    bool operator>(const Span&, const Span&);
+
+    /// Span -> "X.Ys"
+    std::ostream& operator<<(std::ostream&, Span);
+    llvm::raw_ostream& operator<<(llvm::raw_ostream&, Span);
+
+    /// time spans
+    Span hours(std::uint16_t);
+    Span minutes(std::uint16_t);
+    Span seconds(std::uint64_t);
+    Span milliseconds(std::uint64_t);
+    Span microseconds(std::uint64_t);
+    Span nanoseconds(std::uint64_t);
+
+  } // time
+} // klee
 
 #endif

--- a/include/klee/Solver.h
+++ b/include/klee/Solver.h
@@ -12,6 +12,7 @@
 
 #include "klee/Expr.h"
 #include "klee/SolverCmdLine.h"
+#include "klee/Internal/System/Time.h"
 
 #include <vector>
 
@@ -200,7 +201,7 @@ namespace klee {
     virtual std::pair< ref<Expr>, ref<Expr> > getRange(const Query&);
     
     virtual char *getConstraintLog(const Query& query);
-    virtual void setCoreSolverTimeout(double timeout);
+    virtual void setCoreSolverTimeout(time::Span timeout);
   };
 
   /* *** */
@@ -251,12 +252,14 @@ namespace klee {
   /// createKQueryLoggingSolver - Create a solver which will forward all queries
   /// after writing them to the given path in .kquery format.
   Solver *createKQueryLoggingSolver(Solver *s, std::string path,
-                                int minQueryTimeToLog);
+                                    time::Span minQueryTimeToLog,
+                                    bool logTimedOut);
 
   /// createSMTLIBLoggingSolver - Create a solver which will forward all queries
   /// after writing them to the given path in .smt2 format.
   Solver *createSMTLIBLoggingSolver(Solver *s, std::string path,
-                                    int minQueryTimeToLog);
+                                    time::Span minQueryTimeToLog,
+                                    bool logTimedOut);
 
 
   /// createDummySolver - Create a dummy solver implementation which always

--- a/include/klee/SolverCmdLine.h
+++ b/include/klee/SolverCmdLine.h
@@ -32,9 +32,11 @@ extern llvm::cl::opt<bool> UseIndependentSolver;
 
 extern llvm::cl::opt<bool> DebugValidateSolver;
 
-extern llvm::cl::opt<int> MinQueryTimeToLog;
+extern llvm::cl::opt<std::string> MinQueryTimeToLog;
 
-extern llvm::cl::opt<double> MaxCoreSolverTime;
+extern llvm::cl::opt<bool> LogTimedOutQueries;
+
+extern llvm::cl::opt<std::string> MaxCoreSolverTime;
 
 extern llvm::cl::opt<bool> UseForkedCoreSolver;
 

--- a/include/klee/SolverImpl.h
+++ b/include/klee/SolverImpl.h
@@ -10,6 +10,7 @@
 #ifndef KLEE_SOLVERIMPL_H
 #define KLEE_SOLVERIMPL_H
 
+#include "klee/Internal/System/Time.h"
 #include "Solver.h"
 
 #include <vector>
@@ -105,7 +106,7 @@ namespace klee {
         return(NULL);
     }
 
-    virtual void setCoreSolverTimeout(double timeout) {};
+    virtual void setCoreSolverTimeout(time::Span timeout) {};
 };
 
 }

--- a/include/klee/TimerStatIncrementer.h
+++ b/include/klee/TimerStatIncrementer.h
@@ -22,10 +22,11 @@ namespace klee {
   public:
     TimerStatIncrementer(Statistic &_statistic) : statistic(_statistic) {}
     ~TimerStatIncrementer() {
-      statistic += timer.check(); 
+      // record microseconds
+      statistic += timer.check().toMicroseconds();
     }
 
-    uint64_t check() { return timer.check(); }
+    time::Span check() { return timer.check(); }
   };
 }
 

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -23,6 +23,15 @@ using namespace llvm;
 
 namespace klee {
 
+cl::extrahelp TimeFormatInfo(
+  "\nTime format used by KLEE's options\n"
+  "\n"
+  "  Time spans can be specified in two ways:\n"
+  "    1. As positive real numbers representing seconds, e.g. '10', '3.5' but not 'INF', 'NaN', '1e3', '-4.5s'\n"
+  "    2. As a sequence of natural numbers with specified units, e.g. '1h10min' (= '70min'), '5min10s' but not '3.5min', '8S'\n"
+  "       The following units are supported: h, min, s, ms, us, ns.\n"
+);
+
 cl::opt<bool>
 UseFastCexSolver("use-fast-cex-solver",
 		 cl::init(false),
@@ -47,19 +56,19 @@ cl::opt<bool>
 DebugValidateSolver("debug-validate-solver",
                     cl::init(false));
   
-cl::opt<int>
+cl::opt<std::string>
 MinQueryTimeToLog("min-query-time-to-log",
-                  cl::init(0),
-                  cl::value_desc("milliseconds"),
-                  cl::desc("Set time threshold (in ms) for queries logged in files. "
-                           "Only queries longer than threshold will be logged. (default=0). "
-                           "Set this param to a negative value to log timeouts only."));
+                  cl::desc("Set time threshold for queries logged in files. "
+                           "Only queries longer than threshold will be logged. (default=0s)"));
 
-cl::opt<double>
+cl::opt<bool>
+LogTimedOutQueries("log-timed-out-queries",
+                   cl::init(true),
+                   cl::desc("Log queries that timed out. (default=true)."));
+
+cl::opt<std::string>
 MaxCoreSolverTime("max-solver-time",
-                  cl::desc("Maximum amount of time for a single SMT query (default=0s (off)). Enables --use-forked-solver"),
-                  cl::init(0.0),
-                  cl::value_desc("seconds"));
+                  cl::desc("Maximum amount of time for a single SMT query (default=0s (off)). Enables --use-forked-solver"));
 
 cl::opt<bool>
 UseForkedCoreSolver("use-forked-solver",

--- a/lib/Basic/ConstructSolverChain.cpp
+++ b/lib/Basic/ConstructSolverChain.cpp
@@ -13,7 +13,9 @@
 #include "klee/Common.h"
 #include "klee/SolverCmdLine.h"
 #include "klee/Internal/Support/ErrorHandling.h"
+#include "klee/Internal/System/Time.h"
 #include "llvm/Support/raw_ostream.h"
+
 
 namespace klee {
 Solver *constructSolverChain(Solver *coreSolver,
@@ -22,17 +24,16 @@ Solver *constructSolverChain(Solver *coreSolver,
                              std::string queryKQueryLogPath,
                              std::string baseSolverQueryKQueryLogPath) {
   Solver *solver = coreSolver;
+  const time::Span minQueryTimeToLog(MinQueryTimeToLog);
 
   if (queryLoggingOptions.isSet(SOLVER_KQUERY)) {
-    solver = createKQueryLoggingSolver(solver, baseSolverQueryKQueryLogPath,
-                                   MinQueryTimeToLog);
+    solver = createKQueryLoggingSolver(solver, baseSolverQueryKQueryLogPath, minQueryTimeToLog, LogTimedOutQueries);
     klee_message("Logging queries that reach solver in .kquery format to %s\n",
                  baseSolverQueryKQueryLogPath.c_str());
   }
 
   if (queryLoggingOptions.isSet(SOLVER_SMTLIB)) {
-    solver = createSMTLIBLoggingSolver(solver, baseSolverQuerySMT2LogPath,
-                                       MinQueryTimeToLog);
+    solver = createSMTLIBLoggingSolver(solver, baseSolverQuerySMT2LogPath, minQueryTimeToLog, LogTimedOutQueries);
     klee_message("Logging queries that reach solver in .smt2 format to %s\n",
                  baseSolverQuerySMT2LogPath.c_str());
   }
@@ -56,15 +57,13 @@ Solver *constructSolverChain(Solver *coreSolver,
     solver = createValidatingSolver(solver, coreSolver);
 
   if (queryLoggingOptions.isSet(ALL_KQUERY)) {
-    solver = createKQueryLoggingSolver(solver, queryKQueryLogPath,
-                                       MinQueryTimeToLog);
+    solver = createKQueryLoggingSolver(solver, queryKQueryLogPath, minQueryTimeToLog, LogTimedOutQueries);
     klee_message("Logging all queries in .kquery format to %s\n",
                  queryKQueryLogPath.c_str());
   }
 
   if (queryLoggingOptions.isSet(ALL_SMTLIB)) {
-    solver =
-        createSMTLIBLoggingSolver(solver, querySMT2LogPath, MinQueryTimeToLog);
+    solver = createSMTLIBLoggingSolver(solver, querySMT2LogPath, minQueryTimeToLog, LogTimedOutQueries);
     klee_message("Logging all queries in .smt2 format to %s\n",
                  querySMT2LogPath.c_str());
   }

--- a/lib/Core/AddressSpace.cpp
+++ b/lib/Core/AddressSpace.cpp
@@ -196,7 +196,7 @@ int AddressSpace::checkPointerInObject(ExecutionState &state,
 
 bool AddressSpace::resolve(ExecutionState &state, TimingSolver *solver,
                            ref<Expr> p, ResolutionList &rl,
-                           unsigned maxResolutions, double timeout) const {
+                           unsigned maxResolutions, time::Span timeout) const {
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(p)) {
     ObjectPair res;
     if (resolveOne(CE, res))
@@ -204,7 +204,6 @@ bool AddressSpace::resolve(ExecutionState &state, TimingSolver *solver,
     return false;
   } else {
     TimerStatIncrementer timer(stats::resolveTime);
-    uint64_t timeout_us = (uint64_t) (timeout * 1000000.);
 
     // XXX in general this isn't exactly what we want... for
     // a multiple resolution case (or for example, a \in {b,c,0})
@@ -238,7 +237,7 @@ bool AddressSpace::resolve(ExecutionState &state, TimingSolver *solver,
     while (oi != begin) {
       --oi;
       const MemoryObject *mo = oi->first;
-      if (timeout_us && timeout_us < timer.check())
+      if (timeout && timeout < timer.check())
         return true;
 
       int incomplete =
@@ -257,7 +256,7 @@ bool AddressSpace::resolve(ExecutionState &state, TimingSolver *solver,
     // search forwards
     for (oi = start; oi != end; ++oi) {
       const MemoryObject *mo = oi->first;
-      if (timeout_us && timeout_us < timer.check())
+      if (timeout && timeout < timer.check())
         return true;
 
       bool mustBeTrue;

--- a/lib/Core/AddressSpace.h
+++ b/lib/Core/AddressSpace.h
@@ -14,6 +14,7 @@
 
 #include "klee/Expr.h"
 #include "klee/Internal/ADT/ImmutableMap.h"
+#include "klee/Internal/System/Time.h"
 
 namespace klee {
   class ExecutionState;
@@ -61,7 +62,7 @@ namespace klee {
     ///
     /// \invariant forall o in objects, o->copyOnWriteOwner <= cowKey
     MemoryMap objects;
-    
+
     AddressSpace() : cowKey(1) {}
     AddressSpace(const AddressSpace &b) : cowKey(++b.cowKey), objects(b.objects) { }
     ~AddressSpace() {}
@@ -97,7 +98,7 @@ namespace klee {
                  ref<Expr> p,
                  ResolutionList &rl, 
                  unsigned maxResolutions=0,
-                 double timeout=0.) const;
+                 time::Span timeout=time::Span()) const;
 
     /***/
 

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -66,7 +66,6 @@ ExecutionState::ExecutionState(KFunction *kf) :
     pc(kf->instructions),
     prevPC(pc),
 
-    queryCost(0.), 
     weight(1),
     depth(0),
 
@@ -79,7 +78,7 @@ ExecutionState::ExecutionState(KFunction *kf) :
 }
 
 ExecutionState::ExecutionState(const std::vector<ref<Expr> > &assumptions)
-    : constraints(assumptions), queryCost(0.), ptreeNode(0) {}
+    : constraints(assumptions), ptreeNode(0) {}
 
 ExecutionState::~ExecutionState() {
   for (unsigned int i=0; i<symbolics.size(); i++)

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -244,15 +244,13 @@ namespace {
 		      cl::init(1.),
 		      cl::desc("(default=1.0)"));
 
-  cl::opt<double>
+  cl::opt<std::string>
   MaxInstructionTime("max-instruction-time",
-                     cl::desc("Only allow a single instruction to take this much time (default=0s (off)). Enables --use-forked-solver"),
-                     cl::init(0));
+                     cl::desc("Allow a single instruction to take only this much time (default=0s (off)). Enables --use-forked-solver"));
   
-  cl::opt<double>
+  cl::opt<std::string>
   SeedTime("seed-time",
-           cl::desc("Amount of time to dedicate to seeds, before normal search (default=0 (off))"),
-           cl::init(0));
+           cl::desc("Amount of time to dedicate to seeds, before normal search (default=0s (off))"));
   
   cl::list<Executor::TerminateReason>
   ExitOnErrorType("exit-on-error-type",
@@ -328,11 +326,14 @@ Executor::Executor(LLVMContext &ctx, const InterpreterOptions &opts,
       pathWriter(0), symPathWriter(0), specialFunctionHandler(0),
       processTree(0), replayKTest(0), replayPath(0), usingSeeds(0),
       atMemoryLimit(false), inhibitForking(false), haltExecution(false),
-      ivcEnabled(false),
-      coreSolverTimeout(MaxCoreSolverTime != 0 && MaxInstructionTime != 0
-                            ? std::min(MaxCoreSolverTime, MaxInstructionTime)
-                            : std::max(MaxCoreSolverTime, MaxInstructionTime)),
-      debugLogBuffer(debugBufferString) {
+      ivcEnabled(false), debugLogBuffer(debugBufferString) {
+
+
+  const time::Span maxCoreSolverTime(MaxCoreSolverTime);
+  maxInstructionTime = time::Span(MaxInstructionTime);
+  coreSolverTimeout = maxCoreSolverTime && maxInstructionTime ?
+                      std::min(maxCoreSolverTime, maxInstructionTime)
+                    : std::max(maxCoreSolverTime, maxInstructionTime);
 
   if (coreSolverTimeout) UseForkedCoreSolver = true;
   Solver *coreSolver = klee::createCoreSolver(CoreSolverToUse);
@@ -779,7 +780,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
   if (!isSeeding && !isa<ConstantExpr>(condition) && 
       (MaxStaticForkPct!=1. || MaxStaticSolvePct != 1. ||
        MaxStaticCPForkPct!=1. || MaxStaticCPSolvePct != 1.) &&
-      statsTracker->elapsed() > 60.) {
+      statsTracker->elapsed() > time::seconds(60)) {
     StatisticManager &sm = *theStatisticManager;
     CallPathNode *cpn = current.stack.back().callPathNode;
     if ((MaxStaticForkPct<1. &&
@@ -803,12 +804,12 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
     }
   }
 
-  double timeout = coreSolverTimeout;
+  time::Span timeout = coreSolverTimeout;
   if (isSeeding)
     timeout *= it->second.size();
   solver->setTimeout(timeout);
   bool success = solver->evaluate(current, condition, res);
-  solver->setTimeout(0);
+  solver->setTimeout(time::Span());
   if (!success) {
     current.pc = current.prevPC;
     terminateStateEarly(current, "Query timed out (fork).");
@@ -1076,7 +1077,7 @@ ref<Expr> Executor::toUnique(const ExecutionState &state,
       if (solver->mustBeTrue(state, cond, isTrue) && isTrue)
         result = value;
     }
-    solver->setTimeout(0);
+    solver->setTimeout(time::Span());
   }
   
   return result;
@@ -2774,7 +2775,7 @@ void Executor::run(ExecutionState &initialState) {
       v.push_back(SeedInfo(*it));
 
     int lastNumSeeds = usingSeeds->size()+10;
-    double lastTime, startTime = lastTime = util::getWallTime();
+    time::Point lastTime, startTime = lastTime = time::getWallTime();
     ExecutionState *lastState = 0;
     while (!seedMap.empty()) {
       if (haltExecution) {
@@ -2793,7 +2794,7 @@ void Executor::run(ExecutionState &initialState) {
       stepInstruction(state);
 
       executeInstruction(state, ki);
-      processTimers(&state, MaxInstructionTime * numSeeds);
+      processTimers(&state, maxInstructionTime * numSeeds);
       updateStates(&state);
 
       if ((stats::instructions % 1000) == 0) {
@@ -2804,13 +2805,14 @@ void Executor::run(ExecutionState &initialState) {
           numSeeds += it->second.size();
           numStates++;
         }
-        double time = util::getWallTime();
-        if (SeedTime>0. && time > startTime + SeedTime) {
+        const auto time = time::getWallTime();
+        const time::Span seedTime(SeedTime);
+        if (seedTime && time > startTime + seedTime) {
           klee_warning("seed time expired, %d seeds remain over %d states",
                        numSeeds, numStates);
           break;
         } else if (numSeeds<=lastNumSeeds-10 ||
-                   time >= lastTime+10) {
+                   time - lastTime >= time::seconds(10)) {
           lastTime = time;
           lastNumSeeds = numSeeds;          
           klee_message("%d seeds remaining over: %d states", 
@@ -2846,7 +2848,7 @@ void Executor::run(ExecutionState &initialState) {
     stepInstruction(state);
 
     executeInstruction(state, ki);
-    processTimers(&state, MaxInstructionTime);
+    processTimers(&state, maxInstructionTime);
 
     checkMemoryUsage();
 
@@ -3457,7 +3459,7 @@ void Executor::executeMemoryOperation(ExecutionState &state,
     address = toConstant(state, address, "resolveOne failure");
     success = state.addressSpace.resolveOne(cast<ConstantExpr>(address), op);
   }
-  solver->setTimeout(0);
+  solver->setTimeout(time::Span());
 
   if (success) {
     const MemoryObject *mo = op.first;
@@ -3473,7 +3475,7 @@ void Executor::executeMemoryOperation(ExecutionState &state,
     bool inBounds;
     solver->setTimeout(coreSolverTimeout);
     bool success = solver->mustBeTrue(state, check, inBounds);
-    solver->setTimeout(0);
+    solver->setTimeout(time::Span());
     if (!success) {
       state.pc = state.prevPC;
       terminateStateEarly(state, "Query timed out (bounds check).");
@@ -3511,7 +3513,7 @@ void Executor::executeMemoryOperation(ExecutionState &state,
   solver->setTimeout(coreSolverTimeout);
   bool incomplete = state.addressSpace.resolve(state, solver, address, rl,
                                                0, coreSolverTimeout);
-  solver->setTimeout(0);
+  solver->setTimeout(time::Span());
   
   // XXX there is some query wasteage here. who cares?
   ExecutionState *unbound = &state;
@@ -3827,7 +3829,7 @@ bool Executor::getSymbolicSolution(const ExecutionState &state,
   for (unsigned i = 0; i != state.symbolics.size(); ++i)
     objects.push_back(state.symbolics[i].second);
   bool success = solver->getInitialValues(tmp, objects, values);
-  solver->setTimeout(0);
+  solver->setTimeout(time::Span());
   if (!success) {
     klee_warning("unable to compute initial values (invalid constraints?)!");
     ExprPPrinter::printQuery(llvm::errs(), state.constraints,

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -20,6 +20,7 @@
 #include "klee/Internal/Module/Cell.h"
 #include "klee/Internal/Module/KInstruction.h"
 #include "klee/Internal/Module/KModule.h"
+#include "klee/Internal/System/Time.h"
 #include "klee/util/ArrayCache.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -216,7 +217,10 @@ private:
 
   /// The maximum time to allow for a single core solver query.
   /// (e.g. for a single STP query)
-  double coreSolverTimeout;
+  time::Span coreSolverTimeout;
+
+  /// Maximum time to allow for a single instruction.
+  time::Span maxInstructionTime;
 
   /// Assumes ownership of the created array objects
   ArrayCache arrayCache;
@@ -461,11 +465,10 @@ private:
   ///
   /// \param timer The timer object to run on firings.
   /// \param rate The approximate delay (in seconds) between firings.
-  void addTimer(Timer *timer, double rate);
+  void addTimer(Timer *timer, time::Span rate);
 
   void initTimers();
-  void processTimers(ExecutionState *current,
-                     double maxInstTime);
+  void processTimers(ExecutionState *current, time::Span maxInstTime);
   void checkMemoryUsage();
   void printDebugInstructions(ExecutionState &state);
   void doDumpStates();

--- a/lib/Core/ExecutorTimerInfo.h
+++ b/lib/Core/ExecutorTimerInfo.h
@@ -23,15 +23,15 @@ public:
   Timer *timer;
 
   /// Approximate delay per timer firing.
-  double rate;
+  time::Span rate;
   /// Wall time for next firing.
-  double nextFireTime;
+  time::Point nextFireTime;
 
 public:
-  TimerInfo(Timer *_timer, double _rate)
+  TimerInfo(Timer *_timer, time::Span _rate)
     : timer(_timer),
       rate(_rate),
-      nextFireTime(util::getWallTime() + rate) {}
+      nextFireTime(time::getWallTime() + rate) {}
   ~TimerInfo() { delete timer; }
 };
 

--- a/lib/Core/Searcher.h
+++ b/lib/Core/Searcher.h
@@ -10,11 +10,14 @@
 #ifndef KLEE_SEARCHER_H
 #define KLEE_SEARCHER_H
 
+#include "klee/Internal/System/Time.h"
+
 #include "llvm/Support/raw_ostream.h"
-#include <vector>
-#include <set>
+
 #include <map>
 #include <queue>
+#include <set>
+#include <vector>
 
 namespace llvm {
   class BasicBlock;
@@ -208,16 +211,16 @@ namespace klee {
 
   class BatchingSearcher : public Searcher {
     Searcher *baseSearcher;
-    double timeBudget;
+    time::Span timeBudget;
     unsigned instructionBudget;
 
     ExecutionState *lastState;
-    double lastStartTime;
+    time::Point lastStartTime;
     unsigned lastStartInstructions;
 
   public:
     BatchingSearcher(Searcher *baseSearcher, 
-                     double _timeBudget,
+                     time::Span _timeBudget,
                      unsigned _instructionBudget);
     ~BatchingSearcher();
 
@@ -237,7 +240,8 @@ namespace klee {
 
   class IterativeDeepeningTimeSearcher : public Searcher {
     Searcher *baseSearcher;
-    double time, startTime;
+    time::Point startTime;
+    time::Span time;
     std::set<ExecutionState*> pausedStates;
 
   public:

--- a/lib/Core/StatsTracker.h
+++ b/lib/Core/StatsTracker.h
@@ -11,6 +11,7 @@
 #define KLEE_STATSTRACKER_H
 
 #include "CallPathManager.h"
+#include "klee/Internal/System/Time.h"
 
 #include <memory>
 #include <set>
@@ -38,7 +39,7 @@ namespace klee {
     std::string objectFilename;
 
     std::unique_ptr<llvm::raw_fd_ostream> statsFile, istatsFile;
-    double startWallTime;
+    time::Point startWallTime;
 
     unsigned numBranches;
     unsigned fullBranches, partialBranches;
@@ -81,8 +82,8 @@ namespace klee {
     // about to be stepped
     void stepInstruction(ExecutionState &es);
 
-    /// Return time in seconds since execution start.
-    double elapsed();
+    /// Return duration since execution start.
+    time::Span elapsed();
 
     void computeReachableUncovered();
   };

--- a/lib/Core/TimingSolver.cpp
+++ b/lib/Core/TimingSolver.cpp
@@ -37,7 +37,7 @@ bool TimingSolver::evaluate(const ExecutionState& state, ref<Expr> expr,
 
   bool success = solver->evaluate(Query(state.constraints, expr), result);
 
-  state.queryCost += timer.check() / 1e6;
+  state.queryCost += timer.check();
 
   return success;
 }
@@ -57,7 +57,7 @@ bool TimingSolver::mustBeTrue(const ExecutionState& state, ref<Expr> expr,
 
   bool success = solver->mustBeTrue(Query(state.constraints, expr), result);
 
-  state.queryCost += timer.check() / 1e6;
+  state.queryCost += timer.check();
 
   return success;
 }
@@ -100,7 +100,7 @@ bool TimingSolver::getValue(const ExecutionState& state, ref<Expr> expr,
 
   bool success = solver->getValue(Query(state.constraints, expr), result);
 
-  state.queryCost += timer.check() / 1e6;
+  state.queryCost += timer.check();
 
   return success;
 }
@@ -120,7 +120,7 @@ TimingSolver::getInitialValues(const ExecutionState& state,
                                                 ConstantExpr::alloc(0, Expr::Bool)), 
                                           objects, result);
   
-  state.queryCost += timer.check() / 1e6;
+  state.queryCost += timer.check();
   
   return success;
 }

--- a/lib/Core/TimingSolver.h
+++ b/lib/Core/TimingSolver.h
@@ -12,6 +12,7 @@
 
 #include "klee/Expr.h"
 #include "klee/Solver.h"
+#include "klee/Internal/System/Time.h"
 
 #include <vector>
 
@@ -38,7 +39,7 @@ namespace klee {
       delete solver;
     }
 
-    void setTimeout(double t) {
+    void setTimeout(time::Span t) {
       solver->setCoreSolverTimeout(t);
     }
     

--- a/lib/Core/UserSearcher.cpp
+++ b/lib/Core/UserSearcher.cpp
@@ -51,10 +51,10 @@ namespace {
                     cl::desc("Number of instructions to batch when using --use-batching-search"),
                     cl::init(10000));
   
-  cl::opt<double>
+  cl::opt<std::string>
   BatchTime("batch-time",
-            cl::desc("Amount of time to batch when using --use-batching-search"),
-            cl::init(5.0));
+            cl::desc("Amount of time to batch when using --use-batching-search (default=5s)"),
+            cl::init("5s"));
 
 }
 
@@ -120,7 +120,7 @@ Searcher *klee::constructUserSearcher(Executor &executor) {
   }
 
   if (UseBatchingSearch) {
-    searcher = new BatchingSearcher(searcher, BatchTime, BatchInstructions);
+    searcher = new BatchingSearcher(searcher, time::Span(BatchTime), BatchInstructions);
   }
 
   if (UseMerge && UseIncompleteMerge) {

--- a/lib/Solver/AssignmentValidatingSolver.cpp
+++ b/lib/Solver/AssignmentValidatingSolver.cpp
@@ -32,7 +32,7 @@ public:
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query &);
-  void setCoreSolverTimeout(double timeout);
+  void setCoreSolverTimeout(time::Span timeout);
 };
 
 // TODO: use computeInitialValues for all queries for more stress testing
@@ -148,7 +148,7 @@ char *AssignmentValidatingSolver::getConstraintLog(const Query &query) {
   return solver->impl->getConstraintLog(query);
 }
 
-void AssignmentValidatingSolver::setCoreSolverTimeout(double timeout) {
+void AssignmentValidatingSolver::setCoreSolverTimeout(time::Span timeout) {
   return solver->impl->setCoreSolverTimeout(timeout);
 }
 

--- a/lib/Solver/CachingSolver.cpp
+++ b/lib/Solver/CachingSolver.cpp
@@ -93,7 +93,7 @@ public:
   }
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query&);
-  void setCoreSolverTimeout(double timeout);
+  void setCoreSolverTimeout(time::Span timeout);
 };
 
 /** @returns the canonical version of the given query.  The reference
@@ -257,7 +257,7 @@ char *CachingSolver::getConstraintLog(const Query& query) {
   return solver->impl->getConstraintLog(query);
 }
 
-void CachingSolver::setCoreSolverTimeout(double timeout) {
+void CachingSolver::setCoreSolverTimeout(time::Span timeout) {
   solver->impl->setCoreSolverTimeout(timeout);
 }
 

--- a/lib/Solver/CexCachingSolver.cpp
+++ b/lib/Solver/CexCachingSolver.cpp
@@ -91,7 +91,7 @@ public:
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query& query);
-  void setCoreSolverTimeout(double timeout);
+  void setCoreSolverTimeout(time::Span timeout);
 };
 
 ///
@@ -371,7 +371,7 @@ char *CexCachingSolver::getConstraintLog(const Query& query) {
   return solver->impl->getConstraintLog(query);
 }
 
-void CexCachingSolver::setCoreSolverTimeout(double timeout) {
+void CexCachingSolver::setCoreSolverTimeout(time::Span timeout) {
   solver->impl->setCoreSolverTimeout(timeout);
 }
 

--- a/lib/Solver/IncompleteSolver.cpp
+++ b/lib/Solver/IncompleteSolver.cpp
@@ -143,7 +143,7 @@ char *StagedSolverImpl::getConstraintLog(const Query& query) {
   return secondary->impl->getConstraintLog(query);
 }
 
-void StagedSolverImpl::setCoreSolverTimeout(double timeout) {
+void StagedSolverImpl::setCoreSolverTimeout(time::Span timeout) {
   secondary->impl->setCoreSolverTimeout(timeout);
 }
 

--- a/lib/Solver/IndependentSolver.cpp
+++ b/lib/Solver/IndependentSolver.cpp
@@ -408,7 +408,7 @@ public:
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query&);
-  void setCoreSolverTimeout(double timeout);
+  void setCoreSolverTimeout(time::Span timeout);
 };
   
 bool IndependentSolver::computeValidity(const Query& query,
@@ -555,7 +555,7 @@ char *IndependentSolver::getConstraintLog(const Query& query) {
   return solver->impl->getConstraintLog(query);
 }
 
-void IndependentSolver::setCoreSolverTimeout(double timeout) {
+void IndependentSolver::setCoreSolverTimeout(time::Span timeout) {
   solver->impl->setCoreSolverTimeout(timeout);
 }
 

--- a/lib/Solver/KQueryLoggingSolver.cpp
+++ b/lib/Solver/KQueryLoggingSolver.cpp
@@ -11,6 +11,7 @@
 
 #include "klee/Expr.h"
 #include "klee/util/ExprPPrinter.h"
+#include "klee/Internal/System/Time.h"
 
 using namespace klee;
 
@@ -49,8 +50,8 @@ private :
     }
 
 public:
-    KQueryLoggingSolver(Solver *_solver, std::string path, int queryTimeToLog)
-    : QueryLoggingSolver(_solver, path, "#", queryTimeToLog),
+    KQueryLoggingSolver(Solver *_solver, std::string path, time::Span queryTimeToLog, bool logTimedOut)
+    : QueryLoggingSolver(_solver, path, "#", queryTimeToLog, logTimedOut),
     printer(ExprPPrinter::create(logBuffer)) {
     }
 
@@ -62,7 +63,7 @@ public:
 ///
 
 Solver *klee::createKQueryLoggingSolver(Solver *_solver, std::string path,
-                                    int minQueryTimeToLog) {
-  return new Solver(new KQueryLoggingSolver(_solver, path, minQueryTimeToLog));
+                                    time::Span minQueryTimeToLog, bool logTimedOut) {
+  return new Solver(new KQueryLoggingSolver(_solver, path, minQueryTimeToLog, logTimedOut));
 }
 

--- a/lib/Solver/MetaSMTSolver.h
+++ b/lib/Solver/MetaSMTSolver.h
@@ -21,7 +21,7 @@ public:
   virtual ~MetaSMTSolver();
 
   virtual char *getConstraintLog(const Query &);
-  virtual void setCoreSolverTimeout(double timeout);
+  virtual void setCoreSolverTimeout(time::Span timeout);
 };
 
 /// createMetaSMTSolver - Create a solver using the metaSMT backend set by

--- a/lib/Solver/QueryLoggingSolver.h
+++ b/lib/Solver/QueryLoggingSolver.h
@@ -13,6 +13,8 @@
 
 #include "klee/Solver.h"
 #include "klee/SolverImpl.h"
+#include "klee/Internal/System/Time.h"
+
 #include "llvm/Support/raw_ostream.h"
 
 using namespace klee;
@@ -31,13 +33,10 @@ protected:
   // @brief buffer to store logs before flushing to file
   llvm::raw_string_ostream logBuffer;
   unsigned queryCount;
-  int minQueryTimeToLog; // we log to file only those queries
-                         // which take longer than the specified time (ms);
-                         // if this param is negative, log only those queries
-                         // on which the solver has timed out
-
-  double startTime;
-  double lastQueryTime;
+  time::Span minQueryTimeToLog; // we log to file only those queries which take longer than the specified time
+  bool logTimedOutQueries = false;
+  time::Point startTime;
+  time::Span lastQueryDuration;
   const std::string queryCommentSign; // sign representing commented lines
                                       // in given a query format
 
@@ -57,8 +56,8 @@ protected:
   void flushBufferConditionally(bool writeToFile);
 
 public:
-  QueryLoggingSolver(Solver *_solver, std::string path,
-                     const std::string &commentSign, int queryTimeToLog);
+  QueryLoggingSolver(Solver *_solver, std::string path, const std::string &commentSign,
+                     time::Span queryTimeToLog, bool logTimedOut);
 
   virtual ~QueryLoggingSolver();
 
@@ -72,7 +71,7 @@ public:
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query &);
-  void setCoreSolverTimeout(double timeout);
+  void setCoreSolverTimeout(time::Span timeout);
 };
 
 #endif /* KLEE_QUERYLOGGINGSOLVER_H */

--- a/lib/Solver/SMTLIBLoggingSolver.cpp
+++ b/lib/Solver/SMTLIBLoggingSolver.cpp
@@ -43,9 +43,10 @@ class SMTLIBLoggingSolver : public QueryLoggingSolver
         
 	public:
 		SMTLIBLoggingSolver(Solver *_solver,
-                                    std::string path,
-                                    int queryTimeToLog)                
-		: QueryLoggingSolver(_solver, path, ";", queryTimeToLog)
+                        std::string path,
+                        time::Span queryTimeToLog,
+                        bool logTimedOut)
+		: QueryLoggingSolver(_solver, path, ";", queryTimeToLog, logTimedOut)
 		{
 		  //Setup the printer
 		  printer.setOutput(logBuffer);
@@ -54,7 +55,7 @@ class SMTLIBLoggingSolver : public QueryLoggingSolver
 
 
 Solver* klee::createSMTLIBLoggingSolver(Solver *_solver, std::string path,
-                                        int minQueryTimeToLog)
+                                        time::Span minQueryTimeToLog, bool logTimedOut)
 {
-  return new Solver(new SMTLIBLoggingSolver(_solver, path, minQueryTimeToLog));
+  return new Solver(new SMTLIBLoggingSolver(_solver, path, minQueryTimeToLog, logTimedOut));
 }

--- a/lib/Solver/STPSolver.h
+++ b/lib/Solver/STPSolver.h
@@ -32,7 +32,7 @@ public:
   /// setCoreSolverTimeout - Set constraint solver timeout delay to the given
   /// value; 0
   /// is off.
-  virtual void setCoreSolverTimeout(double timeout);
+  virtual void setCoreSolverTimeout(time::Span timeout);
 };
 }
 

--- a/lib/Solver/Solver.cpp
+++ b/lib/Solver/Solver.cpp
@@ -29,7 +29,7 @@ char *Solver::getConstraintLog(const Query& query) {
     return impl->getConstraintLog(query);
 }
 
-void Solver::setCoreSolverTimeout(double timeout) {
+void Solver::setCoreSolverTimeout(time::Span timeout) {
     impl->setCoreSolverTimeout(timeout);
 }
 

--- a/lib/Solver/ValidatingSolver.cpp
+++ b/lib/Solver/ValidatingSolver.cpp
@@ -31,7 +31,7 @@ public:
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query &);
-  void setCoreSolverTimeout(double timeout);
+  void setCoreSolverTimeout(time::Span timeout);
 };
 
 bool ValidatingSolver::computeTruth(const Query &query, bool &isValid) {
@@ -132,7 +132,7 @@ char *ValidatingSolver::getConstraintLog(const Query &query) {
   return solver->impl->getConstraintLog(query);
 }
 
-void ValidatingSolver::setCoreSolverTimeout(double timeout) {
+void ValidatingSolver::setCoreSolverTimeout(time::Span timeout) {
   solver->impl->setCoreSolverTimeout(timeout);
 }
 

--- a/lib/Solver/Z3Solver.h
+++ b/lib/Solver/Z3Solver.h
@@ -27,7 +27,7 @@ public:
   /// setCoreSolverTimeout - Set constraint solver timeout delay to the given
   /// value; 0
   /// is off.
-  virtual void setCoreSolverTimeout(double timeout);
+  virtual void setCoreSolverTimeout(time::Span timeout);
 };
 }
 

--- a/lib/Support/Time.cpp
+++ b/lib/Support/Time.cpp
@@ -7,58 +7,193 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "klee/Config/Version.h"
+#include "klee/Internal/Support/ErrorHandling.h"
 #include "klee/Internal/System/Time.h"
 
-#if LLVM_VERSION_CODE >= LLVM_VERSION(4, 0)
-#include <chrono>
 
-#include <llvm/Support/Chrono.h>
-#else
-#include "llvm/Support/TimeValue.h"
-#endif
+#include <cstdint>
+#include <regex>
+#include <sstream>
+#include <tuple>
+#include <sys/resource.h>
 
-#include "llvm/Support/Process.h"
 
-using namespace llvm;
 using namespace klee;
 
-#if LLVM_VERSION_CODE >= LLVM_VERSION(4, 0)
-double util::durationToDouble(std::chrono::nanoseconds dur)
-{
-  return dur.count() / 1e9;
+
+/* Why std::chrono:
+ * - C++11
+ * - separation between time points and durations
+ * - good performance on Linux and macOS (similar to gettimeofday)
+ * and not:
+ * - clock_gettime(CLOCK_MONOTONIC_COARSE): software clock, Linux-specific
+ * - clock_gettime(CLOCK_MONOTONIC): slowest on macOS, C-like API
+ * - gettimeofday: C-like API, non-monotonic
+ *
+ * TODO: add time literals with C++14
+ */
+
+// === Point ===
+
+// operators
+time::Point& time::Point::operator+=(const time::Span &span) { point += span.duration; return *this; }
+time::Point& time::Point::operator-=(const time::Span &span) { point -= span.duration; return *this; }
+
+time::Point time::operator+(const time::Point &point, const time::Span &span) { return time::Point(point.point + span.duration); }
+time::Point time::operator+(const time::Span &span, const time::Point &point) { return time::Point(point.point + span.duration); }
+time::Point time::operator-(const time::Point &point, const time::Span &span) { return time::Point(point.point - span.duration); }
+time::Span time::operator-(const time::Point &lhs, const time::Point &rhs) { return time::Span(lhs.point - rhs.point); }
+bool time::operator==(const time::Point &lhs, const time::Point &rhs) { return lhs.point == rhs.point; }
+bool time::operator!=(const time::Point &lhs, const time::Point &rhs) { return lhs.point != rhs.point; }
+bool time::operator<(const time::Point &lhs, const time::Point &rhs) { return lhs.point < rhs.point; }
+bool time::operator<=(const time::Point &lhs, const time::Point &rhs) { return lhs.point <= rhs.point; }
+bool time::operator>(const time::Point &lhs, const time::Point &rhs) { return lhs.point > rhs.point; }
+bool time::operator>=(const time::Point &lhs, const time::Point &rhs) { return lhs.point >= rhs.point; }
+
+
+// === Span ===
+
+// ctors
+/// returns span from string in old (X.Y) and new (3h4min) format
+time::Span::Span(const std::string &s) {
+  if (s.empty()) return;
+
+  std::regex re("^([0-9]*\\.?[0-9]+)|((([0-9]+)(h|min|s|ms|us|ns))+)$", std::regex::extended);
+  std::regex nre("([0-9]+)(h|min|s|ms|us|ns)", std::regex::extended);
+  std::smatch match;
+  std::string submatch;
+
+  // error
+  if (!std::regex_match(s, match, re)) goto error;
+
+  // old (double) format
+  submatch = match[1].str();
+  if (match[1].matched) {
+    errno = 0;
+    auto value = std::stod(submatch);
+    if (errno) goto error;
+
+    std::chrono::duration<double> d(value);
+    duration = std::chrono::duration_cast<std::chrono::microseconds>(d);
+  }
+
+  // new (string) format
+  submatch = match[2].str();
+  for (std::smatch m; std::regex_search(submatch, m, nre); submatch = m.suffix()) {
+    errno = 0;
+    const auto value = std::stoull(m[1]);
+    if (errno) goto error;
+
+    Duration d;
+    if (m[2] == "h") d = std::chrono::hours(value);
+    else if (m[2] == "min") d = std::chrono::minutes(value);
+    else if (m[2] ==   "s") d = std::chrono::seconds(value);
+    else if (m[2] ==  "ms") d = std::chrono::milliseconds(value);
+    else if (m[2] ==  "us") d = std::chrono::microseconds(value);
+    else if (m[2] ==  "ns") d = std::chrono::nanoseconds(value);
+    else goto error;
+
+    duration += d;
+  }
+
+  return;
+
+error:
+  klee_error("Illegal number format: %s", s.c_str());
 }
 
-double util::getUserTime() {
-  sys::TimePoint<> now;
-  std::chrono::nanoseconds user, sys;
+// operators
+time::Span& time::Span::operator=(const time::Duration &d) { duration = d; return *this; };
+time::Span& time::Span::operator+=(const time::Span &other) { duration += other.duration; return *this; }
+time::Span& time::Span::operator-=(const time::Span &other) { duration -= other.duration; return *this; }
+time::Span& time::Span::operator*=(const time::Duration::rep &rep) { duration *= rep; return *this; }
 
-  sys::Process::GetTimeUsage(now, user, sys);
+time::Span time::operator+(const time::Span &lhs, const time::Span &rhs) { return time::Span(lhs.duration + rhs.duration); }
+time::Span time::operator-(const time::Span &lhs, const time::Span &rhs) { return time::Span(lhs.duration - rhs.duration); }
+time::Span time::operator*(const time::Span &span, const time::Duration::rep &rep) { return time::Span(span.duration * rep); }
+time::Span time::operator*(const time::Duration::rep &rep, const time::Span &span) { return time::Span(span.duration * rep); }
+time::Span time::operator/(const time::Span &span, const time::Duration::rep &rep) { return time::Span(span.duration / rep); }
+bool time::operator==(const time::Span &lhs, const time::Span &rhs) { return lhs.duration == rhs.duration; }
+bool time::operator<=(const time::Span &lhs, const time::Span &rhs) { return lhs.duration <= rhs.duration; }
+bool time::operator>=(const time::Span &lhs, const time::Span &rhs) { return lhs.duration >= rhs.duration; }
+bool time::operator<(const time::Span &lhs, const time::Span &rhs) { return lhs.duration < rhs.duration; }
+bool time::operator>(const time::Span &lhs, const time::Span &rhs) { return lhs.duration > rhs.duration; }
 
-  return durationToDouble(user);
+std::ostream& time::operator<<(std::ostream &stream, time::Span span) { return stream << span.toSeconds() << 's'; }
+llvm::raw_ostream& time::operator<<(llvm::raw_ostream &stream, time::Span span) { return stream << span.toSeconds() << 's'; }
+
+
+// units
+time::Span time::hours(std::uint16_t ticks) { return time::Span(std::chrono::hours(ticks)); }
+time::Span time::minutes(std::uint16_t ticks) { return time::Span(std::chrono::minutes(ticks)); }
+time::Span time::seconds(std::uint64_t ticks) { return time::Span(std::chrono::seconds(ticks)); }
+time::Span time::milliseconds(std::uint64_t ticks) { return time::Span(std::chrono::milliseconds(ticks)); }
+time::Span time::microseconds(std::uint64_t ticks) { return time::Span(std::chrono::microseconds(ticks)); }
+time::Span time::nanoseconds(std::uint64_t ticks) { return time::Span(std::chrono::nanoseconds(ticks)); }
+
+
+// conversions
+time::Span::operator time::Duration() const { return duration; }
+
+time::Span::operator bool() const { return duration.count() != 0; }
+
+time::Span::operator timeval() const {
+  timeval tv{};
+  const auto secs = std::chrono::duration_cast<std::chrono::seconds>(duration);
+  const auto usecs = std::chrono::duration_cast<std::chrono::microseconds>(duration - secs);
+  tv.tv_sec = secs.count();
+  tv.tv_usec = usecs.count();
+  return tv;
 }
 
-double util::getWallTime() {
-  return durationToDouble(getWallTimeVal().time_since_epoch());
+std::uint64_t time::Span::toMicroseconds() const {
+  return (std::uint64_t)std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
 }
 
-sys::TimePoint<> util::getWallTimeVal() {
-  return std::chrono::system_clock::now();
+double time::Span::toSeconds() const {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count() / (double)1000000000;
 }
 
-#else
-double util::getUserTime() {
-  sys::TimeValue now(0,0),user(0,0),sys(0,0);
-  sys::Process::GetTimeUsage(now,user,sys);
-  return (user.seconds() + (double) user.nanoseconds() * 1e-9);
+std::tuple<std::uint32_t, std::uint8_t, std::uint8_t> time::Span::toHMS() const {
+  auto d = duration;
+  const auto h = std::chrono::duration_cast<std::chrono::hours>(d);
+  const auto m = std::chrono::duration_cast<std::chrono::minutes>(d -= h);
+  const auto s = std::chrono::duration_cast<std::chrono::seconds>(d -= m);
+
+  return std::make_tuple((std::uint32_t) h.count(), (std::uint8_t) m.count(), (std::uint8_t) s.count());
 }
 
-double util::getWallTime() {
-  sys::TimeValue now = getWallTimeVal();
-  return (now.seconds() + ((double) now.nanoseconds() * 1e-9));
+
+// methods
+/// Returns information about clock
+std::string time::getClockInfo() {
+  std::stringstream buffer;
+  buffer << "Using monotonic steady clock with "
+         << std::chrono::steady_clock::period::num
+         << '/'
+         << std::chrono::steady_clock::period::den
+         << "s resolution\n";
+  return buffer.str();
 }
 
-sys::TimeValue util::getWallTimeVal() {
-  return sys::TimeValue::now();
+
+/// Returns time spent by this process in user mode
+time::Span time::getUserTime() {
+  rusage usage{};
+  auto ret = ::getrusage(RUSAGE_SELF, &usage);
+
+  if (ret) {
+    klee_warning("getrusage returned with error, return (0,0)");
+    return {};
+  } else {
+    return time::seconds(static_cast<std::uint64_t>(usage.ru_utime.tv_sec)) +
+           time::microseconds(static_cast<std::uint64_t>(usage.ru_utime.tv_usec));
+  }
 }
-#endif
+
+
+/// Returns point in time using a monotonic steady clock
+time::Point time::getWallTime() {
+  return time::Point(std::chrono::steady_clock::now());
+}
+

--- a/lib/Support/Timer.cpp
+++ b/lib/Support/Timer.cpp
@@ -9,32 +9,14 @@
 
 #include "klee/Config/Version.h"
 #include "klee/Internal/Support/Timer.h"
-
 #include "klee/Internal/System/Time.h"
 
 using namespace klee;
-using namespace llvm;
-
-#if LLVM_VERSION_CODE >= LLVM_VERSION(4, 0)
 
 WallTimer::WallTimer() {
-  start = util::getWallTimeVal();
+  start = time::getWallTime();
 }
 
-uint64_t WallTimer::check() {
-  auto now = util::getWallTimeVal();
-  return std::chrono::duration_cast<std::chrono::microseconds>(now -
-    start).count();
+time::Span WallTimer::check() {
+  return time::Span(time::getWallTime() - start);
 }
-
-#else
-
-WallTimer::WallTimer() {
-  startMicroseconds = util::getWallTimeVal().usec();
-}
-
-uint64_t WallTimer::check() {
-  return util::getWallTimeVal().usec() - startMicroseconds;
-}
-
-#endif

--- a/tools/kleaver/main.cpp
+++ b/tools/kleaver/main.cpp
@@ -216,8 +216,9 @@ static bool EvaluateInputAST(const char *Filename,
   Solver *coreSolver = klee::createCoreSolver(CoreSolverToUse);
 
   if (CoreSolverToUse != DUMMY_SOLVER) {
-    if (0 != MaxCoreSolverTime) {
-      coreSolver->setCoreSolverTimeout(MaxCoreSolverTime);
+    const time::Span maxCoreSolverTime(MaxCoreSolverTime);
+    if (maxCoreSolverTime) {
+      coreSolver->setCoreSolverTimeout(maxCoreSolverTime);
     }
   }
 

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -58,6 +58,7 @@
 #include <sys/wait.h>
 
 #include <cerrno>
+#include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <iterator>
@@ -213,7 +214,7 @@ namespace {
            cl::init(0));
 }
 
-extern cl::opt<double> MaxTime;
+extern cl::opt<std::string> MaxTime;
 
 /***/
 
@@ -409,7 +410,7 @@ void KleeHandler::processTestCase(const ExecutionState &state,
     if (!success)
       klee_warning("unable to get symbolic solution, losing test case");
 
-    double start_time = util::getWallTime();
+    const auto start_time = time::getWallTime();
 
     unsigned id = ++m_numTotalTests;
 
@@ -515,10 +516,10 @@ void KleeHandler::processTestCase(const ExecutionState &state,
       m_interpreter->setHaltExecution(true);
 
     if (WriteTestInfo) {
-      double elapsed_time = util::getWallTime() - start_time;
+      time::Span elapsed_time(time::getWallTime() - start_time);
       auto f = openTestFile("info", id);
       if (f)
-        *f << "Time to generate test case: " << elapsed_time << "s\n";
+        *f << "Time to generate test case: " << elapsed_time << '\n';
     }
   }
 
@@ -940,21 +941,6 @@ static void halt_via_gdb(int pid) {
     perror("system");
 }
 
-// returns the end of the string put in buf
-static char *format_tdiff(char *buf, long seconds)
-{
-  assert(seconds >= 0);
-
-  long minutes = seconds / 60;  seconds %= 60;
-  long hours   = minutes / 60;  minutes %= 60;
-  long days    = hours   / 24;  hours   %= 24;
-
-  buf = strrchr(buf, '\0');
-  if (days > 0) buf += sprintf(buf, "%ld days, ", days);
-  buf += sprintf(buf, "%02ld:%02ld:%02ld", hours, minutes, seconds);
-  return buf;
-}
-
 #ifndef SUPPORT_KLEE_UCLIBC
 static void
 linkWithUclibc(StringRef libDir,
@@ -1080,7 +1066,7 @@ int main(int argc, char **argv, char **envp) {
 #endif
 
   if (Watchdog) {
-    if (MaxTime==0) {
+    if (MaxTime.empty()) {
       klee_error("--watchdog used without --max-time");
     }
 
@@ -1092,7 +1078,8 @@ int main(int argc, char **argv, char **envp) {
       fflush(stderr);
       sys::SetInterruptFunction(interrupt_handle_watchdog);
 
-      double nextStep = util::getWallTime() + MaxTime*1.1;
+      const time::Span maxTime(MaxTime);
+      auto nextStep = time::getWallTime() + maxTime + (maxTime / 10);
       int level = 0;
 
       // Simple stupid code...
@@ -1114,7 +1101,7 @@ int main(int argc, char **argv, char **envp) {
         } else if (res==pid && WIFEXITED(status)) {
           return WEXITSTATUS(status);
         } else {
-          double time = util::getWallTime();
+          auto time = time::getWallTime();
 
           if (time > nextStep) {
             ++level;
@@ -1136,7 +1123,8 @@ int main(int argc, char **argv, char **envp) {
 
             // Ideally this triggers a dump, which may take a while,
             // so try and give the process extra time to clean up.
-            nextStep = util::getWallTime() + std::max(15., MaxTime*.1);
+            auto max = std::max(time::seconds(15), maxTime / 10);
+            nextStep = time::getWallTime() + max;
           }
         }
       }
@@ -1293,12 +1281,16 @@ int main(int argc, char **argv, char **envp) {
     interpreter->setReplayPath(&replayPath);
   }
 
-  char buf[256];
-  time_t t[2];
-  t[0] = time(NULL);
-  strftime(buf, sizeof(buf), "Started: %Y-%m-%d %H:%M:%S\n", localtime(&t[0]));
-  handler->getInfoStream() << buf;
-  handler->getInfoStream().flush();
+
+  auto startTime = std::time(nullptr);
+  { // output clock info and start time
+    std::stringstream startInfo;
+    startInfo << time::getClockInfo()
+              << "Started: "
+              << std::put_time(std::localtime(&startTime), "%Y-%m-%d %H:%M:%S") << '\n';
+    handler->getInfoStream() << startInfo.str();
+    handler->getInfoStream().flush();
+  }
 
   if (!ReplayKTestDir.empty() || !ReplayKTestFile.empty()) {
     assert(SeedOutFile.empty());
@@ -1396,13 +1388,24 @@ int main(int argc, char **argv, char **envp) {
     }
   }
 
-  t[1] = time(NULL);
-  strftime(buf, sizeof(buf), "Finished: %Y-%m-%d %H:%M:%S\n", localtime(&t[1]));
-  handler->getInfoStream() << buf;
-
-  strcpy(buf, "Elapsed: ");
-  strcpy(format_tdiff(buf, t[1] - t[0]), "\n");
-  handler->getInfoStream() << buf;
+  auto endTime = std::time(nullptr);
+  { // output end and elapsed time
+    std::uint32_t h;
+    std::uint8_t m, s;
+    std::tie(h,m,s) = time::seconds(endTime - startTime).toHMS();
+    std::stringstream endInfo;
+    endInfo << "Finished: "
+            << std::put_time(std::localtime(&endTime), "%Y-%m-%d %H:%M:%S") << '\n'
+            << "Elapsed: "
+            << std::setfill('0') << std::setw(2) << h
+            << ':'
+            << std::setfill('0') << std::setw(2) << +m
+            << ':'
+            << std::setfill('0') << std::setw(2) << +s
+            << '\n';
+            handler->getInfoStream() << endInfo.str();
+    handler->getInfoStream().flush();
+  }
 
   // Free all the args.
   for (unsigned i=0; i<InputArgv.size()+1; i++)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -86,6 +86,7 @@ add_subdirectory(Ref)
 add_subdirectory(Solver)
 add_subdirectory(TreeStream)
 add_subdirectory(DiscretePDF)
+add_subdirectory(Time)
 
 # Set up lit configuration
 set (UNIT_TEST_EXE_SUFFIX "Test")

--- a/unittests/Time/CMakeLists.txt
+++ b/unittests/Time/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_klee_unit_test(TimeTest
+  TimeTest.cpp)
+target_link_libraries(TimeTest PRIVATE kleeSupport)

--- a/unittests/Time/TimeTest.cpp
+++ b/unittests/Time/TimeTest.cpp
@@ -1,0 +1,165 @@
+#include "klee/Internal/System/Time.h"
+#include "gtest/gtest.h"
+#include "gtest/gtest-death-test.h"
+
+#include <cerrno>
+#include <sstream>
+
+
+int finished = 0;
+
+using namespace klee;
+
+
+TEST(TimeTest, TimingFunctions) {
+  auto t = time::getClockInfo();
+  ASSERT_STRNE(t.c_str(), "");
+
+  auto p0 = time::getWallTime();
+  auto p1 = time::getWallTime();
+  ASSERT_GT(p0, time::Point());
+  ASSERT_GT(p1, time::Point());
+  ASSERT_LE(p0, p1);
+
+  time::getUserTime();
+}
+
+
+TEST(TimeTest, TimeParserNewFormat) {
+  // valid
+  errno = 0;
+  auto s0 = time::Span("");
+  ASSERT_EQ(s0, time::Span());
+  ASSERT_EQ(errno, 0);
+
+  s0 = time::Span("3h10min");
+  ASSERT_EQ(s0, time::minutes(190));
+  s0 = time::Span("5min5min");
+  ASSERT_EQ(s0, time::seconds(600));
+  s0 = time::Span("3us");
+  ASSERT_EQ(s0, time::microseconds(3));
+  s0 = time::Span("1h1min1s1ms1us1ns");
+  ASSERT_EQ(s0, time::nanoseconds(3661001001001));
+  s0 = time::Span("1min1min");
+  ASSERT_EQ(s0, time::minutes(2));
+
+  // invalid
+  ASSERT_EXIT(time::Span("h"), ::testing::ExitedWithCode(1), "Illegal number format: h");
+  ASSERT_EXIT(time::Span("-5min"), ::testing::ExitedWithCode(1), "Illegal number format: -5min");
+  ASSERT_EXIT(time::Span("3.5h"), ::testing::ExitedWithCode(1), "Illegal number format: 3.5h");
+  ASSERT_EXIT(time::Span("3mi"), ::testing::ExitedWithCode(1), "Illegal number format: 3mi");
+}
+
+
+TEST(TimeTest, TimeParserOldFormat) {
+  // valid
+  errno = 0;
+
+  auto s0 = time::Span("20");
+  ASSERT_EQ(s0, time::seconds(20));
+  s0 = time::Span("3.5");
+  ASSERT_EQ(s0, time::milliseconds(3500));
+  s0 = time::Span("0.0");
+  ASSERT_EQ(s0, time::Span());
+  s0 = time::Span("0");
+  ASSERT_EQ(s0, time::Span());
+
+  ASSERT_EQ(errno, 0);
+
+  // invalid
+  ASSERT_EXIT(time::Span("-3.5"), ::testing::ExitedWithCode(1), "Illegal number format: -3.5");
+  ASSERT_EXIT(time::Span("NAN"), ::testing::ExitedWithCode(1), "Illegal number format: NAN");
+  ASSERT_EXIT(time::Span("INF"), ::testing::ExitedWithCode(1), "Illegal number format: INF");
+  ASSERT_EXIT(time::Span("foo"), ::testing::ExitedWithCode(1), "Illegal number format: foo");
+}
+
+
+TEST(TimeTest, TimeArithmeticAndComparisons) {
+  auto h   = time::hours(1);
+  auto min = time::minutes(1);
+  auto sec = time::seconds(1);
+  auto ms  = time::milliseconds(1);
+  auto us  = time::microseconds(1);
+  auto ns  = time::nanoseconds(1);
+
+  ASSERT_GT(h, min);
+  ASSERT_GT(min, sec);
+  ASSERT_GT(sec, ms);
+  ASSERT_GT(ms, us);
+  ASSERT_GT(us, ns);
+
+  ASSERT_LT(min, h);
+  ASSERT_LT(sec, min);
+  ASSERT_LT(ms, sec);
+  ASSERT_LT(us, ms);
+  ASSERT_LT(ns, us);
+
+  ASSERT_GE(h, min);
+  ASSERT_LE(min, h);
+
+  auto sec2 = time::seconds(1);
+  ASSERT_EQ(sec, sec2);
+  sec2 += time::nanoseconds(1);
+  ASSERT_LT(sec, sec2);
+
+  auto op0 = time::seconds(1);
+  auto op1 = op0 / 1000;
+  ASSERT_EQ(op1, ms);
+  op0 = time::nanoseconds(3);
+  op1 = op0 * 1000;
+  ASSERT_EQ(op1, 3*us);
+
+  op0 = (time::seconds(10) + time::minutes(1) - time::milliseconds(10000)) * 60;
+  ASSERT_EQ(op0, h);
+
+  auto p1 = time::getWallTime();
+  auto p2 = p1;
+  p1 += time::seconds(10);
+  p2 -= time::seconds(15);
+  ASSERT_EQ(p1 - p2, time::seconds(25));
+
+  auto s = time::minutes(3);
+  p1 = s + p2;
+  ASSERT_NE(p1, p2);
+  ASSERT_LT(p2, p1);
+  p1 = p1 - s;
+  ASSERT_EQ(p1, p2);
+
+  s = time::minutes(5);
+  s -= time::minutes(4);
+  ASSERT_EQ(s, time::seconds(60));
+}
+
+
+TEST(TimeTest, TimeConversions) {
+  auto t = time::Span("3h14min1s");
+  auto d = t.toSeconds();
+  ASSERT_EQ(d, 11641.0);
+
+  std::uint32_t h;
+  std::uint8_t m, s;
+  std::tie(h, m, s) = t.toHMS();
+  ASSERT_EQ(h, 3u);
+  ASSERT_EQ(m, 14u);
+  ASSERT_EQ(s, 1u);
+
+  ASSERT_TRUE((bool)t);
+  ASSERT_FALSE((bool)time::Span());
+
+  auto us = t.toMicroseconds();
+  ASSERT_EQ(us, 11641000000u);
+
+  t += time::microseconds(42);
+  auto v = (timeval)t;
+  ASSERT_EQ(v.tv_sec, 11641);
+  ASSERT_EQ(v.tv_usec, 42);
+
+  t = std::chrono::seconds(1);
+  ASSERT_EQ(t, time::seconds(1));
+  auto u = (std::chrono::steady_clock::duration)t;
+  ASSERT_EQ(u, std::chrono::seconds(1));
+
+  std::ostringstream os;
+  os << time::Span("2.5");
+  ASSERT_EQ(os.str(), "2.5s");
+}


### PR DESCRIPTION
This should not change the behaviour of KLEE and mimics the old API.

- functions moved from util into time namespace
- uses time points and time spans instead of "context-sensitive" double
- CLI time arguments now can have the form "3h5min8us"

Changed command line parameters:
- batch-time (double to string)
- istats-write-interval (double to string)
- max-instruction-time (double to string)
- max-solver-time (double to string)
- max-time (double to string)
- min-query-time-to-log (double to string)
- seed-time (double to string)
- stats-write-interval (double to string)
- uncovered-update-interval (double to string)
- added: log-timed-out-queries (replaces negative max-solver-time, default: on)

This PR closes #210, #207 and avoids ifdef hell as in #674.

I measured the performance before implementing that interface. In short:
- gettime/coarse: adv: fastest, disadv: software clock (resolution jiffies), linux-specific
- gettime/monotonic: adv: POSIX, fastest on Linux; disadv: slowest on OS X (by far)
- chrono/steady: adv: C++11, almost as fast as gettime/monotonic, implemented in this PR
- gettimeofday: adv: slightly faster than std::chrono on OS X, disadv: C-like API

I've introduced `time::Point` and `time::Span` classes as C++ got the defaults wrong as always (e.g. Duration is not 0 initialised).