### PR TITLE
 Various fixes for ktest-tool

### DIFF
--- a/scripts/build/build-travis.sh
+++ b/scripts/build/build-travis.sh
@@ -7,10 +7,14 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   brew install ccache
   set +e
-  brew install python@2
-  if [[ "X$?" != "X0" ]]; then
-     brew link --overwrite python@2
-  fi
+  brew upgrade python               # upgrade to Python 3
+  brew install python@2             # install Python 2 (OSX version outdated + pip missing)
+  brew link --overwrite python@2    # keg-only => link manually
+  rm -f /usr/local/bin/{python,pip} # re-link python/pip to Python 2
+  py2path=$(find /usr/local/Cellar/python@2/ -name "python" -type f | head -n 1)
+  pip2path=$(find /usr/local/Cellar/python@2/ -name "pip" -type f | head -n 1)
+  ln -s "${py2path}" /usr/local/bin/python
+  ln -s "${pip2path}" /usr/local/bin/pip
   set -e
   pip install lit==0.6.0
   export PATH="/usr/local/opt/ccache/libexec:$PATH"

--- a/test/regression/2014-09-13-debug-info.c
+++ b/test/regression/2014-09-13-debug-info.c
@@ -8,7 +8,7 @@
 // one with the prefered CEX. We verify this by using ktest-tool to dump the
 // values, and then checking the output.
 //
-// RUN: /bin/sh -c "ktest-tool --write-int %t.klee-out/*.ktest" | sort > %t.data-values
+// RUN: /bin/sh -c "ktest-tool %t.klee-out/*.ktest" | sort > %t.data-values
 // RUN: FileCheck < %t.data-values %s
 
 // CHECK: object 0: data: 0

--- a/test/regression/2014-09-13-debug-info.c
+++ b/test/regression/2014-09-13-debug-info.c
@@ -11,10 +11,10 @@
 // RUN: /bin/sh -c "ktest-tool %t.klee-out/*.ktest" | sort > %t.data-values
 // RUN: FileCheck < %t.data-values %s
 
-// CHECK: object 0: data: 0
-// CHECK: object 0: data: 17
-// CHECK: object 0: data: 32
-// CHECK: object 0: data: 99
+// CHECK: object 0: int : 0
+// CHECK: object 0: int : 17
+// CHECK: object 0: int : 32
+// CHECK: object 0: int : 99
 
 #include <klee/klee.h>
 

--- a/tools/ktest-tool/ktest-tool
+++ b/tools/ktest-tool/ktest-tool
@@ -12,7 +12,6 @@
 
 import binascii
 import io
-import os
 import string
 import struct
 import sys
@@ -32,11 +31,11 @@ class KTest:
         try:
             f = open(path, 'rb')
         except IOError:
-            print("ERROR: file %s not found" % path)
+            print('ERROR: file %s not found' % path)
             sys.exit(1)
 
         hdr = f.read(5)
-        if len(hdr) != 5 or (hdr != b'KTEST' and hdr != b"BOUT\n"):
+        if len(hdr) != 5 or (hdr != b'KTEST' and hdr != b'BOUT\n'):
             raise KTestError('unrecognized file')
         version, = struct.unpack('>i', f.read(4))
         if version > version_no:
@@ -117,24 +116,53 @@ class KTest:
 
 
 def main():
