### PR TITLE
Fix case where IntrinsicCleaner adds a terminator instruction in the middle of a basic block

### DIFF
--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -206,6 +206,14 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
 
         ii->eraseFromParent();
 
+       	//check if the instruction after the one we just replaced is not the end of the basic block
+        //and if it is not (i.e. it is a valid instruction), delete it and all remaining 
+        //because the cleaner just introduced a terminating instruction (unreachable)
+        //otherwise llvm will assert in Verifier::visitTerminatorInstr
+        while(i != ie){  // i was already incremented above.
+          (i++)->eraseFromParent();
+        }
+
         dirty = true;
         break;
       }


### PR DESCRIPTION
This handles the case where the llvm trap Intrinsic is cleaned by klee, but the trap intrinsic was not the end of the basic block.