### PR TITLE
Compile the runtime in release mode when ENABLE_OPTIMIZED=1 in the CI

### DIFF
--- a/scripts/build/p-klee.inc
+++ b/scripts/build/p-klee.inc
@@ -135,8 +135,10 @@ fi
   
   if [ "X${ENABLE_OPTIMIZED}" == "X1" ]; then
     CMAKE_ARGUMENTS+=("-DCMAKE_BUILD_TYPE=RelWithDebInfo")
+    CMAKE_ARGUMENTS+=("-DKLEE_RUNTIME_BUILD_TYPE=Release+Debug")
   else
     CMAKE_ARGUMENTS+=("-DCMAKE_BUILD_TYPE=Debug")
+    CMAKE_ARGUMENTS+=("-DKLEE_RUNTIME_BUILD_TYPE=Debug+Asserts")
   fi
   
 # TODO: We should support Ninja too


### PR DESCRIPTION
We should also compile the runtime in release mode, so that we can catch bugs such as #1102 