### PR TITLE
More FreeBSD fixes and FreeBSD CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,16 @@
+task:
+  freebsd_instance:
+    matrix:
+      - image: freebsd-11-2-release-amd64
+      - image: freebsd-12-0-release-amd64
+  deps_script:
+    - pkg install -y llvm80 gmake z3 cmake pkgconf google-perftools python3 python36 py36-sqlite3 py36-tabulate
+  build_script:
+    - mkdir build
+    - cd build
+    - cmake -DLLVM_CONFIG_BINARY=/usr/local/bin/llvm-config80 -DMAKE_BINARY=/usr/local/bin/gmake -DENABLE_TCMALLOC:BOOL=true -DENABLE_POSIX_RUNTIME:BOOL=ON -DENABLE_SOLVER_Z3:BOOL=true -DENABLE_SYSTEM_TESTS:BOOL=ON ..
+    - gmake
+  test_script:
+    - sed -i.bak -e 's/lit\./lit80\./' test/lit.cfg
+    - cd build
+    - gmake check

--- a/runtime/POSIX/FreeBSD.h
+++ b/runtime/POSIX/FreeBSD.h
@@ -15,6 +15,8 @@
 
 #define stat64 stat
 
+#include <sys/syscall.h>
+
 struct rlimit64;
 
 #define	__NR_syscall	SYS_syscall
@@ -134,9 +136,17 @@ struct rlimit64;
 #define	__NR_setgid	SYS_setgid
 #define	__NR_setegid	SYS_setegid
 #define	__NR_seteuid	SYS_seteuid
+#ifdef SYS_stat
 #define	__NR_stat	SYS_stat
+#else
+#define	__NR_stat	SYS_freebsd11_stat
+#endif
 #define	__NR_fstat	SYS_fstat
+#ifdef SYS_lstat
 #define	__NR_lstat	SYS_lstat
+#else
+#define	__NR_lstat	SYS_freebsd11_lstat
+#endif
 #define	__NR_pathconf	SYS_pathconf
 #define	__NR_fpathconf	SYS_fpathconf
 #define	__NR_getrlimit	SYS_getrlimit
@@ -183,8 +193,13 @@ struct rlimit64;
 #define	__NR_aio_read	SYS_aio_read
 #define	__NR_aio_write	SYS_aio_write
 #define	__NR_lio_listio	SYS_lio_listio
+#ifdef SYS_getdents
 #define	__NR_getdents	SYS_getdents
 #define	__NR_getdents64	SYS_getdents
+#else
+#define	__NR_getdents	SYS_freebsd11_getdents
+#define	__NR_getdents64	SYS_freebsd11_getdents
+#endif
 #define	__NR_lchmod	SYS_lchmod
 #define	__NR_netbsd_lchown	SYS_netbsd_lchown
 #define	__NR_lutimes	SYS_lutimes

--- a/runtime/POSIX/fd_32.c
+++ b/runtime/POSIX/fd_32.c
@@ -71,7 +71,7 @@ int open(const char *pathname, int flags, ...) {
     /* get mode */
     va_list ap;
     va_start(ap, flags);
-    mode = va_arg(ap, mode_t);
+    mode = va_arg(ap, int);
     va_end(ap);
   }
 
@@ -85,7 +85,7 @@ int openat(int fd, const char *pathname, int flags, ...) {
     /* get mode */
     va_list ap;
     va_start(ap, flags);
-    mode = va_arg(ap, mode_t);
+    mode = va_arg(ap, int);
     va_end(ap);
   }
 
