### PR TITLE
Force concretization to follow seeds

### DIFF
--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -409,6 +409,10 @@ private:
   ref<klee::ConstantExpr> toConstant(ExecutionState &state, ref<Expr> e, 
                                      const char *purpose);
 
+  /// Return a constant value for the given expression dictated by one
+  /// of the given seeds
+  ref<klee::ConstantExpr> getOneValueFromSeeds(std::vector<SeedInfo> &seeds, ref<Expr> e);
+
   /// Bind a constant value for e to the given target. NOTE: This
   /// function may fork state if the state has multiple seeds.
   void executeGetValue(ExecutionState &state, ref<Expr> e, KInstruction *target);

--- a/test/Feature/SeedConcretizeExternalCall.c
+++ b/test/Feature/SeedConcretizeExternalCall.c
@@ -1,0 +1,26 @@
+// RUN: %clang -emit-llvm -c -g %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --entry-point=TestGen %t.bc "initial"
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: not test -f %t.klee-out/test000002.ktest
+
+// RUN: rm -rf %t.klee-out-2
+// RUN: %klee --external-calls=all --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest %t.bc
+// RUN: grep -q "ASSERTION FAIL" %t.klee-out-2/messages.txt
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+void TestGen() {
+  unsigned z;
+  klee_make_symbolic(&z, sizeof z, "z");
+  klee_assume(z == 0xBADA55);
+}
+
+int main(int argc, char **argv) {
+  int z;
+  klee_make_symbolic(&z, sizeof z, "z");
+  assert(abs(z) != 0xBADA55);
+  return 0;
+}

--- a/test/Feature/SeedConcretizeFP.c
+++ b/test/Feature/SeedConcretizeFP.c
@@ -1,0 +1,27 @@
+// RUN: %clang -emit-llvm -c -g %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --entry-point=TestGen %t.bc "initial"
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: not test -f %t.klee-out/test000002.ktest
+
+// RUN: rm -rf %t.klee-out-2
+// RUN: %klee --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest %t.bc
+// RUN: grep -q "ASSERTION FAIL" %t.klee-out-2/messages.txt
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+void TestGen() {
+  unsigned z;
+  klee_make_symbolic(&z, sizeof z, "z");
+  klee_assume(z == 0xBADA55);
+}
+
+int main(int argc, char **argv) {
+  unsigned z;
+  klee_make_symbolic(&z, sizeof z, "z");
+  double d = z;
+  assert(d != 0xBADA55);
+  return 0;
+}

--- a/test/Feature/SeedConcretizeMalloc.c
+++ b/test/Feature/SeedConcretizeMalloc.c
@@ -1,0 +1,27 @@
+// RUN: %clang -emit-llvm -c -g %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --entry-point=TestGen %t.bc "initial"
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: not test -f %t.klee-out/test000002.ktest
+
+// RUN: rm -rf %t.klee-out-2
+// RUN: %klee --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest %t.bc
+// RUN: grep -q "memory error: out of bound pointer" %t.klee-out-2/messages.txt
+
+#include <stdio.h>
+#include <stdlib.h>
+
+void TestGen() {
+  unsigned z;
+  klee_make_symbolic(&z, sizeof z, "z");
+  klee_assume((z & 0xFF) == (0xBADC0DED & 0xFF));
+}
+
+int main(int argc, char **argv) {
+  unsigned z;
+  klee_make_symbolic(&z, sizeof z, "z");
+  unsigned char *p = (unsigned char *) malloc((z & 0xFF) + 1);
+  if (z == 0xBADC0DED) free(p);
+  p[0] = z;
+  return 0;
+}


### PR DESCRIPTION
Even in seed mode, KLEE still concretizes expressions to solver-picked values ignoring all seeds. This behavior is not very useful, especially for hybrid fuzzing. This PR tries to force concretization to follow one of the seeds in the 3 most common cases (symbolic memory allocation, floating point instructions and external calls). It is also possible to keep following all seeds by forking multiple states, but the implementation is more complex and I do not currently have a use-case for that.

