### PR TITLE
Remove legacy from tests

### DIFF
--- a/test/Expr/Evaluate2.kquery
+++ b/test/Expr/Evaluate2.kquery
@@ -2,4 +2,5 @@
 
 # RUN: grep "Query 0:	VALID" %t.log
 # XFAIL: *
+# see https://github.com/klee/klee/issues/97
 (query [false] false)

--- a/test/Feature/SolverTimeout.c
+++ b/test/Feature/SolverTimeout.c
@@ -1,9 +1,9 @@
-// RUN: %clang %s -emit-llvm %O0opt -c -o %t1.bc
+// RUN: %clang %s -emit-llvm %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --max-solver-time=1 %t1.bc
-// FIXME: This test occasionally fails when using Z3 4.4.1 but
-// not when using Z3 from the master branch. So disable the test for now.
-// REQUIRES: stp
+// RUN: %klee --output-dir=%t.klee-out --max-solver-time=1 %t.bc
+//
+// Note: This test occasionally fails when using Z3 4.4.1
+
 #include <stdio.h>
 
 int main() {

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -39,12 +39,12 @@ if klee_obj_root is not None:
 if klee_obj_root is not None:
   klee_tools_dir = getattr(config, 'klee_tools_dir', None)
   if not klee_tools_dir:
-    lit.fatal('No KLEE tools dir set!')
+    lit_config.fatal('No KLEE tools dir set!')
 
   # Check LLVM tool directory
   llvm_tools_dir = getattr(config, 'llvm_tools_dir', None)
   if not llvm_tools_dir:
-    lit.fatal('No LLVM tool directory set!')
+    lit_config.fatal('No LLVM tool directory set!')
 
   path = os.path.pathsep.join(
     (
@@ -80,7 +80,7 @@ addEnv('CPLUS_INCLUDE_PATH')
 
 # Check that the object root is known.
 if config.test_exec_root is None:
-  lit.fatal('test execution root not set!')
+  lit_config.fatal('test execution root not set!')
 
 
 # Add substitutions from lit.site.cfg
@@ -88,7 +88,7 @@ subs = [ 'clangxx', 'clang', 'cc', 'cxx', 'O0opt' ]
 for name in subs:
   value = getattr(config, name, None)
   if value == None:
-    lit.fatal('{0} is not set'.format(name))
+    lit_config.fatal('{0} is not set'.format(name))
   config.substitutions.append( ('%' + name, value))
 
 # Add a substitution for lli.
@@ -114,14 +114,8 @@ config.substitutions.append(
 
 # Get KLEE and Kleaver specific parameters passed on llvm-lit cmd line
 # e.g. llvm-lit --param klee_opts=--help
-try:
-  lit.params
-except AttributeError:
-  klee_extra_params = lit_config.params.get('klee_opts',"")
-  kleaver_extra_params = lit_config.params.get('kleaver_opts',"")
-else:
-  klee_extra_params = lit.params.get('klee_opts',"")
-  kleaver_extra_params = lit.params.get('kleaver_opts',"")
+klee_extra_params = lit_config.params.get('klee_opts',"")
+kleaver_extra_params = lit_config.params.get('kleaver_opts',"")
 
 if len(klee_extra_params) != 0:
   print("Passing extra KLEE command line args: {0}".format(

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -155,7 +155,7 @@ config.substitutions.append(
 
 # Add feature for the LLVM version in use, so it can be tested in REQUIRES and
 # XFAIL checks. We also add "not-XXX" variants, for the same reason.
-known_llvm_versions = set(["3.8", "3.9", "4.0", "5.0", "6.0", "7.0", "8.0"])
+known_llvm_versions = set(["3.8", "3.9", "4.0", "5.0", "6.0", "7.0", "7.1", "8.0"])
 current_llvm_version = "%s.%s" % (config.llvm_version_major,
                                   config.llvm_version_minor)
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -158,6 +158,11 @@ config.substitutions.append(
 known_llvm_versions = set(["3.8", "3.9", "4.0", "5.0", "6.0", "7.0", "8.0"])
 current_llvm_version = "%s.%s" % (config.llvm_version_major,
                                   config.llvm_version_minor)
+
+if current_llvm_version not in known_llvm_versions:
+  lit_config.fatal("LLVM Version %s is not listed in known_llvm_versions!"
+                   % current_llvm_version)
+
 config.available_features.add("llvm-" + current_llvm_version)
 for version in known_llvm_versions:
   if version != current_llvm_version:


### PR DESCRIPTION
Get rid of some legacy code:
* Since LLVM version 3.6.0 or lit version 0.5.0, `lit_config` is the name of the global object, not `lit`.
* In `lit.cfg`, test whether the current LLVM version is in the set of known versions.
* re-enable `SolverTimeout.c` test that "occasionally fails when using Z3 4.4.1" (from 2015)

---

Other than this, I stumbled upon https://github.com/klee/klee/blob/0fd707b62988ed25c31242eb3d858895d96eb619/test/Expr/Evaluate2.kquery#L1-L5
which is in its current form since d786ba65b69c57fec0804d4a529682844ac2d411 stating "(query [false] false), which should return VALID, [...] currently returns INVALID". Indeed, Kleaver still returns INVALID, but I fail to see the reason why it should return VALID.