### PR TITLE
Fix representation of ReadExpr of equivalent arrays

### DIFF
--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -533,9 +533,9 @@ unsigned Array::computeHash() {
 ref<Expr> ReadExpr::create(const UpdateList &ul, ref<Expr> index) {
   // rollback update nodes if possible
 
-  // Iterate throught the update list from the most recent to the
-  // least reasent to find a potential written value for a concrete index;
-  // stop, if an update with symbolic has been found as we don't know which
+  // Iterate through the update list from the most recent to the
+  // least recent to find a potential written value for a concrete index;
+  // stop if an update with symbolic has been found as we don't know which
   // array element has been updated
   const UpdateNode *un = ul.head;
   bool updateListHasSymbolicWrites = false;

--- a/test/Expr/ReadExprConsistency.c
+++ b/test/Expr/ReadExprConsistency.c
@@ -1,0 +1,39 @@
+// RUN: %clang %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error %t.bc 2>%t.log
+// RUN: cat %t.log | FileCheck %s
+
+#include <assert.h>
+
+/*
+This tests checks ensures that only relevant updates are present when doing
+concrete reads. If they are not, there can be situations where ReadExpr are
+in inconcistent state and depend on ordering of other operations.
+
+See
+https://github.com/klee/klee/issues/921
+https://github.com/klee/klee/pull/1061
+*/
+
+void klee_print_expr(const char*, char);
+int main() {
+	char  arr[3];
+  char symbolic;
+  klee_make_symbolic(&symbolic, sizeof(symbolic), "symbolic");
+  klee_assume(symbolic >= 0 & symbolic < 3); 
+  klee_make_symbolic(arr, sizeof(arr), "arr");
+  
+  
+  char a = arr[2];  // (ReadExpr 2 arr)
+  //CHECK: arr[2]:(Read w8 2 arr)
+  klee_print_expr("arr[2]", arr[2]);
+  arr[1] = 0;
+  char b = arr[symbolic];  // (ReadExpr symbolic [1=0]@arr)
+  //CHECK: arr[2]:(Read w8 2 arr)
+  //CHECK-NOT: arr[2]:(Read w8 2 [1=0]@arr)
+  klee_print_expr("arr[2]", arr[2]);
+  
+  if(a == b) printf("Equal!\n");
+  else printf("Not Equal!\n");
+  return 0;
+}


### PR DESCRIPTION
ObjectStates can be shared between multiple states.
A read expression of a symbolic object can be represented differently
depending on previous read expression on the same object.

If the read expression uses a symbolic index, all pending updates
will become entries in the update list of the object state.
If the same object state is read again, with a concrete index,
the latest update list item will be referenced, even though it might
contain more recent but non-essential updates.

If, instead, a concrete read will be executed first, it does not contain
the non-essential updates.

For both executions, the ReadExpr with a constant index will have two
different representations, which is not intented.

This patch makes sure, we do not include more recent, non-essential
updates for concrete reads.

Fixes #921