### PR TITLE
Provide klee runtime build type as parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ env:
     - ENABLE_OPTIMIZED: 1
     - ENABLE_DEBUG: 1
     - GTEST_VERSION: 1.7.0
+    - KLEE_RUNTIME_BUILD: "Debug+Asserts"
     - LLVM_VERSION: 6.0
     - METASMT_VERSION: qf_abv
     - MINISAT_VERSION: "master"
@@ -85,8 +86,8 @@ env:
     # Check at least one build with Asserts disabled.
     - SOLVERS=STP DISABLE_ASSERTIONS=1
 
-    # Check without TCMALLOC
-    - USE_TCMALLOC=0
+    # Check without TCMALLOC and with an optimised runtime library
+    - USE_TCMALLOC=0 KLEE_RUNTIME_BUILD="Release+Debug+Asserts"
 
     # Coverage build
     - ENABLE_OPTIMIZED=0 COVERAGE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ ENV STP_VERSION=2.3.3
 ENV MINISAT_VERSION=master
 ENV Z3_VERSION=4.8.4
 ENV USE_LIBCXX=1
+ENV KLEE_RUNTIME_BUILD="Debug+Asserts"
+
 COPY . /tmp/klee_src/
 RUN /tmp/klee_src//scripts/build/build.sh --debug --install-system-deps klee
 LABEL maintainer="KLEE Developers"

--- a/scripts/build/p-klee.inc
+++ b/scripts/build/p-klee.inc
@@ -138,6 +138,8 @@ fi
   else
     CMAKE_ARGUMENTS+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
+
+  CMAKE_ARGUMENTS+=("-DKLEE_RUNTIME_BUILD_TYPE=${KLEE_RUNTIME_BUILD}")
   
 # TODO: We should support Ninja too
 # Configure KLEE

--- a/scripts/build/v-klee.inc
+++ b/scripts/build/v-klee.inc
@@ -1,6 +1,7 @@
 # Build information for KLEE
 required_variables_klee=(
   "COVERAGE"
+  "KLEE_RUNTIME_BUILD"
   "USE_TCMALLOC"
   "USE_LIBCXX"
 )


### PR DESCRIPTION
Allow to build klee runtime with different build parameters using the build script.

Supersedes #1119 