-    from optparse import OptionParser
-    op = OptionParser("usage: %prog [options] files")
-    op.add_option('', '--trim-zeros', dest='trimZeros', action='store_true',
-                  default=False,
-                  help='trim trailing zeros')
+    epilog = """
+        output description:
+          A .ktest file comprises a file header and a list of memory objects.
+          Each object holds concrete test data for a symbolic memory object.
+          As no type information is stored, ktest-tool outputs data in
+          different representations.
 
-    opts, args = op.parse_args()
-    if not args:
-        op.error("incorrect number of arguments")
+          ktest file header:
+            ktest file: path to ktest file
+            args: program arguments
+            num objects: number of memory objects
+          memory object:
+            name: object name
+            size: object size
+            data: concrete object data as Python byte string
+            hex: data as hex string
+            int: data as integer if size is 1, 2, 4, 8 bytes
+            uint: data as unsigned integer if size is 1, 2, 4, 8 bytes
+            text: data as ascii text, '.' for non-printable characters
 
-    for file in args:
+        example:
+          > ktest-tool klee-last/test000003.ktest
+          ktest file : 'klee-last/test000003.ktest'
+          args       : ['get_sign.bc']
+          num objects: 1
+          object 0: name: 'a'
+          object 0: size: 4
+          object 0: data: b'\\x00\\x00\\x00\\x80'
+          object 0: hex : 0x00000080
+          object 0: int : -2147483648
+          object 0: uint: 2147483648
+          object 0: text: ....
+    """
+
+    from argparse import ArgumentParser, RawDescriptionHelpFormatter
+    from textwrap import dedent
+
+    ap = ArgumentParser(prog='ktest-tool', formatter_class=RawDescriptionHelpFormatter, epilog=dedent(epilog))
+    ap.add_argument('--trim-zeros', help='trim trailing zeros', action='store_true')
+    ap.add_argument('files', help='a .ktest file', metavar='file', nargs='+')
+    args = ap.parse_args()
+
+    for file in args.files:
         ktest = KTest.fromfile(file)
-        fmt = '{:trimzeros}' if opts.trimZeros else '{}'
+        fmt = '{:trimzeros}' if args.trim_zeros else '{}'
         print(fmt.format(ktest), end='')
 
-        if file != args[-1]:
-            print()
 
-
-if __name__=='__main__':
+if __name__ == '__main__':
     main()

--- a/tools/ktest-tool/ktest-tool
+++ b/tools/ktest-tool/ktest-tool
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 # ===-- ktest-tool --------------------------------------------------------===##
 # 
@@ -9,25 +10,33 @@
 # 
 # ===----------------------------------------------------------------------===##
 
+import binascii
+import io
 import os
+import string
 import struct
 import sys
 
-version_no=3
+version_no = 3
+
 
 class KTestError(Exception):
     pass
 
+
 class KTest:
+    valid_chars = string.digits + string.ascii_letters + string.punctuation + ' '
+
     @staticmethod
     def fromfile(path):
-        if not os.path.exists(path):
-            print("ERROR: file %s not found" % (path))
+        try:
+            f = open(path, 'rb')
+        except IOError:
+            print("ERROR: file %s not found" % path)
             sys.exit(1)
-            
-        f = open(path,'rb')
+
         hdr = f.read(5)
-        if len(hdr)!=5 or (hdr!=b'KTEST' and hdr != b"BOUT\n"):
+        if len(hdr) != 5 or (hdr != b'KTEST' and hdr != b"BOUT\n"):
             raise KTestError('unrecognized file')
         version, = struct.unpack('>i', f.read(4))
         if version > version_no:
@@ -37,7 +46,7 @@ class KTest:
         for i in range(numArgs):
             size, = struct.unpack('>i', f.read(4))
             args.append(str(f.read(size).decode(encoding='ascii')))
-            
+
         if version >= 2:
             symArgvs, = struct.unpack('>i', f.read(4))
             symArgvLen, = struct.unpack('>i', f.read(4))
@@ -49,73 +58,83 @@ class KTest:
         objects = []
         for i in range(numObjects):
             size, = struct.unpack('>i', f.read(4))
-            name = f.read(size)
+            name = f.read(size).decode('utf-8')
             size, = struct.unpack('>i', f.read(4))
             bytes = f.read(size)
-            objects.append( (name,bytes) )
+            objects.append((name, bytes))
 
         # Create an instance
-        b = KTest(version, args, symArgvs, symArgvLen, objects)
-        # Augment with extra filename field
-        b.filename = path
+        b = KTest(version, path, args, symArgvs, symArgvLen, objects)
         return b
-    
-    def __init__(self, version, args, symArgvs, symArgvLen, objects):
+
+    def __init__(self, version, path, args, symArgvs, symArgvLen, objects):
         self.version = version
+        self.path = path
         self.symArgvs = symArgvs
         self.symArgvLen = symArgvLen
         self.args = args
         self.objects = objects
 
