### PR TITLE
Add option to dump proc tree to CSV file

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -405,10 +405,6 @@ namespace klee {
   RNG theRNG;
 }
 
-// XXX hack
-extern "C" unsigned dumpStates, dumpPTree;
-unsigned dumpStates = 0, dumpPTree = 0;
-
 const char *Executor::TerminateReasonNames[] = {
   [ Abort ] = "abort",
   [ Assert ] = "assert",
@@ -2908,8 +2904,6 @@ void Executor::run(ExecutionState &initialState) {
 
       executeInstruction(state, ki);
       processTimers(&state, maxInstructionTime * numSeeds);
-      if (::dumpStates) dumpStates();
-      if (::dumpPTree) dumpPTree();
       updateStates(&state);
 
       if ((stats::instructions % 1000) == 0) {
@@ -2964,8 +2958,6 @@ void Executor::run(ExecutionState &initialState) {
 
     executeInstruction(state, ki);
     processTimers(&state, maxInstructionTime);
-    if (::dumpStates) dumpStates();
-    if (::dumpPTree) dumpPTree();
 
     checkMemoryUsage();
 
@@ -4088,67 +4080,6 @@ int *Executor::getErrnoLocation(const ExecutionState &state) const {
 #else
   return __error();
 #endif
-}
-
-
-void Executor::dumpPTree() {
-  if (!::dumpPTree) return;
-
-  char name[32];
-  snprintf(name, sizeof(name),"ptree%08d.dot", (int) stats::instructions);
-  auto os = interpreterHandler->openOutputFile(name);
-  if (os) {
-    processTree->dump(*os);
-  }
-
-  ::dumpPTree = 0;
-}
-
-void Executor::dumpStates() {
-  if (!::dumpStates) return;
-
-  auto os = interpreterHandler->openOutputFile("states.txt");
-
-  if (os) {
-    for (ExecutionState *es : states) {
-      *os << "(" << es << ",";
-      *os << "[";
-      auto next = es->stack.begin();
-      ++next;
-      for (auto sfIt = es->stack.begin(), sf_ie = es->stack.end();
-           sfIt != sf_ie; ++sfIt) {
-        *os << "('" << sfIt->kf->function->getName().str() << "',";
-        if (next == es->stack.end()) {
-          *os << es->prevPC->info->line << "), ";
-        } else {
-          *os << next->caller->info->line << "), ";
-          ++next;
-        }
-      }
-      *os << "], ";
-
-      StackFrame &sf = es->stack.back();
-      uint64_t md2u = computeMinDistToUncovered(es->pc,
-                                                sf.minDistToUncoveredOnReturn);
-      uint64_t icnt = theStatisticManager->getIndexedValue(stats::instructions,
-                                                           es->pc->info->id);
-      uint64_t cpicnt = sf.callPathNode->statistics.getValue(stats::instructions);
-
-      *os << "{";
-      *os << "'depth' : " << es->depth << ", ";
-      *os << "'weight' : " << es->weight << ", ";
-      *os << "'queryCost' : " << es->queryCost << ", ";
-      *os << "'coveredNew' : " << es->coveredNew << ", ";
-      *os << "'instsSinceCovNew' : " << es->instsSinceCovNew << ", ";
-      *os << "'md2u' : " << md2u << ", ";
-      *os << "'icnt' : " << icnt << ", ";
-      *os << "'CPicnt' : " << cpicnt << ", ";
-      *os << "}";
-      *os << ")\n";
-    }
-  }
-
-  ::dumpStates = 0;
 }
 
 ///

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -238,9 +238,12 @@ private:
   /// Optimizes expressions
   ExprOptimizer optimizer;
 
+  // Out CSV file to
+  std::unique_ptr<llvm::raw_fd_ostream> os;
+
   llvm::Function* getTargetFunction(llvm::Value *calledVal,
                                     ExecutionState &state);
-  
+
   void executeInstruction(ExecutionState &state, KInstruction *ki);
 
   void printFileLine(ExecutionState &state, KInstruction *ki,
@@ -478,6 +481,11 @@ private:
   void checkMemoryUsage();
   void printDebugInstructions(ExecutionState &state);
   void doDumpStates();
+
+  /// Only for debug purposes; enable via debugger or klee-control
+  void dumpStates();
+  void dumpPTree();
+  void dumpPTreeCSV(PTreeNode *n);
 
 public:
   Executor(llvm::LLVMContext &ctx, const InterpreterOptions &opts,

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -479,10 +479,6 @@ private:
   void printDebugInstructions(ExecutionState &state);
   void doDumpStates();
 
-  /// Only for debug purposes; enable via debugger or klee-control
-  void dumpStates();
-  void dumpPTree();
-
 public:
   Executor(llvm::LLVMContext &ctx, const InterpreterOptions &opts,
       InterpreterHandler *ie);

--- a/lib/Core/ExecutorTimers.cpp
+++ b/lib/Core/ExecutorTimers.cpp
@@ -62,6 +62,10 @@ public:
 static const time::Span kMilliSecondsPerTick(time::milliseconds(100));
 static volatile unsigned timerTicks = 0;
 
+// XXX hack
+extern "C" unsigned dumpStates, dumpPTree;
+unsigned dumpStates = 0, dumpPTree = 0;
+
 static void onAlarm(int) {
   ++timerTicks;
 }
@@ -110,7 +114,63 @@ void Executor::processTimers(ExecutionState *current,
     ticks = 1;
   }
 
-  if (ticks) {
+  if (ticks || dumpPTree || dumpStates) {
+    if (dumpPTree) {
+      char name[32];
+      snprintf(name, sizeof(name), "ptree%08d.dot", (int) stats::instructions);
+      auto os = interpreterHandler->openOutputFile(name);
+      if (os) {
+        processTree->dump(*os);
+      }
+
+      dumpPTree = 0;
+    }
+
+    if (dumpStates) {
+      auto os = interpreterHandler->openOutputFile("states.txt");
+
+      if (os) {
+        for (ExecutionState *es : states) {
+          *os << "(" << es << ",";
+          *os << "[";
+          auto next = es->stack.begin();
+          ++next;
+          for (auto sfIt = es->stack.begin(), sf_ie = es->stack.end();
+               sfIt != sf_ie; ++sfIt) {
+            *os << "('" << sfIt->kf->function->getName().str() << "',";
+            if (next == es->stack.end()) {
+              *os << es->prevPC->info->line << "), ";
+            } else {
+              *os << next->caller->info->line << "), ";
+              ++next;
+            }
+          }
+          *os << "], ";
+
+          StackFrame &sf = es->stack.back();
+          uint64_t md2u = computeMinDistToUncovered(es->pc,
+                                                    sf.minDistToUncoveredOnReturn);
+          uint64_t icnt = theStatisticManager->getIndexedValue(stats::instructions,
+                                                               es->pc->info->id);
+          uint64_t cpicnt = sf.callPathNode->statistics.getValue(stats::instructions);
+
+          *os << "{";
+          *os << "'depth' : " << es->depth << ", ";
+          *os << "'weight' : " << es->weight << ", ";
+          *os << "'queryCost' : " << es->queryCost << ", ";
+          *os << "'coveredNew' : " << es->coveredNew << ", ";
+          *os << "'instsSinceCovNew' : " << es->instsSinceCovNew << ", ";
+          *os << "'md2u' : " << md2u << ", ";
+          *os << "'icnt' : " << icnt << ", ";
+          *os << "'CPicnt' : " << cpicnt << ", ";
+          *os << "}";
+          *os << ")\n";
+        }
+      }
+
+      dumpStates = 0;
+    }
+
     if (maxInstTime && current &&
         std::find(removedStates.begin(), removedStates.end(), current) ==
             removedStates.end()) {
@@ -123,10 +183,10 @@ void Executor::processTimers(ExecutionState *current,
     if (!timers.empty()) {
       auto time = time::getWallTime();
 
-      for (std::vector<TimerInfo*>::iterator it = timers.begin(),
+      for (std::vector<TimerInfo*>::iterator it = timers.begin(), 
              ie = timers.end(); it != ie; ++it) {
         TimerInfo *ti = *it;
-
+        
         if (time >= ti->nextFireTime) {
           ti->timer->run();
           ti->nextFireTime = time + ti->rate;

--- a/lib/Core/PTree.cpp
+++ b/lib/Core/PTree.cpp
@@ -9,8 +9,10 @@
 
 #include "PTree.h"
 
+#include "klee/ExecutionState.h"
 #include "klee/Expr/Expr.h"
 #include "klee/Expr/ExprPPrinter.h"
+#include "klee/Internal/Module/KInstruction.h"
 
 #include <vector>
 
@@ -45,6 +47,17 @@ void PTree::remove(Node *n) {
   } while (n && !n->left && !n->right);
 }
 
+void PTree::dumpCSV(Node *parent, llvm::raw_ostream &os) {
+  assert(parent && parent->left && parent->right);
+  auto left = parent->left;
+  auto right = parent->right;
+  os << parent->creationIndex << "," << left->creationIndex << ","
+     << left->data->prevPC->getSourceLocation() << "\n";
+
+  os << parent->creationIndex << "," << right->creationIndex << ","
+     << right->data->prevPC->getSourceLocation() << "\n";
+}
+
 void PTree::dump(llvm::raw_ostream &os) {
   ExprPPrinter *pp = ExprPPrinter::create(os);
   pp->setNewline("\\l");
@@ -77,6 +90,7 @@ void PTree::dump(llvm::raw_ostream &os) {
   delete pp;
 }
 
-PTreeNode::PTreeNode(PTreeNode * parent, ExecutionState * data)
-  : parent{parent}, data{data} {}
+int PTreeNode::nextIndex = 0;
 
+PTreeNode::PTreeNode(PTreeNode *parent, ExecutionState *data)
+    : parent{parent}, data{data}, creationIndex{nextIndex++} {}

--- a/lib/Core/PTree.h
+++ b/lib/Core/PTree.h
@@ -12,6 +12,8 @@
 
 #include "klee/Expr/Expr.h"
 
+#include <fstream>
+
 namespace klee {
   class ExecutionState;
 
@@ -31,6 +33,7 @@ namespace klee {
     void remove(Node *n);
 
     void dump(llvm::raw_ostream &os);
+    void dumpCSV(Node *parent, llvm::raw_ostream &os);
   };
 
   class PTreeNode {
@@ -42,6 +45,8 @@ namespace klee {
     ExecutionState *data = nullptr;
 
   private:
+    static int nextIndex;
+    int creationIndex;
     PTreeNode(PTreeNode * parent, ExecutionState * data);
     ~PTreeNode() = default;
   };

--- a/test/Feature/DumpProcessTree.c
+++ b/test/Feature/DumpProcessTree.c
@@ -1,0 +1,27 @@
+// RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee  -output-exec-tree --output-dir=%t.klee-out  %t.bc 2> %t.log
+// RUN: FileCheck -check-prefix=CHECK-CSV -input-file=%t.klee-out/ptree00000000.csv %s
+
+#include "klee/klee.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int get_sign(int x) {
+  if (x == 0)
+    return 0;
+
+  if (x < 0)
+    return -1;
+  else
+    return 1;
+}
+
+int main() {
+  int a;
+  klee_make_symbolic(&a, sizeof(a), "a");
+  get_sign(a);
+  return 0;
+}
+// Check we find a line with the expected format
+// CHECK-CSV: parent,child,location


### PR DESCRIPTION
Is there a better way of opening the csv file in the klee-last directory than hard coding it (line 27 of PTree.cpp)?

And is it worth having a local variable (PTree.h) to store whether we should dump the process tree or just call the StatsTracker::dumpProcessTree() function?