### PR TITLE
Fix two test issues (fix 'REQUIRES: uclibc' tests)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,11 +17,6 @@ set(LLVMCXX "${LLVMCXX} -I${CMAKE_SOURCE_DIR}/include")
 set(NATIVE_CC "${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} -I ${CMAKE_SOURCE_DIR}/include")
 set(NATIVE_CXX "${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} -I ${CMAKE_SOURCE_DIR}/include")
 set(TARGET_TRIPLE "${TARGET_TRIPLE}")
-if (ENABLE_KLEE_UCLIBC)
-  set(ENABLE_UCLIBC 1)
-else()
-  set(ENABLE_UCLIBC 0)
-endif()
 
 # FIXME: Do this to avoid changing the template file that
 # is shared by both build systems.

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -186,13 +186,17 @@ else:
 # Zlib
 config.available_features.add('zlib' if config.enable_zlib else 'not-zlib')
 
+# Uclibc
+if config.enable_uclibc:
+  config.available_features.add('uclibc')
+
 # POSIX runtime feature
 if config.enable_posix_runtime:
   config.available_features.add('posix-runtime')
 
 # LibC++ runtime feature
 if config.enable_libcxx:
-  config.available_features.add('{}libcxx'.format('' if config.enable_libcxx else 'not-'))
+  config.available_features.add('libcxx')
 
 # Target operating system features
 supported_targets = ['linux', 'darwin', 'freebsd']

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -29,7 +29,7 @@ if @LLVM_VERSION_MAJOR@ >= 5:
   config.O0opt += " -Xclang -disable-O0-optnone"
 
 # Features
-config.enable_uclibc = True if @ENABLE_UCLIBC@ == 1 else False
+config.enable_uclibc = True if @SUPPORT_KLEE_UCLIBC@ == 1 else False
 config.enable_posix_runtime = True if @ENABLE_POSIX_RUNTIME@ == 1 else False
 config.enable_libcxx = True if @SUPPORT_KLEE_LIBCXX@ == 1 else False
 config.have_selinux = True if @HAVE_SELINUX@ == 1 else False


### PR DESCRIPTION
Specifying `REQUIRES: uclibc` in a test currently disables the test on _all_ platforms due to the wrong variable being used to check for availability of this feature, which this PR fixes.

Some CI platforms (Xcode, freebsd) run without uclibc support, which is why I noticed this problem.

Also the way in which availability of the 'libcxx'-feature for tests was determined was redundant, so this PR also cleans that up.