### PR TITLE
Check for stack overflow in a tested program

### DIFF
--- a/test/Feature/StackOverflow.c
+++ b/test/Feature/StackOverflow.c
@@ -1,0 +1,16 @@
+// RUN: %llvmgcc -emit-llvm -g -c -o %t.bc %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out %t.bc > %t.output.log 2>&1
+// RUN: FileCheck -input-file=%t.output.log %s
+
+void recursive(unsigned nr){
+  if (nr == 0)
+    return;
+  recursive(nr-1);
+}
+
+int main() {
+  recursive(10000);
+  return 0;
+}
+// CHECK: Maximum stack size reached


### PR DESCRIPTION
Check if a state reaches the maximum number of stack frames allowed.
To be performant, the number of stack frames are checked.
In comparison, native execution checks the size of the stack.
Still, this is good enough to find possible stack overflows.

The limit can be changed with `-max-stack-frames`. The current
default is 8192 frames.