### PR TITLE
Use default travis OS X version instead of outdated old one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,6 @@ env:
 matrix:
   include:
     - os: osx
-      osx_image: xcode8.3
       env: SOLVERS=STP UCLIBC_VERSION=0 USE_TCMALLOC=0 USE_LIBCXX=0
     - env: BUILD_DOCKER=1
 addons:


### PR DESCRIPTION
Travis OS X is complaining about an outdated version.

Use the default one instead of the old one.
This should fix all the build issues we currently observe related to Mac OSX.