-        # add a field that represents the name of the program used to
-        # generate this .ktest file:
-        program_full_path = self.args[0]
-        program_name = os.path.basename(program_full_path)
-        # sometimes program names end in .bc, so strip them
-        if program_name.endswith('.bc'):
-          program_name = program_name[:-3]
-        self.programName = program_name
-        
-def trimZeros(str):
-    for i in range(len(str))[::-1]:
-        if str[i] != '\x00':
-            return str[:i+1]
-    return ''
-    
-def main(args):
+    def __format__(self, format_spec):
+        sio = io.StringIO()
+        width = str(len(str(max(1, len(self.objects) - 1))))
+
+        # print ktest info
+        print('ktest file : %r' % self.path, file=sio)
+        print('args       : %r' % self.args, file=sio)
+        print('num objects: %r' % len(self.objects), file=sio)
+
+        # format strings
+        fmt = dict()
+        fmt['name'] = "object {0:" + width + "d}: name: '{1}'"
+        fmt['size'] = "object {0:" + width + "d}: size: {1}"
+        fmt['int' ] = "object {0:" + width + "d}: int : {1}"
+        fmt['uint'] = "object {0:" + width + "d}: uint: {1}"
+        fmt['data'] = "object {0:" + width + "d}: data: {1}"
+        fmt['hex' ] = "object {0:" + width + "d}: hex : 0x{1}"
+        fmt['text'] = "object {0:" + width + "d}: text: {1}"
+
+        # print objects
+        for i, (name, data) in enumerate(self.objects):
+            def p(key, arg): print(fmt[key].format(i, arg), file=sio)
+
+            blob = data.rstrip(b'\x00') if format_spec.endswith('trimzeros') else data
+            txt = ''.join(c if c in self.valid_chars else '.' for c in blob.decode('ascii', errors='replace').replace('�', '.'))
+            size = len(data)
+
+            p('name', name)
+            p('size', size)
+            p('data', blob)
+            p('hex', binascii.hexlify(blob).decode('ascii'))
+            for n, m in [(1, 'b'), (2, 'h'), (4, 'i'), (8, 'q')]:
+                if size == n:
+                    p('int', struct.unpack(m, data)[0])
+                    p('uint', struct.unpack(m.upper(), data)[0])
+                    break
+            p('text', txt)
+
+        return sio.getvalue()
+
+
+def main():
     from optparse import OptionParser
     op = OptionParser("usage: %prog [options] files")
-    op.add_option('','--trim-zeros', dest='trimZeros', action='store_true', 
+    op.add_option('', '--trim-zeros', dest='trimZeros', action='store_true',
                   default=False,
                   help='trim trailing zeros')
-    op.add_option('','--write-ints', dest='writeInts', action='store_true',
-                  default=False,
-                  help='convert 4-byte sequences to integers')
-    
-    opts,args = op.parse_args()
+
+    opts, args = op.parse_args()
     if not args:
         op.error("incorrect number of arguments")
 
     for file in args:
-        b = KTest.fromfile(file)
-        pos = 0
-        print('ktest file : %r' % file)
-        print('args       : %r' % b.args)
-        print('num objects: %r' % len(b.objects))
-        for i,(name,data) in enumerate(b.objects):
-            if opts.trimZeros:
-                str = trimZeros(data)
-            else:
-                str = data
+        ktest = KTest.fromfile(file)
+        fmt = '{:trimzeros}' if opts.trimZeros else '{}'
+        print(fmt.format(ktest), end='')
 
-            print('object %4d: name: %r' % (i, name))
-            print('object %4d: size: %r' % (i, len(data)))
-            if opts.writeInts and len(data) == 4: 
-                print('object %4d: data: %r' % (i, struct.unpack('i',str)[0]))
-            else:
-                print('object %4d: data: %r' % (i, str))
         if file != args[-1]:
             print()
 
+
 if __name__=='__main__':
-    main(sys.argv)
+    main()


### PR DESCRIPTION
* switch to Python 3
* add file encoding
* some PEP8 reformatting
* fix TOCTOU for open
* replace trimZeros() with rstrip
* remove unused pos/args variables
* remove --write-ints (print by default)
* remove programName section (unused)
* added/modified output rows
  - "data:" now shows the Python representation (for use in scripts; basically just a 'b' in front of the old output)
  - "hex :" shows the hex representation
  - "text:" shows ASCII, all out-of-range/non-printable characters are replaced by a dot
  - "int :"/"uint:" print (un/signed) 8/16/32/64 bit integers
* reduce width for object counter to needed minimum instead of 4
* refactor printing into function

Fixes #1011.
Closes #540.