### PR TITLE
StateMerging segfault fix

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2584,9 +2584,6 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 void Executor::updateStates(ExecutionState *current) {
   if (searcher) {
     searcher->update(current, addedStates, removedStates);
-    searcher->update(nullptr, continuedStates, pausedStates);
-    pausedStates.clear();
-    continuedStates.clear();
   }
   
   states.insert(addedStates.begin(), addedStates.end());
@@ -2607,6 +2604,12 @@ void Executor::updateStates(ExecutionState *current) {
     delete es;
   }
   removedStates.clear();
+
+  if (searcher) {
+    searcher->update(nullptr, continuedStates, pausedStates);
+    pausedStates.clear();
+    continuedStates.clear();
+  }
 }
 
 template <typename TypeIt>

--- a/test/Merging/state_termination.c
+++ b/test/Merging/state_termination.c
@@ -1,0 +1,21 @@
+// RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs  %t.bc 
+
+#include <klee/klee.h>
+
+int main(int argc, char** args){
+
+  int x;
+
+  char str[5];
+  klee_make_symbolic(str, sizeof(str), "str");
+  char *s = str;
+
+  klee_open_merge();
+  while(*s != 's')
+      s++;
+  klee_close_merge();
+
+  return 0;
+}


### PR DESCRIPTION
KLEE currently crashes on a specific edge case involving merging, as discussed in issue #985 

> Whenever a 'MergeHandler' object is deleted, it dumps the remaining (merged) states into the 'Executor::continuedStates' vector. 
> These states are then reintroduced to the searchers.
> But, in Executer::updateStates, the MergeHandler is deleted after the continuedStates are reintroduced, which results in the merged states being forgotten for one simulation step.
> This is fixed by reintroducing the continuedStates after the removal of states.

Also added the failing test case as regression test