### PR TITLE
[expr-visitor] Remove unnecessary allocation

### DIFF
--- a/include/klee/Expr/ExprVisitor.h
+++ b/include/klee/Expr/ExprVisitor.h
@@ -23,7 +23,7 @@ namespace klee {
     private:
       //      Action() {}
       Action(Kind _kind) 
-        : kind(_kind), argument(ConstantExpr::alloc(0, Expr::Bool)) {}
+        : kind(_kind), argument(nullptr) {}
       Action(Kind _kind, const ref<Expr> &_argument) 
         : kind(_kind), argument(_argument) {}
 


### PR DESCRIPTION
I don't see any reason for this ConstantExpr to be allocated and it actually takes a lot of time as these Action objects keep getting created when using ExprVisitor.