### PR TITLE
Fix klee call optimisation

### DIFF
--- a/lib/Module/CMakeLists.txt
+++ b/lib/Module/CMakeLists.txt
@@ -16,6 +16,7 @@ set(KLEE_MODULE_COMPONENT_SRCS
   LowerSwitch.cpp
   ModuleUtil.cpp
   Optimize.cpp
+  OptNone.cpp
   PhiCleaner.cpp
   RaiseAsm.cpp
   Scalarizer.cpp

--- a/lib/Module/OptNone.cpp
+++ b/lib/Module/OptNone.cpp
@@ -1,0 +1,59 @@
+//===-- OptNone.cpp -------------------------------------------------------===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Passes.h"
+
+#include "klee/Config/Version.h"
+
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/Module.h"
+
+namespace klee {
+
+char OptNonePass::ID;
+
+bool OptNonePass::runOnModule(llvm::Module &M) {
+  // Find list of functions that start with `klee_`
+  // and mark all functions that contain such call or invoke as optnone
+  llvm::SmallPtrSet<llvm::Function *,16> CallingFunctions;
+  for (auto &F : M) {
+    if (!F.hasName() || !F.getName().startswith("klee_"))
+      continue;
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
+    for (auto *U : F.users()) {
+      // skip non-calls and non-invokes
+      if (!llvm::isa<llvm::CallInst>(U) && !llvm::isa<llvm::InvokeInst>(U))
+        continue;
+      auto *Inst = llvm::cast<llvm::Instruction>(U);
+      CallingFunctions.insert(Inst->getParent()->getParent());
+    }
+#else
+    for (auto i = F.use_begin(), e = F.use_end(); i != e; ++i) {
+      if (auto Inst = llvm::dyn_cast<llvm::Instruction>(*i)) {
+        CallingFunctions.insert(Inst->getParent()->getParent());
+      }
+    }
+#endif
+  }
+
+  bool changed = false;
+  for (auto F : CallingFunctions) {
+    // Skip if already annotated
+    if (F->hasFnAttribute(llvm::Attribute::OptimizeNone))
+      continue;
+    F->addFnAttr(llvm::Attribute::OptimizeNone);
+    F->addFnAttr(llvm::Attribute::NoInline);
+    changed = true;
+  }
+
+  return changed;
+}
+} // namespace klee

--- a/lib/Module/Passes.h
+++ b/lib/Module/Passes.h
@@ -185,6 +185,14 @@ public:
   bool runOnModule(llvm::Module &M) override;
 };
 #endif
+
+/// Instruments every function that contains a KLEE function call as nonopt
+class OptNonePass : public llvm::ModulePass {
+public:
+  static char ID;
+  OptNonePass() : llvm::ModulePass(ID) {}
+  bool runOnModule(llvm::Module &M) override;
+};
 } // namespace klee
 
 #endif

--- a/test/Feature/srem.c
+++ b/test/Feature/srem.c
@@ -1,6 +1,9 @@
 // RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out -use-cex-cache=1 %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --klee-call-optimisation=false %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --klee-call-optimisation=false --optimize %t.bc 2>&1 | FileCheck %s
+
 #include <stdio.h>
 #include <assert.h>
 

--- a/test/Feature/srem.c
+++ b/test/Feature/srem.c
@@ -1,8 +1,6 @@
 // RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out -use-cex-cache=1 %t.bc
-// RUN: grep "KLEE: done: explored paths = 5" %t.klee-out/info
-// RUN: grep "KLEE: done: generated tests = 4" %t.klee-out/info
+// RUN: %klee --output-dir=%t.klee-out -use-cex-cache=1 %t.bc 2>&1 | FileCheck %s
 #include <stdio.h>
 #include <assert.h>
 
@@ -15,7 +13,8 @@ int main(int argc, char** argv)
     // Test cases divisor is positive or negative
     if (y >= 0) {
       if (y < 2) {
-        // Two test cases generated taking this path, one for y == 0 and y ==1
+        // Two test cases generated taking this path, one for y == 0 and y == 1
+        // CHECK: srem.c:[[@LINE+1]]: divide by zero
         assert(1 % y == 0);
       } else {
         assert(1 % y == 1);
@@ -28,6 +27,14 @@ int main(int argc, char** argv)
       }
     }
 
+    // should fail for y == 0, succeed for all others
+    // BUT: no new testcase is generated as y = 0 already provoked the first assert to fail
     assert(0 % y == 0);
+
+    // should fail for y == 0 and y == +/-1, but succeed for all others
+    // generates one testcase for either y == 1 or y == -1
+    // CHECK: srem.c:[[@LINE+1]]: ASSERTION FAIL
     assert(-1 % y == -1);
+
+    // CHECK: KLEE: done: completed paths = 5
 }


### PR DESCRIPTION
This is part of fixing #1008. It addresses a more general problem: KLEE's function calls are intented to annotate specific variables or parts of the code. But, we use `CFGSimplifierPass` that always runs after a module has been built even with optimisation disabled.
With newer LLVM versions, compiler optimisation got much better. The problem is that function calls (used as annotations) are hoisted and moved away from the  actual code position they should have been applied to in the first place. This leads to a couple of issues:

* less instances of a function call as they get optimised away (#1008)
* missing branch constraints as functions are called prematurely (#920 )

This patch works around this issue by disabling optimisation (`optnone`) on a function level.
It adds an additional pass that disables optimisations only of functions that contain a `klee_`-function calls.

This should be in general less of a performance issue as there are typically not that many `klee_` calls (`klee_make_symbolic`, `klee_assert`, ...).  But, there might be a performance impact with automatically injected calls - calls to check for overflow and div by zero. We can avoid this issue by moving the check from the intrinsics library and make it part of the executor. Anyway, the current implementation already reduces the number of necessary check calls to a minimum.

This fixes #1008, fixes #920 and closes #1007 .
