### PR TITLE
tests: fix Gen(Random)Bout.c: cd - command not found

### DIFF
--- a/runtime/POSIX/klee_init_env.c
+++ b/runtime/POSIX/klee_init_env.c
@@ -208,6 +208,8 @@ usage: (klee_init_env) [options] [program arguments]\n\
     } else if (__streq(argv[k], "--fd-fail") || __streq(argv[k], "-fd-fail")) {
       fd_fail = 1;
       k++;
+    } else if (__streq(argv[k], "--bout-file") || __streq(argv[k], "-bout-file")) {
+      k += 2;
     } else if (__streq(argv[k], "--max-fail") ||
                __streq(argv[k], "-max-fail")) {
       const char *msg = "--max-fail expects an integer argument <max-failures>";

--- a/test/Runtime/POSIX/GenBout.c
+++ b/test/Runtime/POSIX/GenBout.c
@@ -1,12 +1,16 @@
 // -- Core testing commands
 // RUN: rm -rf %t.out
-// RUN: mkdir -p %t.out && cd %t.out
-// RUN: echo -n aaaa > %t.aaaa.txt
-// RUN: echo -n bbbb > %t.bbbb.txt
-// RUN: echo -n cccc > %t.cccc.txt
-// RUN: %gen-bout -o -p -q file1 --sym-stdin %t.aaaa.txt --sym-file %t.bbbb.txt --sym-stdout %t.cccc.txt
+// RUN: rm -f %t.bout
+// RUN: mkdir -p %t.out
+// RUN: echo -n aaaa > %t.out/aaaa.txt
+// RUN: echo -n bbbb > %t.out/bbbb.txt
+// RUN: echo -n cccc > %t.out/cccc.txt
+// RUN: %gen-bout -o -p -q file1 --bout-file %t.bout --sym-stdin %t.out/aaaa.txt --sym-file %t.out/bbbb.txt --sym-stdout %t.out/cccc.txt
 // RUN: %cc %s -O0 -o %t
-// RUN: %klee-replay %t file.bout 2>&1 | grep "klee-replay: EXIT STATUS: NORMAL"
+// RUN: %klee-replay %t %t.bout 2> %t.out/out.txt
+// RUN: FileCheck --input-file=%t.out/out.txt %s
+
+// CHECK: klee-replay: EXIT STATUS: NORMAL
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -41,8 +45,6 @@ int check_file(const char *file_name, const int file_size) {
 }
 
 int main(int argc, char **argv) {
-  int i = 0;
-
   if (argc != 5)
     return 1;
 

--- a/test/Runtime/POSIX/GenRandomBout.c
+++ b/test/Runtime/POSIX/GenRandomBout.c
@@ -1,15 +1,17 @@
 // -- Core testing commands
-// RUN: rm -rf %t.out
-// RUN: mkdir -p %t.out && cd %t.out
-// RUN: %gen-random-bout 100 -sym-arg 4 -sym-files 2 20 -sym-arg 5 -sym-stdin 8 -sym-stdout -sym-arg 6 -sym-args 1 4 5
+// RUN: rm -f %t.bout
+// RUN: %gen-random-bout 100 -sym-arg 4 -sym-files 2 20 -sym-arg 5 -sym-stdin 8 -sym-stdout -sym-arg 6 -sym-args 1 4 5 -bout-file %t.bout
 // RUN: %cc %s -O0 -o %t
-// RUN: %klee-replay %t file.bout 2>&1 | grep "klee-replay: EXIT STATUS: NORMAL"
+// RUN: %klee-replay %t %t.bout 2> %t.out
+// RUN: FileCheck --input-file=%t.out %s
 //
 // -- Option error handling tests
 // RUN: bash -c '%gen-random-bout || :' 2>&1 | grep "Usage"
 // RUN: bash -c '%gen-random-bout 0 --unexpected-option || :' 2>&1 | grep "Unexpected"
 // RUN: bash -c '%gen-random-bout 100 --sym-args 5 3 || :' 2>&1 | grep "ran out of"
 // RUN: bash -c '%gen-random-bout 100 --sym-args 5 3 10 || :' 2>&1 | grep "should be no more"
+
+// CHECK: klee-replay: EXIT STATUS: NORMAL
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -75,7 +77,7 @@ int main(int argc, char **argv) {
   if (check_fd(1, 1024) < 0)
     return 1;
 
-  printf("All size tests passed\n");
+  puts("All size tests passed");
 
   return 0;
 }

--- a/tools/gen-bout/gen-bout.cpp
+++ b/tools/gen-bout/gen-bout.cpp
@@ -49,22 +49,23 @@ static void push_range(KTest *b, const char *name, unsigned value) {
 
 void print_usage_and_exit(char *program_name) {
   fprintf(stderr,
-          "%s: Tool for generating ktest file with concrete input, "
-          "e.g., for using a concrete crashing input as a ktest seed.\n",
-          program_name);
-  fprintf(stderr, "Usage: %s <arguments>\n", program_name);
-  fprintf(stderr, "       <arguments> are the command-line arguments of the "
-                  "programs, with the following treated as special:\n");
-  fprintf(stderr, "       --sym-stdin <filename>      - Specifying a file that "
-                  "is the content of the stdin (only once).\n");
-  fprintf(stderr, "       --sym-stdout <filename>     - Specifying a file that "
-                  "is the content of the stdout (only once).\n");
-  fprintf(stderr, "       --sym-file <filename>       - Specifying a file that "
-                  "is the content of a file named A provided for the program "
-                  "(only once).\n");
-  fprintf(stderr, "   Ex: %s -o -p -q file1 --sym-stdin file2 --sym-file file3 "
-                  "--sym-stdout file4\n",
-          program_name);
+          "%s: Tool for generating a ktest file from concrete input, "
+          "e.g., for using a concrete crashing input as a ktest seed.\n"
+          "Usage: %s <arguments>\n"
+          "       <arguments> are the command-line arguments of the "
+          "program, with the following treated as special:\n"
+          "       --bout-file <filename>      - Specifying the output "
+          "file name for the ktest file (default: file.bout).\n"
+          "       --sym-stdin <filename>      - Specifying a file that "
+          "is the content of stdin (only once).\n"
+          "       --sym-stdout <filename>     - Specifying a file that "
+          "is the content of stdout (only once).\n"
+          "       --sym-file <filename>       - Specifying a file that "
+          "is the content of a file named A provided for the program "
+          "(only once).\n"
+          "   Ex: %s -o -p -q file1 --sym-stdin file2 --sym-file file3 "
+          "--sym-stdout file4\n",
+          program_name, program_name, program_name);
   exit(1);
 }
 
@@ -75,6 +76,7 @@ int main(int argc, char *argv[]) {
   char *stdin_content_filename = NULL;
   char *content_filenames_list[1024];
   char **argv_copy;
+  char *bout_file = NULL;
 
   if (argc < 2)
     print_usage_and_exit(argv[0]);
@@ -121,6 +123,12 @@ int main(int argc, char *argv[]) {
         print_usage_and_exit(argv[0]);
 
       content_filenames_list[file_counter++] = argv[i];
+    } else if (strcmp(argv[i], "--bout-file") == 0 ||
+               strcmp(argv[i], "-bout-file") == 0) {
+      if (++i == (unsigned)argc)
+        print_usage_and_exit(argv[0]);
+
+      bout_file = argv[i];
     } else {
       long nbytes = strlen(argv[i]) + 1;
       static int total_args = 0;
@@ -260,7 +268,7 @@ int main(int argc, char *argv[]) {
 
   push_range(&b, "model_version", 1);
 
-  if (!kTest_toFile(&b, "file.bout"))
+  if (!kTest_toFile(&b, bout_file ? bout_file : "file.bout"))
     assert(0);
 
   for (int i = 0; i < (int)b.numObjects; ++i) {

--- a/tools/gen-random-bout/gen-random-bout.cpp
+++ b/tools/gen-random-bout/gen-random-bout.cpp
@@ -138,13 +138,14 @@ int main(int argc, char *argv[]) {
   unsigned total_files = 0;
   unsigned file_sizes[MAX_FILE_SIZES];
   char **argv_copy;
+  char *bout_file = NULL;
 
   if (argc < 2) {
     error_exit(
         "Usage: %s <random-seed> <argument-types>\n"
         "       If <random-seed> is 0, time(NULL)*getpid() is used as a seed\n"
         "       <argument-types> are the ones accepted by KLEE: --sym-args, "
-        "--sym-files etc.\n"
+        "--sym-files etc. and --bout-file <filename> for the output file (default: random.bout).\n"
         "   Ex: %s 100 --sym-args 0 2 2 --sym-files 1 8\n",
         argv[0], argv[0]);
   }
@@ -226,6 +227,12 @@ int main(int argc, char *argv[]) {
         file_sizes[total_files++] = nbytes;
       }
 
+    } else if (strcmp(argv[i], "--bout-file") == 0 ||
+               strcmp(argv[i], "-bout-file") == 0) {
+      if ((unsigned)argc == ++i)
+        error_exit("Missing file name for --bout-file");
+
+      bout_file = argv[i];
     } else {
       error_exit("Unexpected option <%s>\n", argv[i]);
     }
@@ -273,8 +280,8 @@ int main(int argc, char *argv[]) {
   }
   push_range(&b, "model_version", 1);
 
-  if (!kTest_toFile(&b, "file.bout")) {
-    error_exit("Error in storing data into file.bout\n");
+  if (!kTest_toFile(&b, bout_file ? bout_file : "random.bout")) {
+    error_exit("Error in storing data into random.bout\n");
   }
 
   for (i = 0; i < b.numObjects; ++i) {


### PR DESCRIPTION
Both tests fail on my system where `cd` is a shell builtin and not an installed command. Not sure how that works in Docker... looks like `lit` uses `subprocess.Popen` without shell.