### PR TITLE
Utilise newer LLVM debug information infrastructure

### DIFF
--- a/include/klee/Internal/Module/InstructionInfoTable.h
+++ b/include/klee/Internal/Module/InstructionInfoTable.h
@@ -10,9 +10,10 @@
 #ifndef KLEE_LIB_INSTRUCTIONINFOTABLE_H
 #define KLEE_LIB_INSTRUCTIONINFOTABLE_H
 
-#include <map>
+#include <memory>
 #include <string>
-#include <set>
+#include <unordered_map>
+#include <vector>
 
 namespace llvm {
   class Function;
@@ -27,44 +28,48 @@ namespace klee {
     unsigned id;
     const std::string &file;
     unsigned line;
+    unsigned column;
     unsigned assemblyLine;
 
   public:
-    InstructionInfo(unsigned _id,
-                    const std::string &_file,
-                    unsigned _line,
-                    unsigned _assemblyLine)
-      : id(_id), 
-        file(_file),
-        line(_line),
-        assemblyLine(_assemblyLine) {
-    }
+    InstructionInfo(unsigned _id, const std::string &_file, unsigned _line,
+                    unsigned _column, unsigned _assemblyLine)
+        : id(_id), file(_file), line(_line), column(_column),
+          assemblyLine(_assemblyLine) {}
+  };
+
+  /* Stores debug information for a KInstruction */
+  struct FunctionInfo {
+    unsigned id;
+    const std::string &file;
+    unsigned line;
+    uint64_t assemblyLine;
+
+  public:
+    FunctionInfo(unsigned _id, const std::string &_file, unsigned _line,
+                 uint64_t _assemblyLine)
+        : id(_id), file(_file), line(_line), assemblyLine(_assemblyLine) {}
+
+    FunctionInfo(const FunctionInfo &) = delete;
+    FunctionInfo &operator=(FunctionInfo const &) = delete;
+
+    FunctionInfo(FunctionInfo &&) = default;
   };
 
   class InstructionInfoTable {
-    struct ltstr { 
-      bool operator()(const std::string *a, const std::string *b) const {
-        return *a<*b;
-      }
-    };
-
-    std::string dummyString;
-    InstructionInfo dummyInfo;
-    std::map<const llvm::Instruction*, InstructionInfo> infos;
-    std::set<const std::string *, ltstr> internedStrings;
-
-  private:
-    const std::string *internString(std::string s);
-    bool getInstructionDebugInfo(const llvm::Instruction *I,
-                                 const std::string *&File, unsigned &Line);
+    std::unordered_map<const llvm::Instruction *,
+                       std::unique_ptr<InstructionInfo>>
+        infos;
+    std::unordered_map<const llvm::Function *, std::unique_ptr<FunctionInfo>>
+        functionInfos;
+    std::vector<std::unique_ptr<std::string>> internedStrings;
 
   public:
-    InstructionInfoTable(llvm::Module *m);
-    ~InstructionInfoTable();
+    InstructionInfoTable(const llvm::Module &m);
 
     unsigned getMaxID() const;
-    const InstructionInfo &getInfo(const llvm::Instruction*) const;
-    const InstructionInfo &getFunctionInfo(const llvm::Function*) const;
+    const InstructionInfo &getInfo(const llvm::Instruction &) const;
+    const FunctionInfo &getFunctionInfo(const llvm::Function &) const;
   };
 
 }

--- a/lib/Core/CallPathManager.h
+++ b/lib/Core/CallPathManager.h
@@ -13,6 +13,7 @@
 #include "klee/Statistics.h"
 
 #include <map>
