### PR TITLE
Automatically Vectorized Code is not Scalarized Correctly

### DIFF
--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -286,6 +286,7 @@ void KModule::optimiseAndPrepare(
   default: klee_error("invalid --switch-type");
   }
   pm3.add(new IntrinsicCleanerPass(*targetData));
+  pm3.add(createScalarizerPass());
   pm3.add(new PhiCleanerPass());
   pm3.run(*module);
 }


### PR DESCRIPTION
The `InstructionCombinationPass` can insert vectorized code during KLEE's optimization step. As the `ScalarizerLegacyPass` is not run afterwards (again), these automatically vectorized code causes KLEE to encounter unexpected instructions later on.

As a concrete example, build KLEE's master branch with `KLEE_RUNTIME_BUILD_TYPE` set to `Release` and linked against LLVM 8 and consider the following simple example:

```C
#include <string.h>

int main() {
  char arr[1024];
  memset(arr, 0, sizeof(arr);
  return arr[0];
}
```

Executing KLEE on this example with `-optimize` and the freestanding runtime will add vectorized code (`shufflevector` instructions) during the `InstructionCombiningPass` step in the optimization process. As the `ScalarizerLegacyPass` is not executed after the optimization step, this vectorized code will not be removed, and therefore result in an error when KLEE tries to execute these instructions.

This behavior seems to trigger from LLVM 5 to LLVM 8 in my experiments, while the optimization passes from LLVM 4 do not seem to generate vector instructions.

This PR attempts to solve the problem by executing the `ScalarizerLegacyPass` at an appropriate time later in the process.

This behavior was detected in the course of the SYMBIOSYS research project at COMSYS, RWTH Aachen University. This research is supported by the European Research Council (ERC) under the EU's Horizon 2020 Research and Innovation Programme grant agreement n. 647295 (SYMBIOSYS).