### PR TITLE
Install tabulate when building.

### DIFF
--- a/scripts/build/p-klee-linux-ubuntu-16.04.inc
+++ b/scripts/build/p-klee-linux-ubuntu-16.04.inc
@@ -17,5 +17,5 @@ install_build_dependencies_klee() {
 
   apt -y --no-install-recommends install "${dependencies[@]}"
 
-  pip install lit
+  pip install lit tabulate
 }

--- a/scripts/build/p-klee-osx.inc
+++ b/scripts/build/p-klee-osx.inc
@@ -10,5 +10,5 @@ install_build_dependencies_klee() {
   ln -s "${py2path}" /usr/local/bin/python
   ln -s "${pip2path}" /usr/local/bin/pip
   set -e
-  pip install lit
+  pip install lit tabulate
 }


### PR DESCRIPTION
Fixes #1069.

This makes the tabulate package available in the Docker image.

Taken from #1025. I am not 100% sure if this is the right location, because tabulate is strictly speaking not a build dependency. But this works well and doesn't require adding a new flag to the build script.