@@ -170,7 +170,7 @@ int statfs(const char *path, struct statfs *buf32) {
 #ifndef __FreeBSD__
 ssize_t getdents(int fd, struct dirent *dirp, size_t nbytes) {
 #else
-int getdents(int fd, char *dirp, int nbytes) {
+ssize_t getdents(int fd, char *dirp, size_t nbytes) {
 #endif
   struct dirent64 *dp64 = (struct dirent64*) dirp;
   ssize_t res = __fd_getdents(fd, dp64, nbytes);
@@ -179,7 +179,7 @@ int getdents(int fd, char *dirp, int nbytes) {
     struct dirent64 *end = (struct dirent64*) ((char*) dp64 + res);
     while (dp64 < end) {
       struct dirent *dp = (struct dirent *) dp64;
-      size_t name_len = (dp64->d_reclen - 
+      size_t name_len = (dp64->d_reclen -
                            (size_t) &((struct dirent64*) 0)->d_name);
       dp->d_ino = dp64->d_ino;
 #ifdef _DIRENT_HAVE_D_OFF
@@ -206,7 +206,7 @@ __attribute__((weak)) int open64(const char *pathname, int flags, ...) {
     /* get mode */
     va_list ap;
     va_start(ap, flags);
-    mode = va_arg(ap, mode_t);
+    mode = va_arg(ap, int);
     va_end(ap);
   }
 

--- a/runtime/POSIX/fd_64.c
+++ b/runtime/POSIX/fd_64.c
@@ -46,12 +46,12 @@
 
 int open(const char *pathname, int flags, ...) {
   mode_t mode = 0;
-  
+
   if (flags & O_CREAT) {
     /* get mode */
     va_list ap;
     va_start(ap, flags);
-    mode = va_arg(ap, mode_t);
+    mode = va_arg(ap, int);
     va_end(ap);
   }
 
@@ -60,12 +60,12 @@ int open(const char *pathname, int flags, ...) {
 
 int openat(int fd, const char *pathname, int flags, ...) {
   mode_t mode = 0;
-  
+
   if (flags & O_CREAT) {
     /* get mode */
     va_list ap;
     va_start(ap, flags);
-    mode = va_arg(ap, mode_t);
+    mode = va_arg(ap, int);
     va_end(ap);
   }
 

--- a/runtime/POSIX/illegal.c
+++ b/runtime/POSIX/illegal.c
@@ -25,8 +25,13 @@ int kill(pid_t pid, int sig) {
   return -1;
 }
 
+#ifndef __FreeBSD__
 int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__((weak));
 int _setjmp (struct __jmp_buf_tag __env[1]) {
+#else
+int _setjmp (jmp_buf env) __returns_twice;
+int _setjmp (jmp_buf env) {
+#endif
   klee_warning_once("ignoring");
   return 0;
 }

--- a/runtime/POSIX/stubs.c
+++ b/runtime/POSIX/stubs.c
@@ -19,7 +19,9 @@
 #include <time.h>
 #include <unistd.h>
 #include <utime.h>
+#ifndef __FreeBSD__
 #include <utmp.h>
+#endif
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
@@ -484,8 +486,13 @@ int setpgrp(pid_t a, pid_t b) {
   return -1;
 }
 
+#ifndef __FreeBSD__
 int setpriority(__priority_which_t which, id_t who, int prio) __attribute__((weak));
 int setpriority(__priority_which_t which, id_t who, int prio) {
+#else
+int setpriority(int which, int who, int prio) __attribute__((weak));
+int setpriority(int which, int who, int prio) {
+#endif
   klee_warning("ignoring (EPERM)");
   errno = EPERM;
   return -1;
@@ -505,19 +512,26 @@ int setresuid(uid_t ruid, uid_t euid, uid_t suid) {
   return -1;
 }
 
+#ifndef __FreeBSD__
 int setrlimit(__rlimit_resource_t resource, const struct rlimit *rlim) __attribute__((weak));
 int setrlimit(__rlimit_resource_t resource, const struct rlimit *rlim) {
+#else
+int setrlimit(int resource, const struct rlimit *rlp) __attribute__((weak));
+int setrlimit(int resource, const struct rlimit *rlp) {
+#endif
   klee_warning("ignoring (EPERM)");
   errno = EPERM;
   return -1;
 }
 
+#ifndef __FreeBSD__
 int setrlimit64(__rlimit_resource_t resource, const struct rlimit64 *rlim) __attribute__((weak));
 int setrlimit64(__rlimit_resource_t resource, const struct rlimit64 *rlim) {
   klee_warning("ignoring (EPERM)");
   errno = EPERM;
   return -1;
 }
+#endif
 
 pid_t setsid(void) __attribute__((weak));
 pid_t setsid(void) {

--- a/tools/gen-random-bout/gen-random-bout.cpp
+++ b/tools/gen-random-bout/gen-random-bout.cpp
@@ -23,6 +23,7 @@
 
 #if defined(__FreeBSD__) || defined(__minix)
 #define stat64 stat
+#define fstat64 fstat
 #endif
 
 #define SMALL_BUFFER_SIZE 64 // To hold "arg<N>" string, temporary


### PR DESCRIPTION
This PR adds support for FreeBSD CI on Cirrus. Right now, some tests are failing due to LLVM packaging issue. It was reported to the maintainer and expected to be fixed soon.