### PR TITLE
tests: disable CompressedExprLogging on zlib-less systems

### DIFF
--- a/test/Feature/CompressedExprLogging.c
+++ b/test/Feature/CompressedExprLogging.c
@@ -1,3 +1,4 @@
+// REQUIRES: zlib
 // RUN: %llvmgcc %s -emit-llvm -g -O0 -c -o %t1.bc
 // We disable the cex-cache to eliminate nondeterminism across different
 // solvers, in particular when counting the number of queries in the last two

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -178,6 +178,9 @@ if config.enable_z3:
 else:
   config.available_features.add('not-z3')
 
+# Zlib
+config.available_features.add('zlib' if config.enable_zlib else 'not-zlib')
+
 # POSIX runtime feature
 if config.enable_posix_runtime:
   config.available_features.add('posix-runtime')

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -27,6 +27,7 @@ config.enable_posix_runtime = True if @ENABLE_POSIX_RUNTIME@ == 1 else False
 config.have_selinux = True if @HAVE_SELINUX@ == 1 else False
 config.enable_stp = True if @ENABLE_STP@ == 1 else False
 config.enable_z3 = True if @ENABLE_Z3@ == 1 else False
+config.enable_zlib = True if @HAVE_ZLIB_H@ == 1 else False
 config.have_asan = True if @IS_ASAN_BUILD@ == 1 else False
 config.have_ubsan = True if @IS_UBSAN_BUILD@ == 1 else False
 


### PR DESCRIPTION
... otherwise it fails.