### PR TITLE
run VerifierPass after optimization and instrumentation

### DIFF
--- a/include/klee/Internal/Module/KModule.h
+++ b/include/klee/Internal/Module/KModule.h
@@ -143,6 +143,10 @@ namespace klee {
 
     /// Return an id for the given constant, creating a new one if necessary.
     unsigned getConstantID(llvm::Constant *c, KInstruction* ki);
+
+    /// Run passes that check if module is valid LLVM IR and if invariants
+    /// expected by KLEE's Executor hold.
+    void checkModule();
   };
 } // End klee namespace
 

--- a/include/klee/Internal/Support/ModuleUtil.h
+++ b/include/klee/Internal/Support/ModuleUtil.h
@@ -70,8 +70,6 @@ bool functionEscapes(const llvm::Function *f);
 bool loadFile(const std::string &libraryName, llvm::LLVMContext &context,
               std::vector<std::unique_ptr<llvm::Module>> &modules,
               std::string &errorMsg);
-
-void checkModule(llvm::Module *m);
 }
 
 #endif

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -522,6 +522,7 @@ Executor::setModule(std::vector<std::unique_ptr<llvm::Module>> &modules,
   preservedFunctions.push_back("memmove");
 
   kmodule->optimiseAndPrepare(opts, preservedFunctions);
+  kmodule->checkModule();
 
   // 4.) Manifest the module
   kmodule->manifest(interpreterHandler, StatsTracker::useStatistics());

--- a/lib/Module/ModuleUtil.cpp
+++ b/lib/Module/ModuleUtil.cpp
@@ -33,12 +33,10 @@
 #include "llvm/Support/SourceMgr.h"
 
 #if LLVM_VERSION_CODE < LLVM_VERSION(3, 5)
-#include "llvm/Analysis/Verifier.h"
 #include "llvm/Assembly/AssemblyAnnotationWriter.h"
 #include "llvm/Linker.h"
 #else
 #include "llvm/IR/AssemblyAnnotationWriter.h"
-#include "llvm/IR/Verifier.h"
 #include "llvm/Linker/Linker.h"
 #endif
 
@@ -598,10 +596,4 @@ std::unique_ptr<llvm::Module> module(ParseIR(Buffer.take(), Err, context));
   }
   modules.push_back(std::move(module));
   return true;
-}
-
-void klee::checkModule(llvm::Module *m) {
-  LegacyLLVMPassManagerTy pm;
-  pm.add(createVerifierPass());
-  pm.run(*m);
 }

--- a/lib/Module/Optimize.cpp
+++ b/lib/Module/Optimize.cpp
@@ -56,12 +56,6 @@
 
 using namespace llvm;
 
-// Don't verify at the end
-static cl::opt<bool>
-    DontVerify("disable-verify", cl::ReallyHidden,
-               cl::desc("Do not verify the module integrity (default=false)"),
-               cl::init(false), cl::cat(klee::ModuleCat));
-
 static cl::opt<bool>
     DisableInline("disable-inlining",
                   cl::desc("Do not run the inliner pass (default=false)"),
@@ -74,7 +68,7 @@ static cl::opt<bool> DisableInternalize(
 
 static cl::opt<bool> VerifyEach(
     "verify-each",
-    cl::desc("Verify intermediate results of all passes (default=false)"),
+    cl::desc("Verify intermediate results of all optimization passes (default=false)"),
     cl::init(false),
     cl::cat(klee::ModuleCat));
 
@@ -316,10 +310,6 @@ void Optimize(Module *M, llvm::ArrayRef<const char *> preservedFunctions) {
   addPass(Passes, createCFGSimplificationPass());
   addPass(Passes, createAggressiveDCEPass());
   addPass(Passes, createGlobalDCEPass());
-
-  // Make sure everything is still good.
-  if (!DontVerify)
-    Passes.add(createVerifierPass());
 
   // Run our queue of passes all at once now, efficiently.
   Passes.run(*M);


### PR DESCRIPTION
I noticed that there was an unused `checkModule()` method after the last refactoring in ModuleUtil. Right now, the `VerifierPass` is not run after all of KLEE's custom passes (to make sure that they do not introduce any invalid constructs) but only after the optimization passes. So in this PR, I move the method to `KModule` and insert the `InstructionOperandTypeCheckPass` (which was in previously in `optimiseAndPrepare`). Finally, `checkModule()` is called from `Executor` right after `optimiseAndPrepare()`.