### PR TITLE
PTree: fix dump() method

### DIFF
--- a/lib/Core/PTree.cpp
+++ b/lib/Core/PTree.cpp
@@ -18,10 +18,7 @@ using namespace klee;
 
   /* *** */
 
-PTree::PTree(const data_type &_root) : root(new Node(0,_root)) {
-}
-
-PTree::~PTree() {}
+PTree::PTree(const data_type &root) : root(new Node(nullptr, root)) {}
 
 std::pair<PTreeNode*, PTreeNode*>
 PTree::split(Node *n, 
@@ -39,10 +36,10 @@ void PTree::remove(Node *n) {
     Node *p = n->parent;
     if (p) {
       if (n == p->left) {
-        p->left = 0;
+        p->left = nullptr;
       } else {
         assert(n == p->right);
-        p->right = 0;
+        p->right = nullptr;
       }
     }
     delete n;
@@ -65,13 +62,7 @@ void PTree::dump(llvm::raw_ostream &os) {
   while (!stack.empty()) {
     PTree::Node *n = stack.back();
     stack.pop_back();
-    if (n->condition.isNull()) {
-      os << "\tn" << n << " [label=\"\"";
-    } else {
-      os << "\tn" << n << " [label=\"";
-      pp->print(n->condition);
-      os << "\",shape=diamond";
-    }
+    os << "\tn" << n << " [shape=diamond";
     if (n->data)
       os << ",fillcolor=green";
     os << "];\n";
@@ -88,15 +79,6 @@ void PTree::dump(llvm::raw_ostream &os) {
   delete pp;
 }
 
-PTreeNode::PTreeNode(PTreeNode *_parent, 
-                     ExecutionState *_data) 
-  : parent(_parent),
-    left(0),
-    right(0),
-    data(_data),
-    condition(0) {
-}
-
-PTreeNode::~PTreeNode() {
-}
+PTreeNode::PTreeNode(PTreeNode * parent, ExecutionState * data)
+  : parent{parent}, data{data} {}
 

--- a/lib/Core/PTree.h
+++ b/lib/Core/PTree.h
@@ -22,8 +22,8 @@ namespace klee {
     typedef class PTreeNode Node;
     Node *root;
 
-    PTree(const data_type &_root);
-    ~PTree();
+    explicit PTree(const data_type &_root);
+    ~PTree() = default;
     
     std::pair<Node*,Node*> split(Node *n,
                                  const data_type &leftData,
@@ -36,13 +36,14 @@ namespace klee {
   class PTreeNode {
     friend class PTree;
   public:
-    PTreeNode *parent, *left, *right;
-    ExecutionState *data;
-    ref<Expr> condition;
+    PTreeNode *parent = nullptr;
+    PTreeNode *left = nullptr;
+    PTreeNode *right = nullptr;
+    ExecutionState *data = nullptr;
 
   private:
-    PTreeNode(PTreeNode *_parent, ExecutionState *_data);
-    ~PTreeNode();
+    PTreeNode(PTreeNode * parent, ExecutionState * data);
+    ~PTreeNode() = default;
   };
 }
 


### PR DESCRIPTION
Minor clean-up and fix for `dump()`. Just in case you are curious how it looks like:
![ptree_20](https://user-images.githubusercontent.com/4990858/58641958-2d96cf00-82f4-11e9-9788-7261d4523d53.png)
