### PR TITLE
Enable C++14 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,9 +291,9 @@ endif()
 # C++ version
 ################################################################################
 if ("${CMAKE_VERSION}" VERSION_LESS "3.1")
-  add_global_cxx_flag("-std=c++11" REQUIRED)
+  add_global_cxx_flag("-std=c++14" REQUIRED)
 else ()
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 14)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif ()
 


### PR DESCRIPTION
C++14 has a couple of nice features (https://en.wikipedia.org/wiki/C%2B%2B14).
The minimal compiler requirements are:
* clang 3.4
* gcc 4.9 for all the features we need; gcc 5 for all features
  (gcc 5.4 is the default compiler on Xenial Ubuntu 16.04)

Make C++14 the minimal requirement.