### PR TITLE
simplify PTree API

### DIFF
--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -136,7 +136,7 @@ private:
   TreeStreamWriter *pathWriter, *symPathWriter;
   SpecialFunctionHandler *specialFunctionHandler;
   std::vector<TimerInfo*> timers;
-  PTree *processTree;
+  std::unique_ptr<PTree> processTree;
 
   /// Keeps track of all currently ongoing merges.
   /// An ongoing merge is a set of states which branched from a single state

--- a/lib/Core/PTree.cpp
+++ b/lib/Core/PTree.cpp
@@ -18,16 +18,15 @@
 using namespace klee;
 
 PTree::PTree(ExecutionState *initialState) {
-  root = new PTreeNode(nullptr, initialState);
-  initialState->ptreeNode = root;
+  root = std::make_unique<PTreeNode>(nullptr, initialState);
 }
 
 void PTree::attach(PTreeNode *node, ExecutionState *leftState, ExecutionState *rightState) {
   assert(node && !node->left && !node->right);
 
   node->state = nullptr;
-  node->left = new PTreeNode(node, leftState);
-  node->right = new PTreeNode(node, rightState);
+  node->left = std::make_unique<PTreeNode>(node, leftState);
+  node->right = std::make_unique<PTreeNode>(node, rightState);
 }
 
 void PTree::remove(PTreeNode *n) {
@@ -35,14 +34,13 @@ void PTree::remove(PTreeNode *n) {
   do {
     PTreeNode *p = n->parent;
     if (p) {
-      if (n == p->left) {
+      if (n == p->left.get()) {
         p->left = nullptr;
       } else {
-        assert(n == p->right);
+        assert(n == p->right.get());
         p->right = nullptr;
       }
     }
-    delete n;
     n = p;
   } while (n && !n->left && !n->right);
 }
@@ -58,7 +56,7 @@ void PTree::dump(llvm::raw_ostream &os) {
   os << "\tnode [style=\"filled\",width=.1,height=.1,fontname=\"Terminus\"]\n";
   os << "\tedge [arrowsize=.3]\n";
   std::vector<const PTreeNode*> stack;
-  stack.push_back(root);
+  stack.push_back(root.get());
   while (!stack.empty()) {
     const PTreeNode *n = stack.back();
     stack.pop_back();
@@ -67,12 +65,12 @@ void PTree::dump(llvm::raw_ostream &os) {
       os << ",fillcolor=green";
     os << "];\n";
     if (n->left) {
-      os << "\tn" << n << " -> n" << n->left << ";\n";
-      stack.push_back(n->left);
+      os << "\tn" << n << " -> n" << n->left.get() << ";\n";
+      stack.push_back(n->left.get());
     }
     if (n->right) {
-      os << "\tn" << n << " -> n" << n->right << ";\n";
-      stack.push_back(n->right);
+      os << "\tn" << n << " -> n" << n->right.get() << ";\n";
+      stack.push_back(n->right.get());
     }
   }
   os << "}\n";

--- a/lib/Core/PTree.h
+++ b/lib/Core/PTree.h
@@ -15,35 +15,27 @@
 namespace klee {
   class ExecutionState;
 
-  class PTree { 
-    typedef ExecutionState* data_type;
-
-  public:
-    typedef class PTreeNode Node;
-    Node *root;
-
-    explicit PTree(const data_type &_root);
-    ~PTree() = default;
-    
-    std::pair<Node*,Node*> split(Node *n,
-                                 const data_type &leftData,
-                                 const data_type &rightData);
-    void remove(Node *n);
-
-    void dump(llvm::raw_ostream &os);
-  };
-
   class PTreeNode {
-    friend class PTree;
   public:
     PTreeNode *parent = nullptr;
     PTreeNode *left = nullptr;
     PTreeNode *right = nullptr;
-    ExecutionState *data = nullptr;
+    ExecutionState *state = nullptr;
 
-  private:
-    PTreeNode(PTreeNode * parent, ExecutionState * data);
+    PTreeNode(const PTreeNode&) = delete;
+    PTreeNode(PTreeNode *parent, ExecutionState *state);
     ~PTreeNode() = default;
+  };
+
+  class PTree {
+  public:
+    PTreeNode * root = nullptr;
+    explicit PTree(ExecutionState *initialState);
+    ~PTree() = default;
+
+    static void attach(PTreeNode *node, ExecutionState *leftState, ExecutionState *rightState);
+    static void remove(PTreeNode *node);
+    void dump(llvm::raw_ostream &os);
   };
 }
 

--- a/lib/Core/PTree.h
+++ b/lib/Core/PTree.h
@@ -18,8 +18,8 @@ namespace klee {
   class PTreeNode {
   public:
     PTreeNode *parent = nullptr;
-    PTreeNode *left = nullptr;
-    PTreeNode *right = nullptr;
+    std::unique_ptr<PTreeNode> left;
+    std::unique_ptr<PTreeNode> right;
     ExecutionState *state = nullptr;
 
     PTreeNode(const PTreeNode&) = delete;
@@ -29,7 +29,7 @@ namespace klee {
 
   class PTree {
   public:
-    PTreeNode * root = nullptr;
+    std::unique_ptr<PTreeNode> root;
     explicit PTree(ExecutionState *initialState);
     ~PTree() = default;
 

--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -264,19 +264,19 @@ RandomPathSearcher::~RandomPathSearcher() {
 
 ExecutionState &RandomPathSearcher::selectState() {
   unsigned flips=0, bits=0;
-  PTreeNode *n = executor.processTree->root;
+  PTreeNode *n = executor.processTree->root.get();
   while (!n->state) {
     if (!n->left) {
-      n = n->right;
+      n = n->right.get();
     } else if (!n->right) {
-      n = n->left;
+      n = n->left.get();
     } else {
       if (bits==0) {
         flips = theRNG.getInt32();
         bits = 32;
       }
       --bits;
-      n = (flips&(1<<bits)) ? n->left : n->right;
+      n = (flips&(1<<bits)) ? n->left.get() : n->right.get();
     }
   }
 

--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -264,8 +264,8 @@ RandomPathSearcher::~RandomPathSearcher() {
 
 ExecutionState &RandomPathSearcher::selectState() {
   unsigned flips=0, bits=0;
-  PTree::Node *n = executor.processTree->root;
-  while (!n->data) {
+  PTreeNode *n = executor.processTree->root;
+  while (!n->state) {
     if (!n->left) {
       n = n->right;
     } else if (!n->right) {
@@ -280,7 +280,7 @@ ExecutionState &RandomPathSearcher::selectState() {
     }
   }
 
-  return *n->data;
+  return *n->state;
 }
 
 void


### PR DESCRIPTION
This patch
* replaces `split()` with `attach()`
* adds `unique_ptr`s
* removes some unnecessary type aliases/abstractions

Overall it should make #1141 even shorter as the code duplication in Executor is not needed anymore.