### PR TITLE
make AssignmentLessThan::operator() const-invocable

### DIFF
--- a/lib/Solver/CexCachingSolver.cpp
+++ b/lib/Solver/CexCachingSolver.cpp
@@ -51,7 +51,7 @@ namespace {
 typedef std::set< ref<Expr> > KeyType;
 
 struct AssignmentLessThan {
-  bool operator()(const Assignment *a, const Assignment *b) {
+  bool operator()(const Assignment *a, const Assignment *b) const {
     return a->bindings < b->bindings;
   }
 };


### PR DESCRIPTION
This patch fixes the following error when compiling KLEE with GCC 8.2.1 and C++17 enabled:
```
In file included from /usr/include/c++/8/set:60,
				 from ../include/klee/Expr.h:23,
				 from ../include/klee/Solver.h:13,
				 from ../lib/Solver/CexCachingSolver.cpp:10:
/usr/include/c++/8/bits/stl_tree.h: In instantiation of ‘class std::_Rb_tree<klee::Assignment*, klee::Assignment*, std::_Identity<klee::Assignment*>, AssignmentLessThan, std::allocator<klee::Assignment*> >’:
/usr/include/c++/8/bits/stl_set.h:133:17:   required from ‘class std::set<klee::Assignment*, AssignmentLessThan>’
../lib/Solver/CexCachingSolver.cpp:67:23:   required from here
/usr/include/c++/8/bits/stl_tree.h:457:21: error: static assertion failed: comparison object must be invocable as const
	   static_assert(is_invocable_v<const _Compare&, const _Key&, const _Key&>,
					 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```