### PR TITLE
Core: Executor, remove unused variable

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2896,7 +2896,6 @@ void Executor::run(ExecutionState &initialState) {
       if (it == seedMap.end())
         it = seedMap.begin();
       lastState = it->first;
-      unsigned numSeeds = it->second.size();
       ExecutionState &state = *lastState;
       KInstruction *ki = state.pc;
       stepInstruction(state);


### PR DESCRIPTION
`numSeeds` is unused since commit 4eb050e2999b (ExecutorTimers: refactor
and move to support lib), so remove it.