### PR TITLE
Compile fd_64.c file of POSIX runtime correctly on FreeBSD

### DIFF
--- a/runtime/POSIX/FreeBSD.h
+++ b/runtime/POSIX/FreeBSD.h
@@ -13,7 +13,9 @@
 // for various typedefs inside FreeBSD headers
 #define __BSD_VISIBLE   1
 
+#ifndef INSIDE_FD_64
 #define stat64 stat
+#endif
 
 #include <sys/syscall.h>
 
@@ -434,5 +436,20 @@ struct rlimit64;
 #define	__NR_numa_getaffinity	SYS_numa_getaffinity
 #define	__NR_numa_setaffinity	SYS_numa_setaffinity
 #define	__NR_MAXSYSCALL	SYS_MAXSYSCALL
+
+// we are in fd_64.c, add "64" suffix to its functions
+#ifdef INSIDE_FD_64
+
+#define open open64
+#define openat openat64
+#define lseek lseek64
+#define __xstat __xstat64
+#define stat stat64
+#define __lxstat __lxstat64
+#define lstat lstat64
+#define __fxstat __fxstat64
+#define fstat fstat64
+
+#endif
 
 #endif /* KLEE_FREEBSD_H */

--- a/runtime/POSIX/fd_64.c
+++ b/runtime/POSIX/fd_64.c
@@ -15,6 +15,7 @@
 #endif
 #endif
 
+#define INSIDE_FD_64
 #define _LARGEFILE64_SOURCE
 #define _FILE_OFFSET_BITS 64
 #include "fd.h"


### PR DESCRIPTION
Append "64" suffix to function names.