+#include <memory>
 #include <vector>
 
 namespace llvm {
@@ -31,20 +32,23 @@ namespace klee {
     CallSiteInfo() : count(0) {}
   };
 
-  typedef std::map<llvm::Instruction*,
-                   std::map<llvm::Function*, CallSiteInfo> > CallSiteSummaryTable;    
-  
+  typedef std::map<const llvm::Instruction *,
+                   std::map<const llvm::Function *, CallSiteInfo>>
+      CallSiteSummaryTable;
+
   class CallPathNode {
     friend class CallPathManager;
 
   public:
-    typedef std::map<std::pair<llvm::Instruction*, 
-                               llvm::Function*>, CallPathNode*> children_ty;
+    typedef std::map<
+        std::pair<const llvm::Instruction *, const llvm::Function *>,
+        CallPathNode *>
+        children_ty;
 
     // form list of (callSite,function) path
     CallPathNode *parent;
-    llvm::Instruction *callSite;
-    llvm::Function *function;
+    const llvm::Instruction *callSite;
+    const llvm::Function *function;
     children_ty children;
 
     StatisticRecord statistics;
@@ -52,31 +56,30 @@ namespace klee {
     unsigned count;
 
   public:
-    CallPathNode(CallPathNode *parent, 
-                 llvm::Instruction *callSite,
-                 llvm::Function *function);
+    CallPathNode(CallPathNode *parent, const llvm::Instruction *callSite,
+                 const llvm::Function *function);
 
     void print();
   };
 
   class CallPathManager {
     CallPathNode root;
-    std::vector<CallPathNode*> paths;
+    std::vector<std::unique_ptr<CallPathNode>> paths;
 
   private:
-    CallPathNode *computeCallPath(CallPathNode *parent, 
-                                  llvm::Instruction *callSite,
-                                  llvm::Function *f);
-    
+    CallPathNode *computeCallPath(CallPathNode *parent,
+                                  const llvm::Instruction *callSite,
+                                  const llvm::Function *f);
+
   public:
     CallPathManager();
-    ~CallPathManager();
+    ~CallPathManager() = default;
 
     void getSummaryStatistics(CallSiteSummaryTable &result);
-    
-    CallPathNode *getCallPath(CallPathNode *parent, 
-                              llvm::Instruction *callSite,
-                              llvm::Function *f);
+
+    CallPathNode *getCallPath(CallPathNode *parent,
+                              const llvm::Instruction *callSite,
+                              const llvm::Function *f);
   };
 }
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -597,7 +597,7 @@ void Executor::initializeGlobalObject(ExecutionState &state, ObjectState *os,
     for (unsigned i=0, e=cds->getNumElements(); i != e; ++i)
       initializeGlobalObject(state, os, cds->getElementAsConstant(i),
                              offset + i*elementSize);
-  } else if (!isa<UndefValue>(c)) {
+  } else if (!isa<UndefValue>(c) && !isa<MetadataAsValue>(c)) {
     unsigned StoreBits = targetData->getTypeStoreSizeInBits(c->getType());
     ref<ConstantExpr> C = evalConstant(c);
 
@@ -1329,6 +1329,8 @@ void Executor::executeCall(ExecutionState &state,
                            Function *f,
                            std::vector< ref<Expr> > &arguments) {
   Instruction *i = ki->inst;
+  if (i && isa<DbgInfoIntrinsic>(i))
+    return;
   if (f && f->isDeclaration()) {
     switch(f->getIntrinsicID()) {
     case Intrinsic::not_intrinsic:
@@ -1909,6 +1911,9 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
   case Instruction::Invoke:
   case Instruction::Call: {
+    // Ignore debug intrinsic calls
+    if (isa<DbgInfoIntrinsic>(i))
+      break;
     CallSite cs(i);
 
     unsigned numArgs = cs.arg_size();

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1587,11 +1587,6 @@ Function* Executor::getTargetFunction(Value *calledVal, ExecutionState &state) {
   }
 }
 
-/// TODO remove?
-static bool isDebugIntrinsic(const Function *f, KModule *KM) {
-  return false;
-}
-
 static inline const llvm::fltSemantics * fpWidthToSemantics(unsigned width) {
   switch(width) {
 #if LLVM_VERSION_CODE >= LLVM_VERSION(4, 0)
@@ -1921,7 +1916,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     Function *f = getTargetFunction(fp, state);
 
     // Skip debug intrinsics, we can't evaluate their metadata arguments.
-    if (f && isDebugIntrinsic(f, kmodule.get()))
+    if (isa<DbgInfoIntrinsic>(i))
       break;
 
     if (isa<InlineAsm>(fp)) {

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -597,7 +597,11 @@ void Executor::initializeGlobalObject(ExecutionState &state, ObjectState *os,
     for (unsigned i=0, e=cds->getNumElements(); i != e; ++i)
       initializeGlobalObject(state, os, cds->getElementAsConstant(i),
                              offset + i*elementSize);
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
   } else if (!isa<UndefValue>(c) && !isa<MetadataAsValue>(c)) {
+#else
+  } else if (!isa<UndefValue>(c)) {
+#endif
     unsigned StoreBits = targetData->getTypeStoreSizeInBits(c->getType());
     ref<ConstantExpr> C = evalConstant(c);
 

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -546,7 +546,7 @@ void StatsTracker::writeIStats() {
       // KCachegrind can create two entries for the function, one with an
       // unnamed file and one without.
       Function *fn = &*fnIt;
-      const InstructionInfo &ii = executor.kmodule->infos->getFunctionInfo(fn);
+      const FunctionInfo &ii = executor.kmodule->infos->getFunctionInfo(*fn);
       if (ii.file != sourceFile) {
         of << "fl=" << ii.file << "\n";
         sourceFile = ii.file;
@@ -558,7 +558,7 @@ void StatsTracker::writeIStats() {
         for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
              it != ie; ++it) {
           Instruction *instr = &*it;
-          const InstructionInfo &ii = executor.kmodule->infos->getInfo(instr);
+          const InstructionInfo &ii = executor.kmodule->infos->getInfo(*instr);
           unsigned index = ii.id;
           if (ii.file!=sourceFile) {
             of << "fl=" << ii.file << "\n";
@@ -575,14 +575,13 @@ void StatsTracker::writeIStats() {
               (isa<CallInst>(instr) || isa<InvokeInst>(instr))) {
             CallSiteSummaryTable::iterator it = callSiteStats.find(instr);
             if (it!=callSiteStats.end()) {
-              for (std::map<llvm::Function*, CallSiteInfo>::iterator
-                     fit = it->second.begin(), fie = it->second.end(); 
+              for (auto fit = it->second.begin(), fie = it->second.end();
                    fit != fie; ++fit) {
-                Function *f = fit->first;
+                const Function *f = fit->first;
                 CallSiteInfo &csi = fit->second;
-                const InstructionInfo &fii = 
-                  executor.kmodule->infos->getFunctionInfo(f);
-  
+                const FunctionInfo &fii =
+                    executor.kmodule->infos->getFunctionInfo(*f);
+
                 if (fii.file!="" && fii.file!=sourceFile)
                   of << "cfl=" << fii.file << "\n";
                 of << "cfn=" << f->getName().str() << "\n";
@@ -746,7 +745,7 @@ void StatsTracker::computeReachableUncovered() {
              it != ie; ++it) {
           Instruction *inst = &*it;
           instructions.push_back(inst);
-          unsigned id = infos.getInfo(inst).id;
+          unsigned id = infos.getInfo(*inst).id;
           sm.setIndexedValue(stats::minDistToReturn, 
                              id, 
                              isa<ReturnInst>(inst)
@@ -761,8 +760,8 @@ void StatsTracker::computeReachableUncovered() {
     bool changed;
     do {
       changed = false;
-      for (std::vector<Instruction*>::iterator it = instructions.begin(),
-             ie = instructions.end(); it != ie; ++it) {
+      for (auto it = instructions.begin(), ie = instructions.end(); it != ie;
+           ++it) {
         Instruction *inst = *it;
         unsigned bestThrough = 0;
 
@@ -782,13 +781,13 @@ void StatsTracker::computeReachableUncovered() {
         }
        
         if (bestThrough) {
-          unsigned id = infos.getInfo(*it).id;
+          unsigned id = infos.getInfo(*(*it)).id;
           uint64_t best, cur = best = sm.getIndexedValue(stats::minDistToReturn, id);
           std::vector<Instruction*> succs = getSuccs(*it);
           for (std::vector<Instruction*>::iterator it2 = succs.begin(),
                  ie = succs.end(); it2 != ie; ++it2) {
             uint64_t dist = sm.getIndexedValue(stats::minDistToReturn,
-                                               infos.getInfo(*it2).id);
+                                               infos.getInfo(*(*it2)).id);
             if (dist) {
               uint64_t val = bestThrough + dist;
               if (best==0 || val<best)
@@ -824,7 +823,7 @@ void StatsTracker::computeReachableUncovered() {
       for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
            it != ie; ++it) {
         Instruction *inst = &*it;
-        unsigned id = infos.getInfo(inst).id;
+        unsigned id = infos.getInfo(*inst).id;
         instructions.push_back(inst);
         sm.setIndexedValue(stats::minDistToUncovered, 
                            id, 
@@ -842,8 +841,8 @@ void StatsTracker::computeReachableUncovered() {
     for (std::vector<Instruction*>::iterator it = instructions.begin(),
            ie = instructions.end(); it != ie; ++it) {
       Instruction *inst = *it;
-      uint64_t best, cur = best = sm.getIndexedValue(stats::minDistToUncovered, 
-                                                     infos.getInfo(inst).id);
+      uint64_t best, cur = best = sm.getIndexedValue(stats::minDistToUncovered,
+                                                     infos.getInfo(*inst).id);
       unsigned bestThrough = 0;
       
       if (isa<CallInst>(inst) || isa<InvokeInst>(inst)) {
@@ -858,8 +857,8 @@ void StatsTracker::computeReachableUncovered() {
           }
 
           if (!(*fnIt)->isDeclaration()) {
-            uint64_t calleeDist = sm.getIndexedValue(stats::minDistToUncovered,
-                                                     infos.getFunctionInfo(*fnIt).id);
+            uint64_t calleeDist = sm.getIndexedValue(
+                stats::minDistToUncovered, infos.getFunctionInfo(*(*fnIt)).id);
             if (calleeDist) {
               calleeDist = 1+calleeDist; // count instruction itself
               if (best==0 || calleeDist<best)
@@ -876,7 +875,7 @@ void StatsTracker::computeReachableUncovered() {
         for (std::vector<Instruction*>::iterator it2 = succs.begin(),
                ie = succs.end(); it2 != ie; ++it2) {
           uint64_t dist = sm.getIndexedValue(stats::minDistToUncovered,
-                                             infos.getInfo(*it2).id);
+                                             infos.getInfo(*(*it2)).id);
           if (dist) {
             uint64_t val = bestThrough + dist;
             if (best==0 || val<best)
@@ -886,8 +885,7 @@ void StatsTracker::computeReachableUncovered() {
       }
 
       if (best != cur) {
-        sm.setIndexedValue(stats::minDistToUncovered, 
-                           infos.getInfo(inst).id, 
+        sm.setIndexedValue(stats::minDistToUncovered, infos.getInfo(*inst).id,
                            best);
         changed = true;
       }

--- a/lib/Module/InstructionInfoTable.cpp
+++ b/lib/Module/InstructionInfoTable.cpp
@@ -13,6 +13,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 
 # if LLVM_VERSION_CODE < LLVM_VERSION(3,5)
@@ -36,160 +37,180 @@
 
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Path.h"
 
+#include <cstdint>
 #include <map>
 #include <string>
 
-using namespace llvm;
 using namespace klee;
 
 class InstructionToLineAnnotator : public llvm::AssemblyAnnotationWriter {
 public:
-  void emitInstructionAnnot(const Instruction *i,
+  void emitInstructionAnnot(const llvm::Instruction *i,
                             llvm::formatted_raw_ostream &os) {
     os << "%%%";
-    os << (uintptr_t) i;
+    os << reinterpret_cast<std::uintptr_t>(i);
+  }
+
+  void emitFunctionAnnot(const llvm::Function *f,
+                         llvm::formatted_raw_ostream &os) {
+    os << "%%%";
+    os << reinterpret_cast<std::uintptr_t>(f);
   }
 };
-        
-static void buildInstructionToLineMap(Module *m,
-                                      std::map<const Instruction*, unsigned> &out) {  
+
+static std::map<uintptr_t, uint64_t>
+buildInstructionToLineMap(const llvm::Module &m) {
+
+  std::map<uintptr_t, uint64_t> mapping;
   InstructionToLineAnnotator a;
   std::string str;
+
   llvm::raw_string_ostream os(str);
-  m->print(os, &a);
+  m.print(os, &a);
   os.flush();
+
   const char *s;
 
   unsigned line = 1;
   for (s=str.c_str(); *s; s++) {
-    if (*s=='\n') {
-      line++;
-      if (s[1]=='%' && s[2]=='%' && s[3]=='%') {
-        s += 4;
-        char *end;
-        unsigned long long value = strtoull(s, &end, 10);
-        if (end!=s) {
-          out.insert(std::make_pair((const Instruction*) value, line));
-        }
-        s = end;
-      }
+    if (*s != '\n')
+      continue;
+
+    line++;
+    if (s[1] != '%' || s[2] != '%' || s[3] != '%')
+      continue;
+
+    s += 4;
+    char *end;
+    uint64_t value = strtoull(s, &end, 10);
+    if (end != s) {
+      mapping.insert(std::make_pair(value, line));
     }
-  }
-}
-
-static std::string getDSPIPath(const DILocation &Loc) {
-  std::string dir = Loc.getDirectory();
-  std::string file = Loc.getFilename();
-  if (dir.empty() || file[0] == '/') {
-    return file;
-  } else if (*dir.rbegin() == '/') {
-    return dir + file;
-  } else {
-    return dir + "/" + file;
-  }
-}
-
-bool InstructionInfoTable::getInstructionDebugInfo(const llvm::Instruction *I, 
-                                                   const std::string *&File,
-                                                   unsigned &Line) {
-  if (MDNode *N = I->getMetadata("dbg")) {
-#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
-    DILocation *Loc = cast<DILocation>(N);
-    File = internString(getDSPIPath(*Loc));
-    Line = Loc->getLine();
-#else
-    DILocation Loc(N);
-    File = internString(getDSPIPath(Loc));
-    Line = Loc.getLineNumber();
-#endif
-    return true;
+    s = end;
   }
 
-  return false;
+  return mapping;
 }
 
-InstructionInfoTable::InstructionInfoTable(Module *m) 
-  : dummyString(""), dummyInfo(0, dummyString, 0, 0) {
-  unsigned id = 0;
-  std::map<const Instruction*, unsigned> lineTable;
-  buildInstructionToLineMap(m, lineTable);
+static std::string getFullPath(llvm::StringRef Directory,
+                               llvm::StringRef FileName) {
+  llvm::SmallString<128> file_pathname(Directory);
+  llvm::sys::path::append(file_pathname, FileName);
 
-  for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
-       fnIt != fn_ie; ++fnIt) {
-    Function *fn = &*fnIt;
+  return file_pathname.str();
+}
 
-    // We want to ensure that as all instructions have source information, if
-    // available. Clang sometimes will not write out debug information on the
-    // initial instructions in a function (correspond to the formal parameters),
-    // so we first search forward to find the first instruction with debug info,
-    // if any.
-    const std::string *initialFile = &dummyString;
-    unsigned initialLine = 0;
-    for (inst_iterator it = inst_begin(fn), ie = inst_end(fn); it != ie; ++it) {
-      if (getInstructionDebugInfo(&*it, initialFile, initialLine))
-        break;
+class DebugInfoExtractor {
+  std::vector<std::unique_ptr<std::string>> &internedStrings;
+  llvm::DebugInfoFinder DIF;
+
+  uint64_t counter;
+
+  std::map<uintptr_t, uint64_t> lineTable;
+
+  const llvm::Module &module;
+
+public:
+  DebugInfoExtractor(
+      std::vector<std::unique_ptr<std::string>> &_internedStrings,
+      const llvm::Module &_module)
+      : internedStrings(_internedStrings), counter(0), module(_module) {
+    DIF.processModule(module);
+    lineTable = buildInstructionToLineMap(module);
+  }
+
+  std::string &getInternedString(const std::string &s) {
+    auto found = std::find_if(internedStrings.begin(), internedStrings.end(),
+                              [&s](const std::unique_ptr<std::string> &item) {
+                                return *item.get() == s;
+                              });
+    if (found != internedStrings.end())
+      return *found->get();
+
+    auto newItem = std::unique_ptr<std::string>(new std::string(s));
+    auto result = newItem.get();
+
+    internedStrings.emplace_back(std::move(newItem));
+    return *result;
+  }
+
+  std::unique_ptr<FunctionInfo> getFunctionInfo(const llvm::Function &Func) {
+    auto asmLine = lineTable.at(reinterpret_cast<std::uintptr_t>(&Func));
+
+    // Acquire function debug information
+    for (auto subIt = DIF.subprogram_begin(), subItE = DIF.subprogram_end();
+         subIt != subItE; ++subIt) {
+      llvm::DISubprogram SubProgram(*subIt);
+      if (SubProgram.getFunction() != &Func)
+        continue;
+
+      auto path =
+          getFullPath(SubProgram.getDirectory(), SubProgram.getFilename());
+
+      return std::unique_ptr<FunctionInfo>(
+          new FunctionInfo(counter++, getInternedString(path),
+                           SubProgram.getLineNumber(), asmLine));
     }
 
-    const std::string *file = initialFile;
-    unsigned line = initialLine;
-    for (inst_iterator it = inst_begin(fn), ie = inst_end(fn); it != ie;
-        ++it) {
-      Instruction *instr = &*it;
-      unsigned assemblyLine = lineTable[instr];
-
-      // Update our source level debug information.
-      getInstructionDebugInfo(instr, file, line);
-
-      infos.insert(std::make_pair(instr,
-                                  InstructionInfo(id++, *file, line,
-                                                  assemblyLine)));
-    }
+    return std::unique_ptr<FunctionInfo>(
+        new FunctionInfo(counter++, getInternedString(""), 0, asmLine));
   }
-}
 
-InstructionInfoTable::~InstructionInfoTable() {
-  for (std::set<const std::string *, ltstr>::iterator
-         it = internedStrings.begin(), ie = internedStrings.end();
-       it != ie; ++it)
-    delete *it;
-}
+  std::unique_ptr<InstructionInfo>
+  getInstructionInfo(const llvm::Instruction &Inst, const FunctionInfo &f) {
+    auto asmLine = lineTable.at(reinterpret_cast<std::uintptr_t>(&Inst));
 
-const std::string *InstructionInfoTable::internString(std::string s) {
-  std::set<const std::string *, ltstr>::iterator it = internedStrings.find(&s);
-  if (it==internedStrings.end()) {
-    std::string *interned = new std::string(s);
-    internedStrings.insert(interned);
-    return interned;
-  } else {
-    return *it;
+    llvm::DebugLoc Loc(Inst.getDebugLoc());
+    if (!Loc.isUnknown()) {
+      llvm::DIScope Scope(Loc.getScope(module.getContext()));
+      auto full_path = getFullPath(Scope.getDirectory(), Scope.getFilename());
+      return std::unique_ptr<InstructionInfo>(
+          new InstructionInfo(counter++, getInternedString(full_path),
+                              Loc.getLine(), Loc.getCol(), asmLine));
+    }
+
+    // If nothing found, use the surrounding function
+    return std::unique_ptr<InstructionInfo>(
+        new InstructionInfo(counter++, f.file, f.line, 0, asmLine));
+  }
+};
+
+InstructionInfoTable::InstructionInfoTable(const llvm::Module &m) {
+  DebugInfoExtractor DI(internedStrings, m);
+  for (const auto &Func : m) {
+    auto F = DI.getFunctionInfo(Func);
+    auto FD = F.get();
+    functionInfos.insert(std::make_pair(&Func, std::move(F)));
+
+    for (auto it = llvm::inst_begin(Func), ie = llvm::inst_end(Func); it != ie;
+         ++it) {
+      auto instr = &*it;
+      infos.insert(std::make_pair(instr, DI.getInstructionInfo(*instr, *FD)));
+    }
   }
 }
 
 unsigned InstructionInfoTable::getMaxID() const {
-  return infos.size();
+  return infos.size() + functionInfos.size();
 }
 
 const InstructionInfo &
-InstructionInfoTable::getInfo(const Instruction *inst) const {
-  std::map<const llvm::Instruction*, InstructionInfo>::const_iterator it = 
-    infos.find(inst);
+InstructionInfoTable::getInfo(const llvm::Instruction &inst) const {
+  auto it = infos.find(&inst);
   if (it == infos.end())
     llvm::report_fatal_error("invalid instruction, not present in "
                              "initial module!");
-  return it->second;
+  return *it->second.get();
 }
 
-const InstructionInfo &
-InstructionInfoTable::getFunctionInfo(const Function *f) const {
-  if (f->isDeclaration()) {
-    // FIXME: We should probably eliminate this dummyInfo object, and instead
-    // allocate a per-function object to track the stats for that function
-    // (otherwise, anyone actually trying to use those stats is getting ones
-    // shared across all functions). I'd like to see if this matters in practice
-    // and construct a test case for it if it does, though.
-    return dummyInfo;
-  } else {
-    return getInfo(&*(f->begin()->begin()));
-  }
+const FunctionInfo &
+InstructionInfoTable::getFunctionInfo(const llvm::Function &f) const {
+  auto found = functionInfos.find(&f);
+  if (found == functionInfos.end())
+    llvm::report_fatal_error("invalid instruction, not present in "
+                             "initial module!");
+
+  return *found->second.get();
 }

--- a/lib/Module/InstructionInfoTable.cpp
+++ b/lib/Module/InstructionInfoTable.cpp
@@ -34,6 +34,13 @@
 #else
 #include "llvm/DebugInfo.h"
 #endif
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 7)
+#include "llvm/IR/DebugInfoMetadata.h"
+#endif
+
+#if LLVM_VERSION_CODE == LLVM_VERSION(3, 6)
+#include "llvm/Support/Debug.h"
+#endif
 
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -105,7 +112,9 @@ static std::string getFullPath(llvm::StringRef Directory,
 class DebugInfoExtractor {
   std::vector<std::unique_ptr<std::string>> &internedStrings;
   std::map<uintptr_t, uint64_t> lineTable;
+#if LLVM_VERSION_CODE < LLVM_VERSION(3, 8)
   llvm::DebugInfoFinder DIF;
+#endif
 
   const llvm::Module &module;
 
@@ -114,7 +123,9 @@ public:
       std::vector<std::unique_ptr<std::string>> &_internedStrings,
       const llvm::Module &_module)
       : internedStrings(_internedStrings), module(_module) {
+#if LLVM_VERSION_CODE < LLVM_VERSION(3, 8)
     DIF.processModule(module);
+#endif
     lineTable = buildInstructionToLineMap(module);
   }
 
@@ -136,68 +147,105 @@ public:
   std::unique_ptr<FunctionInfo> getFunctionInfo(const llvm::Function &Func) {
     auto asmLine = lineTable.at(reinterpret_cast<std::uintptr_t>(&Func));
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
-#if LLVM_VERSION_CODE >= LLVM_VERSION(6, 0)
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 9)
     auto dsub = Func.getSubprogram();
 #else
     auto dsub = llvm::getDISubprogram(&Func);
 #endif
-    if (dsub == nullptr)
-      return std::unique_ptr<FunctionInfo>(
-          new FunctionInfo(0, getInternedString(""), 0, asmLine));
-    auto path = getFullPath(dsub->getDirectory(), dsub->getFilename());
-    return std::unique_ptr<FunctionInfo>(
-        new FunctionInfo(0, getInternedString(path), dsub->getLine(), asmLine));
-
-#else
-    // Acquire function debug information
-#if LLVM_VERSION_CODE < LLVM_VERSION(3, 5)
-    for (auto subIt = DIF.subprogram_begin(), subItE = DIF.subprogram_end();
-         subIt != subItE; ++subIt) {
-      llvm::DISubprogram SubProgram(*subIt);
-#else
-    for (const auto &SubProgram : DIF.subprograms()) {
-#endif
-      if (SubProgram.getFunction() != &Func)
-        continue;
-
-      auto path =
-          getFullPath(SubProgram.getDirectory(), SubProgram.getFilename());
-
+    if (dsub != nullptr) {
+      auto path = getFullPath(dsub->getDirectory(), dsub->getFilename());
       return std::unique_ptr<FunctionInfo>(new FunctionInfo(
-          0, getInternedString(path), SubProgram.getLineNumber(), asmLine));
+          0, getInternedString(path), dsub->getLine(), asmLine));
     }
 
+#elif LLVM_VERSION_CODE == LLVM_VERSION(3, 7)
+    for (const auto SP : DIF.subprograms()) {
+      auto &SubProgram = *SP;
+      if (SubProgram.getFunction() != &Func)
+        continue;
+      auto path =
+          getFullPath(SubProgram.getDirectory(), SubProgram.getFilename());
+      return std::unique_ptr<FunctionInfo>(new FunctionInfo(
+          0, getInternedString(path), SubProgram.getLine(), asmLine));
+    }
+#endif
+
+#if LLVM_VERSION_CODE <= LLVM_VERSION(3, 6)
+    // Workaround missing debug information for older LLVM versions
+    // Search for any instructions inside this function with debug information
+    // and assume it's part of this function in the source code as well.
+    for (auto it = llvm::inst_begin(&Func), ie = llvm::inst_end(&Func);
+         it != ie; ++it) {
+      auto iInfo = getInstructionInfo(*it, nullptr);
+      if (iInfo->file.empty())
+        continue;
+      // Found an instruction
+      return std::unique_ptr<FunctionInfo>(new FunctionInfo(
+          0, getInternedString(iInfo->file), iInfo->line, asmLine));
+    }
+
+#endif
+    // Fallback: Mark as unknown
     return std::unique_ptr<FunctionInfo>(
         new FunctionInfo(0, getInternedString(""), 0, asmLine));
-#endif
   }
 
   std::unique_ptr<InstructionInfo>
-  getInstructionInfo(const llvm::Instruction &Inst, const FunctionInfo &f) {
+  getInstructionInfo(const llvm::Instruction &Inst, const FunctionInfo *f) {
     auto asmLine = lineTable.at(reinterpret_cast<std::uintptr_t>(&Inst));
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 8)
+    // Retrieve debug information associated with instruction
     auto dl = Inst.getDebugLoc();
-    auto dil = dl.get();
-    if (dil != nullptr) {
-      auto full_path = getFullPath(dil->getDirectory(), dil->getFilename());
 
+    // Check if a valid debug location is assigned to the instruction.
+    if (dl.get() != nullptr) {
+      auto full_path = dl.get()->getFilename();
+      auto line = dl.getLine();
+      auto column = dl.getCol();
+
+      // Still, if the line is unknown, take the context of the instruction to
+      // narrow it down
+      if (line == 0) {
+        if (auto LexicalBlock =
+                llvm::dyn_cast<llvm::DILexicalBlock>(dl.getScope())) {
+          line = LexicalBlock->getLine();
+          column = LexicalBlock->getColumn();
+        }
+      }
       return std::unique_ptr<InstructionInfo>(new InstructionInfo(
-          0, getInternedString(full_path), dl.getLine(), dl.getCol(), asmLine));
+          0, getInternedString(full_path), line, column, asmLine));
     }
-#else
+#elif LLVM_VERSION_CODE == LLVM_VERSION(3, 7)
+    // Retrieve debug information
     llvm::DebugLoc Loc(Inst.getDebugLoc());
-    if (!Loc.isUnknown()) {
-      llvm::DIScope Scope(Loc.getScope(module.getContext()));
-      auto full_path = getFullPath(Scope.getDirectory(), Scope.getFilename());
+    // Check if valid
+    if (Loc.get() != nullptr) {
+      auto subProg = getDISubprogram(Loc.getScope());
+      auto full_path =
+          getFullPath(subProg->getDirectory(), subProg->getFilename());
       return std::unique_ptr<InstructionInfo>(
           new InstructionInfo(0, getInternedString(full_path), Loc.getLine(),
                               Loc.getCol(), asmLine));
     }
+#elif LLVM_VERSION_CODE <= LLVM_VERSION(3, 6)
+    if (llvm::MDNode *N = Inst.getMetadata("dbg")) {
+      llvm::DILocation Loc(N);
+      auto path = getFullPath(Loc.getDirectory(), Loc.getFilename());
+      auto Line = Loc.getLineNumber();
+      return std::unique_ptr<InstructionInfo>(
+          new InstructionInfo(0, getInternedString(path), Line, 0, asmLine));
+    }
 #endif
+
+    if (f != nullptr)
+      // If nothing found, use the surrounding function
+      return std::unique_ptr<InstructionInfo>(
+          new InstructionInfo(0, f->file, f->line, 0, asmLine));
     // If nothing found, use the surrounding function
     return std::unique_ptr<InstructionInfo>(
-        new InstructionInfo(0, f.file, f.line, 0, asmLine));
+        new InstructionInfo(0, getInternedString(""), 0, 0, asmLine));
   }
 };
 
@@ -206,13 +254,13 @@ InstructionInfoTable::InstructionInfoTable(const llvm::Module &m) {
   DebugInfoExtractor DI(internedStrings, m);
   for (const auto &Func : m) {
     auto F = DI.getFunctionInfo(Func);
-    auto FD = F.get();
+    auto FR = F.get();
     functionInfos.insert(std::make_pair(&Func, std::move(F)));
 
     for (auto it = llvm::inst_begin(Func), ie = llvm::inst_end(Func); it != ie;
          ++it) {
       auto instr = &*it;
-      infos.insert(std::make_pair(instr, DI.getInstructionInfo(*instr, *FD)));
+      infos.insert(std::make_pair(instr, DI.getInstructionInfo(*instr, FR)));
     }
   }
 

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -198,11 +198,11 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
 
       case Intrinsic::dbg_value:
       case Intrinsic::dbg_declare: {
-        // Remove these regardless of lower intrinsics flag. This can
-        // be removed once IntrinsicLowering is fixed to not have bad
-        // caches.
-        ii->eraseFromParent();
-        dirty = true;
+        //        // Remove these regardless of lower intrinsics flag. This can
+        //        // be removed once IntrinsicLowering is fixed to not have bad
+        //        // caches.
+        //        ii->eraseFromParent();
+        //        dirty = true;
         break;
       }
 

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -53,6 +53,9 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
     // increment now since deletion of instructions makes iterator invalid.
     ++i;
     if (ii) {
+      if (isa<DbgInfoIntrinsic>(ii))
+        continue;
+
       switch (ii->getIntrinsicID()) {
       case Intrinsic::vastart:
       case Intrinsic::vaend:

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -199,16 +199,6 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         break;
       }
 
-      case Intrinsic::dbg_value:
-      case Intrinsic::dbg_declare: {
-        //        // Remove these regardless of lower intrinsics flag. This can
-        //        // be removed once IntrinsicLowering is fixed to not have bad
-        //        // caches.
-        //        ii->eraseFromParent();
-        //        dirty = true;
-        break;
-      }
-
       case Intrinsic::trap: {
         // Intrinsic instruction "llvm.trap" found. Directly lower it to
         // a call of the abort() function.

--- a/lib/Module/KInstruction.cpp
+++ b/lib/Module/KInstruction.cpp
@@ -21,6 +21,7 @@ KInstruction::~KInstruction() {
 
 std::string KInstruction::getSourceLocation() const {
   if (!info->file.empty())
-    return info->file + ":" + std::to_string(info->line);
+    return info->file + ":" + std::to_string(info->line) + " " +
+           std::to_string(info->column);
   else return "[no debug info]";
 }

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -427,7 +427,8 @@ static int getOperandNum(Value *v,
     return a->getArgNo();
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 6)
     // Metadata is no longer a Value
-  } else if (isa<BasicBlock>(v) || isa<InlineAsm>(v)) {
+  } else if (isa<BasicBlock>(v) || isa<InlineAsm>(v) ||
+             isa<MetadataAsValue>(v)) {
 #else
   } else if (isa<BasicBlock>(v) || isa<InlineAsm>(v) ||
              isa<MDNode>(v)) {

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -327,7 +327,7 @@ void KModule::manifest(InterpreterHandler *ih, bool forceSourceOutput) {
   /* Build shadow structures */
 
   infos = std::unique_ptr<InstructionInfoTable>(
-      new InstructionInfoTable(module.get()));
+      new InstructionInfoTable(*module.get()));
 
   std::vector<Function *> declarations;
 
@@ -341,7 +341,7 @@ void KModule::manifest(InterpreterHandler *ih, bool forceSourceOutput) {
 
     for (unsigned i=0; i<kf->numInstructions; ++i) {
       KInstruction *ki = kf->instructions[i];
-      ki->info = &infos->getInfo(ki->inst);
+      ki->info = &infos->getInfo(*ki->inst);
     }
 
     functionMap.insert(std::make_pair(&Function, kf.get()));


### PR DESCRIPTION
Currently, KLEE handles debug information on a best-effort basis based on the historic debug information with the following consequences:
- allocas at the beginning of an function has none or wrong debug information assigned
- function information is based on its first instruction that can be wrong due to inlining
- optimisation looses debug information
- debug information for instructions are sometimes wrong due to optimisations

This PR involves the following major changes:
* Separate function debug information tracking from instruction debug information tracking
* Utilise newer LLVM debug infrastructure if possible ( >= LLVM 3.7)
* Keep debug information as part of the module
* Tracks `columns` beside `linenumbers`