### PR TITLE
Add LD_LIBRARY_PATH to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,10 @@ ADD --chown=klee:klee / ${BASE}/klee_src
 
 USER klee
 WORKDIR /home/klee
+ENV LD_LIBRARY_PATH /home/klee/klee_build/lib/
 
 # Add KLEE binary directory to PATH
 RUN /bin/bash -c 'ln -s ${BASE}/klee_src /home/klee/ && ln -s ${BASE}/klee_build* /home/klee/klee_build && echo "export PATH=\"$PATH:$(cd /tmp/llvm-*install*/bin && pwd):/home/klee/klee_build/bin\"" >> /home/klee/.bashrc'
 
 # TODO Remove when STP is fixed
-RUN /bin/bash -c 'echo "export LD_LIBRARY_PATH=$(cd ${BASE}/metaSMT-*-deps/stp-git-basic/lib/ && pwd)" >> /home/klee/.bashrc'
+RUN /bin/bash -c 'echo "export LD_LIBRARY_PATH=$(cd ${BASE}/metaSMT-*-deps/stp-git-basic/lib/ && pwd):$LD_LIBRARY_PATH" >> /home/klee/.bashrc'

--- a/scripts/build/d-klee-linux-ubuntu.inc
+++ b/scripts/build/d-klee-linux-ubuntu.inc
@@ -15,9 +15,10 @@ ADD --chown=klee:klee / ${BASE}/klee_src
 
 USER klee
 WORKDIR /home/klee
+ENV LD_LIBRARY_PATH /home/klee/klee_build/lib/
 
 # Add KLEE binary directory to PATH
 RUN /bin/bash -c 'ln -s ${BASE}/klee_src /home/klee/ && ln -s ${BASE}/klee_build* /home/klee/klee_build && echo "export PATH=\"$PATH:$(cd /tmp/llvm-*install*/bin && pwd):/home/klee/klee_build/bin\"" >> /home/klee/.bashrc'
 
 # TODO Remove when STP is fixed
-RUN /bin/bash -c 'echo "export LD_LIBRARY_PATH=$(cd ${BASE}/metaSMT-*-deps/stp-git-basic/lib/ && pwd)" >> /home/klee/.bashrc'
+RUN /bin/bash -c 'echo "export LD_LIBRARY_PATH=$(cd ${BASE}/metaSMT-*-deps/stp-git-basic/lib/ && pwd):$LD_LIBRARY_PATH" >> /home/klee/.bashrc'


### PR DESCRIPTION
Fixes #1080. The proper LD_LIBRARY_PATH is required when binaries linked
with kleeRuntest are run.

The STP line is changed to extend the library path instead of replace
it, I am not sure if it can be removed at this moment.