### PR TITLE
actually set -O0 in concrete tests

### DIFF
--- a/test/Concrete/CMakeLists.txt
+++ b/test/Concrete/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 #===------------------------------------------------------------------------===#
 if (${LLVM_VERSION_MAJOR} GREATER 4)
-  set(OZERO_OPT "-Xclang -disable-O0-optnone")
+  set(OZERO_OPT "-O0 -Xclang -disable-O0-optnone")
 else()
   set(OZERO_OPT "-O0")
 endif()

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -21,6 +21,8 @@ config.llvmgxx = "@LLVMCXX@"
 config.cc = "@NATIVE_CC@"
 config.cxx = "@NATIVE_CXX@"
 
+# NOTE: any changes to compiler flags also have to be applied to
+#       test/Concrete/CMakeLists.txt
 config.O0opt = "-O0"
 if @LLVM_VERSION_MAJOR@ >= 5:
   config.O0opt += " -Xclang -disable-O0-optnone"


### PR DESCRIPTION
I just noticed a mistake I made in #1009: `-O0` has to be used in conjunction with, not instead of `-Xclang -disable-O0-optnone`. Sorry.