### PR TITLE
Ignore file that triggers non-deterministic coverage from codecov report

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,6 +17,7 @@ ignore:
   - "test/"
   - "unittests"
   - "**/test-utils"
+  - include/klee/Internal/ADT/ImmutableTree.h
 comment:
   layout: "header, diff, changes, uncovered, tree"
   behavior: default


### PR DESCRIPTION
A second attempt to fix the codecov reports...  Otherwise, I propose to disable that check, it's counterproductive right now as it shows PRs as failed in the GitHub dashboard.