### PR TITLE
Renamed --use-cache to --use-branch-cache

### DIFF
--- a/include/klee/SolverCmdLine.h
+++ b/include/klee/SolverCmdLine.h
@@ -26,7 +26,7 @@ extern llvm::cl::opt<bool> UseFastCexSolver;
 
 extern llvm::cl::opt<bool> UseCexCache;
 
-extern llvm::cl::opt<bool> UseCache;
+extern llvm::cl::opt<bool> UseBranchCache;
 
 extern llvm::cl::opt<bool> UseIndependentSolver;
 

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -43,12 +43,12 @@ cl::opt<bool> UseFastCexSolver(
     cl::cat(SolvingCat));
 
 cl::opt<bool> UseCexCache("use-cex-cache", cl::init(true),
-                          cl::desc("Use counterexample caching (default=true)"),
+                          cl::desc("Use the counterexample cache (default=true)"),
                           cl::cat(SolvingCat));
 
-cl::opt<bool> UseCache("use-cache", cl::init(true),
-                       cl::desc("Use validity caching (default=true)"),
-                       cl::cat(SolvingCat));
+cl::opt<bool> UseBranchCache("use-branch-cache", cl::init(true),
+                             cl::desc("Use the branch cache (default=true)"),
+                             cl::cat(SolvingCat));
 
 cl::opt<bool>
     UseIndependentSolver("use-independent-solver", cl::init(true),

--- a/lib/Basic/ConstructSolverChain.cpp
+++ b/lib/Basic/ConstructSolverChain.cpp
@@ -47,7 +47,7 @@ Solver *constructSolverChain(Solver *coreSolver,
   if (UseCexCache)
     solver = createCexCachingSolver(solver);
 
-  if (UseCache)
+  if (UseBranchCache)
     solver = createCachingSolver(solver);
 
   if (UseIndependentSolver)


### PR DESCRIPTION
@MartinNowack based on your suggestion, I renamed `--use-cache`.  As mentioned before, I'd like to go with `--use-branch-cache` to be in sync with the CAV'13 paper, which right now provides the best overview of KLEE's caching architecture.