### PR TITLE
lit: add (not-)asan/ubsan flags; klee: fix handling of failing external calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,6 +598,22 @@ else()
 endif()
 
 ################################################################################
+# Sanitizer support
+################################################################################
+message(STATUS "${CMAKE_CXX_FLAGS}")
+set(IS_ASAN_BUILD 0)
+set(IS_UBSAN_BUILD 0)
+string(REPLACE " " ";" _flags ${CMAKE_CXX_FLAGS})
+foreach(arg IN ITEMS ${_flags})
+  if (${arg} STREQUAL -fsanitize=address)
+    set(IS_ASAN_BUILD 1)
+  elseif (${arg} STREQUAL -fsanitize=undefined)
+    set(IS_UBSAN_BUILD 1)
+  endif()
+endforeach()
+unset(_flags)
+
+################################################################################
 # Generate `config.h`
 ################################################################################
 configure_file(${CMAKE_SOURCE_DIR}/include/klee/Config/config.h.cmin

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -189,3 +189,7 @@ for target in supported_targets:
     config.available_features.add(target)
   else:
     config.available_features.add('not-{}'.format(target))
+
+# Sanitizer
+config.available_features.add('{}asan'.format('' if config.have_asan else 'not-'))
+config.available_features.add('{}ubsan'.format('' if config.have_ubsan else 'not-'))

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -27,6 +27,8 @@ config.enable_posix_runtime = True if @ENABLE_POSIX_RUNTIME@ == 1 else False
 config.have_selinux = True if @HAVE_SELINUX@ == 1 else False
 config.enable_stp = True if @ENABLE_STP@ == 1 else False
 config.enable_z3 = True if @ENABLE_Z3@ == 1 else False
+config.have_asan = True if @IS_ASAN_BUILD@ == 1 else False
+config.have_ubsan = True if @IS_UBSAN_BUILD@ == 1 else False
 
 # Add sanitizer list
 config.environment['LSAN_OPTIONS'] = "suppressions=@KLEE_UTILS_DIR@/sanitizers/lsan.txt"

--- a/test/regression/2018-10-01-double-segfault.c
+++ b/test/regression/2018-10-01-double-segfault.c
@@ -1,0 +1,27 @@
+// REQUIRES: not-asan
+// RUN: %llvmgcc %s -emit-llvm -O0 -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -output-dir=%t.klee-out %t.bc 2>&1 | FileCheck %s
+// CHECK: failed external call: strdup
+// CHECK: failed external call: strdup
+
+// objective: check handling of more than one failing external call
+
+
+#include "klee/klee.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+int main(int argc, char * argv[]) {
+  bool b;
+  klee_make_symbolic(&b, sizeof(bool), "b");
+
+  char * s0;
+  if (b) {
+    s0 = strdup((char *) 0xdeadbeef);
+  } else {
+    s0 = strdup((void *) 0xdeafbee5);
+  }
+  (void) s0;
+}


### PR DESCRIPTION
Currently KLEE only handles the first segfault in external calls as it doesn't unblock SIGSEGV afterwards. This patch unblocks the signal and enables handling of multiple failing calls.

It also introduces asan/not-asan, ubsan/not-ubsan flags for lit as the new test case triggers the ASAN build in Travis.
