### PR TITLE
ExecutorTimers: move dumpStates/dumpPTree into Executor

### DIFF
--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -479,6 +479,10 @@ private:
   void printDebugInstructions(ExecutionState &state);
   void doDumpStates();
 
+  /// Only for debug purposes; enable via debugger or klee-control
+  void dumpStates();
+  void dumpPTree();
+
 public:
   Executor(llvm::LLVMContext &ctx, const InterpreterOptions &opts,
       InterpreterHandler *ie);


### PR DESCRIPTION
* creates two new methods: dumpStates, dumpPTree

#1114 needs some refactoring beforehand and this rarely used dumping functionality is completely in the wrong place. In the long run these functions should move into a StateManager and the PTree.