### PR TITLE
More work on option categories

### DIFF
--- a/include/klee/SolverCmdLine.h
+++ b/include/klee/SolverCmdLine.h
@@ -82,12 +82,11 @@ extern llvm::cl::opt<klee::MetaSMTBackendType> MetaSMTBackend;
 
 class KCommandLine {
 public:
+  /// Hide all options in the specified category
+  static void HideOptions(llvm::cl::OptionCategory &Category);
+
   /// Hide all options except the ones in the specified category
   static void HideUnrelatedOptions(llvm::cl::OptionCategory &Category);
-
-  /// Hide all options except the ones in the specified categories
-  static void HideUnrelatedOptions(
-      llvm::ArrayRef<const llvm::cl::OptionCategory *> Categories);
 };
 } // namespace klee
 

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -112,6 +112,22 @@ cl::opt<bool> UseAssignmentValidatingSolver(
     cl::desc("Debug the correctness of generated assignments (default=false)"),
     cl::cat(SolvingCat));
 
+
+void KCommandLine::HideOptions(llvm::cl::OptionCategory &Category) {
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+  StringMap<cl::Option *> &map = cl::getRegisteredOptions();
+#else
+  StringMap<cl::Option *> map;
+  cl::getRegisteredOptions(map);
+#endif
+
+  for (auto &elem : map) {
+    if (elem.second->Category == &Category) {
+      elem.second->setHiddenFlag(cl::Hidden);
+    }
+  }
+}
+
 void KCommandLine::HideUnrelatedOptions(cl::OptionCategory &Category) {
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
   StringMap<cl::Option *> &map = cl::getRegisteredOptions();
@@ -125,14 +141,6 @@ void KCommandLine::HideUnrelatedOptions(cl::OptionCategory &Category) {
       i->second->setHiddenFlag(cl::Hidden);
     }
   }
-}
-
-void KCommandLine::HideUnrelatedOptions(
-    ArrayRef<const cl::OptionCategory *> Categories) {
-  for (ArrayRef<const cl::OptionCategory *>::iterator i = Categories.begin(),
-                                                      e = Categories.end();
-       i != e; i++)
-    HideUnrelatedOptions(*i);
 }
 
 #ifdef ENABLE_METASMT

--- a/lib/Expr/ExprVisitor.cpp
+++ b/lib/Expr/ExprVisitor.cpp
@@ -7,16 +7,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "klee/Expr.h"
 #include "klee/util/ExprVisitor.h"
 
+#include "klee/Expr.h"
 #include "llvm/Support/CommandLine.h"
 
 namespace {
-  llvm::cl::opt<bool>
-  UseVisitorHash("use-visitor-hash", 
-                 llvm::cl::desc("Use hash-consing during expr visitation."),
-                 llvm::cl::init(true));
+llvm::cl::opt<bool> UseVisitorHash(
+    "use-visitor-hash",
+    llvm::cl::desc(
+        "Use hash-consing during expression visitation (default=true)"),
+    llvm::cl::init(true), llvm::cl::cat(klee::ExprCat));
 }
 
 using namespace klee;

--- a/lib/Support/ErrorHandling.cpp
+++ b/lib/Support/ErrorHandling.cpp
@@ -32,11 +32,13 @@ static const char *errorPrefix = "ERROR";
 static const char *notePrefix = "NOTE";
 
 namespace {
+cl::OptionCategory MiscCat("Miscellaneous options", "");
 cl::opt<bool> WarningsOnlyToFile(
     "warnings-only-to-file", cl::init(false),
     cl::desc("All warnings will be written to warnings.txt only.  If disabled, "
-             "they are also written on screen."));
-}
+             "they are also written on screen."),
+    cl::cat(MiscCat));
+} // namespace
 
 static bool shouldSetColor(const char *pfx, const char *msg,
                            const char *prefixToSearchFor) {

--- a/tools/kleaver/main.cpp
+++ b/tools/kleaver/main.cpp
@@ -394,6 +394,9 @@ static bool printInputAsSMTLIBv2(const char *Filename,
 }
 
 int main(int argc, char **argv) {
+
+  KCommandLine::HideOptions(llvm::cl::GeneralCategory);
+
   bool success = true;
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 9)


### PR DESCRIPTION
With this PR, Kleaver now has a clean help menu, w/o the irrelevant LLVM options.   This cuts the number of lines of `--help` almost in half.