### PR TITLE
minor cmake/build process cleanup

### DIFF
--- a/include/klee/Config/config.h.cmin
+++ b/include/klee/Config/config.h.cmin
@@ -22,9 +22,6 @@
 /* Define if mallinfo() is available on this platform. */
 #cmakedefine HAVE_MALLINFO @HAVE_MALLINFO@
 
-/* Define to 1 if you have the <malloc/malloc.h> header file. */
-#cmakedefine HAVE_MALLOC_MALLOC_H @HAVE_MALLOC_MALLOC_H@
-
 /* Define to 1 if you have the `malloc_zone_statistics' function. */
 #cmakedefine HAVE_MALLOC_ZONE_STATISTICS @HAVE_MALLOC_ZONE_STATISTICS@
 

--- a/lib/Module/CMakeLists.txt
+++ b/lib/Module/CMakeLists.txt
@@ -26,14 +26,11 @@ set(LLVM_COMPONENTS
   bitwriter
   codegen
   ipo
+  irreader
   linker
   support
 )
 
-if ("${LLVM_PACKAGE_VERSION}" VERSION_EQUAL "3.3" OR
-    "${LLVM_PACKAGE_VERSION}" VERSION_GREATER "3.3")
-  list(APPEND LLVM_COMPONENTS irreader)
-endif()
 klee_get_llvm_libs(LLVM_LIBS ${LLVM_COMPONENTS})
 target_link_libraries(kleeModule PUBLIC ${LLVM_LIBS})
 target_link_libraries(kleeModule PRIVATE

--- a/lib/Module/CMakeLists.txt
+++ b/lib/Module/CMakeLists.txt
@@ -38,9 +38,4 @@ klee_get_llvm_libs(LLVM_LIBS ${LLVM_COMPONENTS})
 target_link_libraries(kleeModule PUBLIC ${LLVM_LIBS})
 target_link_libraries(kleeModule PRIVATE
   kleeSupport
-  # FIXME:
-  # There is a circular dependency between `kleeModule` and `kleeCore`.
-  # `ModuleUtil.cpp` uses `klee::SpecialFunctionHandler` (in `kleeCore`) but
-  # `kleeCore` uses `kleeModule`.
-  kleeCore
 )

--- a/lib/Module/ModuleUtil.cpp
+++ b/lib/Module/ModuleUtil.cpp
@@ -12,7 +12,6 @@
 #include "klee/Config/Version.h"
 #include "klee/Internal/Support/Debug.h"
 #include "klee/Internal/Support/ErrorHandling.h"
-#include "../Core/SpecialFunctionHandler.h"
 
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"


### PR DESCRIPTION
This contains three tiny changes:

* get rid of `HAVE_MALLOC_MALLOC_H` in `config.h.cmin` (I forgot to do that in #919)
* #868 with ef90f1e219fec27a3d594158ae5f380a9e9a2f37 removed the dependency on SpecialFunctionHandler in `ModuleUtil.cpp`
* kleeModule always links against `irreader` (as support for LLVM < 3.4 was dropped)