### PR TITLE
fix Executor::initializeGlobals for aliases pointing to another alias

### DIFF
--- a/test/Feature/Alias.c
+++ b/test/Feature/Alias.c
@@ -10,6 +10,10 @@
 int b = 52;
 extern int a __attribute__((alias("b")));
 
+// alias for alias
+// NOTE: this does not have to be before foo is known
+extern int foo2() __attribute__((alias("foo")));
+
 // alias for function
 int __foo() { return 52; }
 extern int foo() __attribute__((alias("__foo")));
@@ -19,6 +23,7 @@ int *c = &a;
 int main() {
   assert(a == 52);
   assert(foo() == 52);
+  assert(foo2() == 52);
   assert(*c == 52);
 
   return 0;

--- a/test/regression/2018-10-28-alias-to-alias.leq36.ll
+++ b/test/regression/2018-10-28-alias-to-alias.leq36.ll
@@ -1,0 +1,21 @@
+; REQUIRES: lt-llvm-3.7
+; RUN: rm -rf %t.klee-out
+; RUN: llvm-as -f %s -o - | %klee --output-dir=%t.klee-out
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; @foo is not known yet
+@foo2 = alias i32 (...)* @foo
+@foo = alias bitcast (i32 ()* @__foo to i32 (...)*)
+
+define i32 @__foo() {
+entry:
+  ret i32 42
+}
+
+define i32 @main() {
+entry:
+  call i32 (...)* @foo()
+  call i32 (...)* @foo2()
+  ret i32 0
+}

--- a/test/regression/2018-10-28-alias-to-alias.leq37.ll
+++ b/test/regression/2018-10-28-alias-to-alias.leq37.ll
@@ -1,0 +1,23 @@
+; LLVM 3.7 no longer accepts '*' with a 'call'
+; REQUIRES: geq-llvm-3.7
+; REQUIRES: lt-llvm-3.8
+; RUN: rm -rf %t.klee-out
+; RUN: llvm-as -f %s -o - | %klee --output-dir=%t.klee-out
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; @foo is not known yet
+@foo2 = alias i32 (...)* @foo
+@foo = alias bitcast (i32 ()* @__foo to i32 (...)*)
+
+define i32 @__foo() {
+entry:
+  ret i32 42
+}
+
+define i32 @main() {
+entry:
+  call i32 (...) @foo()
+  call i32 (...) @foo2()
+  ret i32 0
+}

--- a/test/regression/2018-10-28-alias-to-alias.ll
+++ b/test/regression/2018-10-28-alias-to-alias.ll
@@ -1,0 +1,23 @@
+; LLVM 3.8 requires a type as the first argument to 'alias'
+; LLVM 3.7 no longer accepts '*' with a 'call'
+; REQUIRES: geq-llvm-3.8
+; RUN: rm -rf %t.klee-out
+; RUN: llvm-as -f %s -o - | %klee --output-dir=%t.klee-out
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; @foo is not known yet
+@foo2 = alias i32 (...), i32 (...)* @foo
+@foo = alias i32 (...), bitcast (i32 ()* @__foo to i32 (...)*)
+
+define i32 @__foo() {
+entry:
+  ret i32 42
+}
+
+define i32 @main() {
+entry:
+  call i32 (...) @foo()
+  call i32 (...) @foo2()
+  ret i32 0
+}


### PR DESCRIPTION
This fixes a segfault in `Executor` during `initializeGlobals` when coming across aliases that point to another alias that was not yet added to `globalAddresses`.

**Edit:** Some more information. Although I could reliably reproduce the segfault with LLVM 3.4 on my computer, it rarely occurs on TravisCI. Here is a case of LLVM 3.7 crashing (on TravisCI):
```
#0 0x1230478 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/tmp/klee_build37_O_ND_A_stp2.1.2_z34.4.1_klee_uclibc_v1.0.0/bin/klee+0x1230478)
#1 0x122eee1 SignalHandler(int) (/tmp/klee_build37_O_ND_A_stp2.1.2_z34.4.1_klee_uclibc_v1.0.0/bin/klee+0x122eee1)
#2 0x7faeb74d8390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
#3 0x5af485 klee::ref<klee::ConstantExpr>::inc() const /tmp/klee_src/include/klee/util/Ref.h:41:0
#4 0x5af485 klee::ref<klee::ConstantExpr>::ref(klee::ref<klee::ConstantExpr> const&) /tmp/klee_src/include/klee/util/Ref.h:59:0
#5 0x5af485 klee::Executor::evalConstant(llvm::Constant const*, klee::KInstruction const*) /tmp/klee_src/lib/Core/ExecutorUtil.cpp:58:0
#6 0x595127 klee::ref<klee::ConstantExpr>::ref(klee::ref<klee::ConstantExpr> const&) /tmp/klee_src/include/klee/util/Ref.h:58:0
#7 0x595127 std::pair<llvm::GlobalAlias*, klee::ref<klee::ConstantExpr> >::pair<llvm::GlobalAlias*, klee::ref<klee::ConstantExpr>, void>(llvm::GlobalAlias*&&, klee::ref<klee::ConstantExpr>&&) /usr/include/c++/5/bits/stl_pair.h:145:0
#8 0x595127 std::pair<std::decay_and_strip<llvm::GlobalAlias*>::type, std::decay_and_strip<klee::ref<klee::ConstantExpr> >::type> std::make_pair<llvm::GlobalAlias*, klee::ref<klee::ConstantExpr> >(llvm::GlobalAlias*&&, klee::ref<klee::ConstantExpr>&&) /usr/include/c++/5/bits/stl_pair.h:281:0
#9 0x595127 klee::Executor::initializeGlobals(klee::ExecutionState&) /tmp/klee_src/lib/Core/Executor.cpp:666:0
#10 0x5a6817 klee::Executor::runFunctionAsMain(llvm::Function*, int, char, char) /tmp/klee_src/lib/Core/Executor.cpp:3727:0
#11 0x56b9b3 main /tmp/klee_src/tools/klee/main.cpp:1391:0
#12 0x7faeb644f830 __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x20830)
#13 0x58a0d9 _start (/tmp/klee_build37_O_ND_A_stp2.1.2_z34.4.1_klee_uclibc_v1.0.0/bin/klee+0x58a0d9)
```
LLVM 3.4 with ASan on TravisCI:
```
ASAN:SIGSEGV
=================================================================
==10643==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x0000009d8727 bp 0x7ffd420b5270 sp 0x7ffd420b5260 T0)
	#0 0x9d8726 in klee::ref<klee::ConstantExpr>::inc() const /tmp/klee_src/include/klee/util/Ref.h:41
	#1 0x9ca89b in klee::ref<klee::ConstantExpr>::ref(klee::ref<klee::ConstantExpr> const&) (/tmp/klee_build34_NO_D_A_asan_stp2.1.2_klee_uclibc_v1.0.0/bin/klee+0x9ca89b)
	#2 0xa188e7 in klee::Executor::evalConstant(llvm::Constant const*, klee::KInstruction const*) /tmp/klee_src/lib/Core/ExecutorUtil.cpp:58
	#3 0x9a2f92 in klee::Executor::initializeGlobals(klee::ExecutionState&) /tmp/klee_src/lib/Core/Executor.cpp:666
	#4 0x9bdd16 in klee::Executor::runFunctionAsMain(llvm::Function*, int, char, char) /tmp/klee_src/lib/Core/Executor.cpp:3725
	#5 0x97cf3d in main /tmp/klee_src/tools/klee/main.cpp:1391
	#6 0x7f8a2075e82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
	#7 0x973e18 in _start (/tmp/klee_build34_NO_D_A_asan_stp2.1.2_klee_uclibc_v1.0.0/bin/klee+0x973e18)
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /tmp/klee_src/include/klee/util/Ref.h:41 klee::ref<klee::ConstantExpr>::inc() const
==10643==ABORTING
```
I have not yet seen this segfault with LLVM 5, 6 or 7 but have also not yet found a reason to believe that this is not possible or that something was changed inside LLVM that would reliably prevent such an issue from happening (such as sorting the list of GAs, such that there are no forward references during iteration), but maybe I have looked in the wrong places. It just means that my regression tests do not reliably trigger the issue.