### PR TITLE
add LLVM 9.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     ###########################################################################
 
     # Check a subset of the matrix of:
-    #   LLVM  : {3.8, 3.9, 4.0, 5.0, 6.0, 7}
+    #   LLVM  : {3.8, 3.9, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}
     #   SOLVERS : {Z3, STP, STP:Z3, metaSMT}
     #   STP_VERSION   : {2.3.3, master}
     #   METASMT_VERSION : {v4.rc1}
@@ -56,6 +56,7 @@ env:
 
     matrix:
     # Check supported LLVM versions
+    - LLVM_VERSION=9.0
     - LLVM_VERSION=8.0
     - LLVM_VERSION=7.0
     - LLVM_VERSION=6.0

--- a/lib/Module/Checks.cpp
+++ b/lib/Module/Checks.cpp
@@ -71,9 +71,9 @@ bool DivCheckPass::runOnModule(Module &M) {
 
   LLVMContext &ctx = M.getContext();
   KleeIRMetaData md(ctx);
-  auto divZeroCheckFunction = cast<Function>(
+  auto divZeroCheckFunction =
       M.getOrInsertFunction("klee_div_zero_check", Type::getVoidTy(ctx),
-                            Type::getInt64Ty(ctx) KLEE_LLVM_GOIF_TERMINATOR));
+                            Type::getInt64Ty(ctx) KLEE_LLVM_GOIF_TERMINATOR);
 
   for (auto &divInst : divInstruction) {
     llvm::IRBuilder<> Builder(divInst /* Inserts before divInst*/);
@@ -130,9 +130,9 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
   // Retrieve the checker function
   auto &ctx = M.getContext();
   KleeIRMetaData md(ctx);
-  auto overshiftCheckFunction = cast<Function>(M.getOrInsertFunction(
+  auto overshiftCheckFunction = M.getOrInsertFunction(
       "klee_overshift_check", Type::getVoidTy(ctx), Type::getInt64Ty(ctx),
-      Type::getInt64Ty(ctx) KLEE_LLVM_GOIF_TERMINATOR));
+      Type::getInt64Ty(ctx) KLEE_LLVM_GOIF_TERMINATOR);
 
   for (auto &shiftInst : shiftInstructions) {
     llvm::IRBuilder<> Builder(shiftInst);

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -296,7 +296,9 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
       case Intrinsic::objectsize: {
         // We don't know the size of an object in general so we replace
         // with 0 or -1 depending on the second argument to the intrinsic.
-#if LLVM_VERSION_CODE >= LLVM_VERSION(5, 0)
+#if LLVM_VERSION_CODE >= LLVM_VERSION(9, 0)
+        assert(ii->getNumArgOperands() == 4 && "wrong number of arguments");
+#elif LLVM_VERSION_CODE >= LLVM_VERSION(5, 0)
         assert(ii->getNumArgOperands() == 3 && "wrong number of arguments");
 #else
         assert(ii->getNumArgOperands() == 2 && "wrong number of arguments");
@@ -311,12 +313,22 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(5, 0)
         auto nullArg = ii->getArgOperand(2);
-        assert(nullArg && "Failed to get second argument");
+        assert(nullArg && "Failed to get third argument");
         auto nullArgAsInt = dyn_cast<ConstantInt>(nullArg);
         assert(nullArgAsInt && "Third arg is not a ConstantInt");
         assert(nullArgAsInt->getBitWidth() == 1 &&
                "Third argument is not an i1");
-	/* TODO should we do something with the 3rd argument? */
+        // TODO: should we do something with the 3rd argument?
+#endif
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(9, 0)
+        auto dynamicArg = ii->getArgOperand(3);
+        assert(dynamicArg && "Failed to get fourth argument");
+        auto dynamicArgAsInt = dyn_cast<ConstantInt>(dynamicArg);
+        assert(dynamicArgAsInt && "Fourth arg is not a ConstantInt");
+        assert(dynamicArgAsInt->getBitWidth() == 1 &&
+               "Fourth argument is not an i1");
+        // TODO: should we do something with the 4th argument?
 #endif
 
         Value *replacement = NULL;

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -140,10 +140,15 @@ static Function *getStubFunctionForCtorList(Module *m,
   if (arr) {
     for (unsigned i=0; i<arr->getNumOperands(); i++) {
       auto cs = cast<ConstantStruct>(arr->getOperand(i));
-      // There is a third *optional* element in global_ctor elements (``i8
-      // @data``).
+      // There is a third element in global_ctor elements (``i8 @data``).
+#if LLVM_VERSION_CODE >= LLVM_VERSION(9, 0)
+      assert(cs->getNumOperands() == 3 &&
+             "unexpected element in ctor initializer list");
+#else
+      // before LLVM 9.0, the third operand was optional
       assert((cs->getNumOperands() == 2 || cs->getNumOperands() == 3) &&
              "unexpected element in ctor initializer list");
+#endif
       auto fp = cs->getOperand(1);
       if (!fp->isNullValue()) {
         if (auto ce = dyn_cast<llvm::ConstantExpr>(fp))

--- a/lib/Solver/SolverCmdLine.cpp
+++ b/lib/Solver/SolverCmdLine.cpp
@@ -118,18 +118,15 @@ void KCommandLine::HideOptions(llvm::cl::OptionCategory &Category) {
   StringMap<cl::Option *> &map = cl::getRegisteredOptions();
 
   for (auto &elem : map) {
-    if (elem.second->Category == &Category) {
-      elem.second->setHiddenFlag(cl::Hidden);
-    }
-  }
-}
-
-void KCommandLine::HideUnrelatedOptions(cl::OptionCategory &Category) {
-  StringMap<cl::Option *> &map = cl::getRegisteredOptions();
-  for (StringMap<cl::Option *>::iterator i = map.begin(), e = map.end(); i != e;
-       i++) {
-    if (i->second->Category != &Category) {
-      i->second->setHiddenFlag(cl::Hidden);
+#if LLVM_VERSION_CODE >= LLVM_VERSION(9, 0)
+    for (auto &cat : elem.second->Categories) {
+#else
+    {
+      auto &cat = elem.second->Category;
+#endif
+      if (cat == &Category) {
+        elem.second->setHiddenFlag(cl::Hidden);
+      }
     }
   }
 }

--- a/runtime/klee-libc/bcmp.c
+++ b/runtime/klee-libc/bcmp.c
@@ -1,0 +1,19 @@
+/*===-- bcmp.c ------------------------------------------------------------===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===*/
+
+#include <strings.h>
+
+int bcmp(const void *s1, const void *s2, size_t n) {
+  const unsigned char *p1 = s1, *p2 = s2;
+  while (--n != 0) {
+    if (*p1++ != *p2++)
+      return 1;
+  }
+  return 0;
+}

--- a/test/Intrinsics/objectsize.leq80.ll
+++ b/test/Intrinsics/objectsize.leq80.ll
@@ -1,5 +1,6 @@
-; LLVM 9 added parameter "dynamic" to @llvm.objectsize
-; REQUIRES: geq-llvm-9.0
+; REQUIRES: lt-llvm-9.0
+; LLVM 5 added parameter "nullunknown" to @llvm.objectsize
+; REQUIRES: geq-llvm-5.0
 ; RUN: %llvmas %s -o=%t.bc
 ; RUN: rm -rf %t.klee-out
 ; RUN: %klee -exit-on-error --output-dir=%t.klee-out --optimize=false %t.bc
@@ -11,13 +12,13 @@ define i32 @main() nounwind uwtable {
 entry:
   %a = alloca i8*, align 8
   %0 = load i8*, i8** %a, align 8
-  %1 = call i64 @llvm.objectsize.i64.p0i8(i8* %0, i1 true, i1 false, i1 false)
+  %1 = call i64 @llvm.objectsize.i64.p0i8(i8* %0, i1 true, i1 false)
   %cmp = icmp ne i64 %1, 0
   br i1 %cmp, label %abort.block, label %continue.block
 
 continue.block:
   %2 = load i8*, i8** %a, align 8
-  %3 = call i64 @llvm.objectsize.i64.p0i8(i8* %2, i1 false, i1 false, i1 false)
+  %3 = call i64 @llvm.objectsize.i64.p0i8(i8* %2, i1 false, i1 false)
   %cmp1 = icmp ne i64 %3, -1
   br i1 %cmp1, label %abort.block, label %exit.block
 
@@ -29,6 +30,6 @@ abort.block:
   unreachable
 }
 
-declare i64 @llvm.objectsize.i64.p0i8(i8*, i1, i1, i1) nounwind readnone
+declare i64 @llvm.objectsize.i64.p0i8(i8*, i1, i1) nounwind readnone
 
 declare void @abort() noreturn nounwind

--- a/test/Runtime/FreeStanding/freestanding_only.c
+++ b/test/Runtime/FreeStanding/freestanding_only.c
@@ -26,6 +26,7 @@ int main(int argc, char **argv) {
 
   assert(memcmp(src, dst, LENGTH) == 0);
   // CHECK-NOT: calling external: memcmp
+  // CHECK-NOT: calling external: bcmp
 
   assert(*src == 42);
   assert(*src == *dst);

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -155,7 +155,7 @@ config.substitutions.append(
 
 # Add feature for the LLVM version in use, so it can be tested in REQUIRES and
 # XFAIL checks. We also add "not-XXX" variants, for the same reason.
-known_llvm_versions = set(["3.8", "3.9", "4.0", "5.0", "6.0", "7.0", "7.1", "8.0"])
+known_llvm_versions = set(["3.8", "3.9", "4.0", "5.0", "6.0", "7.0", "7.1", "8.0", "9.0"])
 current_llvm_version = "%s.%s" % (config.llvm_version_major,
                                   config.llvm_version_minor)
 


### PR DESCRIPTION
Significant changes in LLVM since 8.0:
* [multiple `OptionCategory`s allowed](https://reviews.llvm.org/rL360179)
* [altered signature of `getOrInsertFunction()`](https://reviews.llvm.org/rL352827)
* [`@llvm.objectsize()` has four parameters instead of three](https://reviews.llvm.org/rL352664)
* [third field in `@llvm.global_ctors` and `@llvm.global_dtors` is no longer optional](https://reviews.llvm.org/rL360742)
* [`memcpy()` may be converted to `bcmp()` under certain circumstances](https://reviews.llvm.org/rL355672)