### PR TITLE
Add easy way of adding stats

### DIFF
--- a/include/klee/Solver/SolverStats.h
+++ b/include/klee/Solver/SolverStats.h
@@ -15,21 +15,21 @@
 namespace klee {
 namespace stats {
 
-  extern Statistic cexCacheTime;
-  extern Statistic queries;
-  extern Statistic queriesInvalid;
-  extern Statistic queriesValid;
-  extern Statistic queryCacheHits;
-  extern Statistic queryCacheMisses;
-  extern Statistic queryCexCacheHits;
-  extern Statistic queryCexCacheMisses;
-  extern Statistic queryConstructTime;
-  extern Statistic queryConstructs;
-  extern Statistic queryCounterexamples;
-  extern Statistic queryTime;
-  
+extern SQLIntStatistic cexCacheTime;
+extern SQLIntStatistic queries;
+extern SQLIntStatistic queriesInvalid;
+extern SQLIntStatistic queriesValid;
+extern SQLIntStatistic queryCacheHits;
+extern SQLIntStatistic queryCacheMisses;
+extern SQLIntStatistic queryCexCacheHits;
+extern SQLIntStatistic queryCexCacheMisses;
+extern SQLIntStatistic queryConstructTime;
+extern SQLIntStatistic queryConstructs;
+extern SQLIntStatistic queryCounterexamples;
+extern SQLIntStatistic queryTime;
+
 #ifdef KLEE_ARRAY_DEBUG
-  extern Statistic arrayHashTime;
+extern SQLIntStatistic arrayHashTime;
 #endif
 
 }

--- a/include/klee/Statistic.h
+++ b/include/klee/Statistic.h
@@ -13,9 +13,12 @@
 #include "klee/Config/Version.h"
 #include "llvm/Support/DataTypes.h"
 #include <string>
+#include <vector>
 
 namespace klee {
   class Statistic;
+  class StatsTracker;
+  class SQLIntStatistic;
   class StatisticManager;
   class StatisticRecord;
 
@@ -60,6 +63,16 @@ namespace klee {
 
     /// operator+= - Increment the statistic by \arg addend.
     Statistic &operator +=(const uint64_t addend);
+  };
+
+  class SQLIntStatistic : public Statistic {
+  public:
+    const uint16_t verbosityLevel;
+    static std::vector<SQLIntStatistic *> *sqlStatistics;
+    SQLIntStatistic(const std::string &_name, const std::string &_shortName,
+                    uint16_t verbosityLevel = 0);
+
+    ~SQLIntStatistic();
   };
 }
 

--- a/lib/Basic/Statistics.cpp
+++ b/lib/Basic/Statistics.cpp
@@ -82,3 +82,21 @@ Statistic &Statistic::operator +=(const uint64_t addend) {
 uint64_t Statistic::getValue() const {
   return theStatisticManager->getValue(*this);
 }
+
+std::vector<SQLIntStatistic *> *SQLIntStatistic::sqlStatistics = nullptr;
+
+SQLIntStatistic::SQLIntStatistic(const std::string &_name,
+                                 const std::string &_shortName, uint16_t v)
+    : Statistic(_name, _shortName), verbosityLevel(v) {
+  if (!sqlStatistics) {
+    sqlStatistics = new std::vector<SQLIntStatistic *>();
+  }
+  sqlStatistics->push_back(this);
+}
+
+SQLIntStatistic::~SQLIntStatistic() {
+  if (sqlStatistics) {
+    delete sqlStatistics;
+    sqlStatistics = nullptr;
+  }
+}

--- a/lib/Core/CoreStats.cpp
+++ b/lib/Core/CoreStats.cpp
@@ -11,19 +11,19 @@
 
 using namespace klee;
 
-Statistic stats::allocations("Allocations", "Alloc");
-Statistic stats::coveredInstructions("CoveredInstructions", "Icov");
+SQLIntStatistic stats::allocations("Allocations", "Alloc", 1);
+SQLIntStatistic stats::coveredInstructions("CoveredInstructions", "Icov");
 Statistic stats::falseBranches("FalseBranches", "Bf");
-Statistic stats::forkTime("ForkTime", "Ftime");
+SQLIntStatistic stats::forkTime("ForkTime", "Ftime");
 Statistic stats::forks("Forks", "Forks");
 Statistic stats::instructionRealTime("InstructionRealTimes", "Ireal");
 Statistic stats::instructionTime("InstructionTimes", "Itime");
-Statistic stats::instructions("Instructions", "I");
+SQLIntStatistic stats::instructions("Instructions", "I");
 Statistic stats::minDistToReturn("MinDistToReturn", "Rdist");
 Statistic stats::minDistToUncovered("MinDistToUncovered", "UCdist");
 Statistic stats::reachableUncovered("ReachableUncovered", "IuncovReach");
-Statistic stats::resolveTime("ResolveTime", "Rtime");
-Statistic stats::solverTime("SolverTime", "Stime");
+SQLIntStatistic stats::resolveTime("ResolveTime", "Rtime");
+SQLIntStatistic stats::solverTime("SolverTime", "Stime");
 Statistic stats::states("States", "States");
 Statistic stats::trueBranches("TrueBranches", "Bt");
-Statistic stats::uncoveredInstructions("UncoveredInstructions", "Iuncov");
+SQLIntStatistic stats::uncoveredInstructions("UncoveredInstructions", "Iuncov");

--- a/lib/Core/CoreStats.h
+++ b/lib/Core/CoreStats.h
@@ -15,37 +15,37 @@
 namespace klee {
 namespace stats {
 
-  extern Statistic allocations;
-  extern Statistic resolveTime;
-  extern Statistic instructions;
-  extern Statistic instructionTime;
-  extern Statistic instructionRealTime;
-  extern Statistic coveredInstructions;
-  extern Statistic uncoveredInstructions;  
-  extern Statistic trueBranches;
-  extern Statistic falseBranches;
-  extern Statistic forkTime;
-  extern Statistic solverTime;
+extern SQLIntStatistic allocations;
+extern SQLIntStatistic resolveTime;
+extern SQLIntStatistic instructions;
+extern Statistic instructionTime;
+extern Statistic instructionRealTime;
+extern SQLIntStatistic coveredInstructions;
+extern SQLIntStatistic uncoveredInstructions;
+extern Statistic trueBranches;
+extern Statistic falseBranches;
+extern SQLIntStatistic forkTime;
+extern SQLIntStatistic solverTime;
 
-  /// The number of process forks.
-  extern Statistic forks;
+/// The number of process forks.
+extern Statistic forks;
 
-  /// Number of states, this is a "fake" statistic used by istats, it
-  /// isn't normally up-to-date.
-  extern Statistic states;
+/// Number of states, this is a "fake" statistic used by istats, it
+/// isn't normally up-to-date.
+extern Statistic states;
 
-  /// Instruction level statistic for tracking number of reachable
-  /// uncovered instructions.
-  extern Statistic reachableUncovered;
+/// Instruction level statistic for tracking number of reachable
+/// uncovered instructions.
+extern Statistic reachableUncovered;
 
-  /// Instruction level statistic tracking the minimum intraprocedural
-  /// distance to an uncovered instruction; this is only periodically
-  /// updated.
-  extern Statistic minDistToUncovered;
+/// Instruction level statistic tracking the minimum intraprocedural
+/// distance to an uncovered instruction; this is only periodically
+/// updated.
+extern Statistic minDistToUncovered;
 
-  /// Instruction level statistic tracking the minimum intraprocedural
-  /// distance to a function return.
-  extern Statistic minDistToReturn;
+/// Instruction level statistic tracking the minimum intraprocedural
+/// distance to a function return.
+extern Statistic minDistToReturn;
 
 }
 }

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -476,7 +476,6 @@ void StatsTracker::writeStatsHeader() {
              << "MallocUsage ,"
              << "NumQueries ,"
              << "NumQueryConstructs ,"
-             << "NumObjects ,"
              << "WallTime ,"
              << "CoveredInstructions ,"
              << "UncoveredInstructions ,"
@@ -491,7 +490,6 @@ void StatsTracker::writeStatsHeader() {
 #endif
              << "QueryCexCacheHits "
              << ") VALUES ( "
-             << "?, "
              << "?, "
              << "?, "
              << "?, "
@@ -535,7 +533,6 @@ void StatsTracker::writeStatsLine() {
   sqlite3_bind_int64(insertStmt, 7, util::GetTotalMallocUsage() + executor.memory->getUsedDeterministicSize());
   sqlite3_bind_int64(insertStmt, 8, stats::queries);
   sqlite3_bind_int64(insertStmt, 9, stats::queryConstructs);
-  sqlite3_bind_int64(insertStmt, 10, 0);  // was numObjects
   sqlite3_bind_int64(insertStmt, 11, elapsed().toMicroseconds());
   sqlite3_bind_int64(insertStmt, 12, stats::coveredInstructions);
   sqlite3_bind_int64(insertStmt, 13, stats::uncoveredInstructions);

--- a/lib/Solver/SolverStats.cpp
+++ b/lib/Solver/SolverStats.cpp
@@ -11,19 +11,19 @@
 
 using namespace klee;
 
-Statistic stats::cexCacheTime("CexCacheTime", "CCtime");
-Statistic stats::queries("Queries", "Q");
-Statistic stats::queriesInvalid("QueriesInvalid", "Qiv");
-Statistic stats::queriesValid("QueriesValid", "Qv");
-Statistic stats::queryCacheHits("QueryCacheHits", "QChits") ;
-Statistic stats::queryCacheMisses("QueryCacheMisses", "QCmisses");
-Statistic stats::queryCexCacheHits("QueryCexCacheHits", "QCexHits") ;
-Statistic stats::queryCexCacheMisses("QueryCexCacheMisses", "QCexMisses");
-Statistic stats::queryConstructTime("QueryConstructTime", "QBtime") ;
-Statistic stats::queryConstructs("QueriesConstructs", "QB");
-Statistic stats::queryCounterexamples("QueriesCEX", "Qcex");
-Statistic stats::queryTime("QueryTime", "Qtime");
+SQLIntStatistic stats::cexCacheTime("CexCacheTime", "CCtime");
+SQLIntStatistic stats::queries("Queries", "Q");
+SQLIntStatistic stats::queriesInvalid("QueriesInvalid", "Qiv", 1);
+SQLIntStatistic stats::queriesValid("QueriesValid", "Qv", 1);
+SQLIntStatistic stats::queryCacheHits("QueryCacheHits", "QChits", 1);
+SQLIntStatistic stats::queryCacheMisses("QueryCacheMisses", "QCmisses", 1);
+SQLIntStatistic stats::queryCexCacheHits("QueryCexCacheHits", "QCexHits");
+SQLIntStatistic stats::queryCexCacheMisses("QueryCexCacheMisses", "QCexMisses");
+SQLIntStatistic stats::queryConstructTime("QueryConstructTime", "QBtime", 1);
+SQLIntStatistic stats::queryConstructs("QueriesConstructs", "QB");
+SQLIntStatistic stats::queryCounterexamples("QueriesCEX", "Qcex", 1);
+SQLIntStatistic stats::queryTime("QueryTime", "Qtime");
 
 #ifdef KLEE_ARRAY_DEBUG
-Statistic stats::arrayHashTime("ArrayHashTime", "AHtime");
+SQLIntStatistic stats::arrayHashTime("ArrayHashTime", "AHtime");
 #endif

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -67,7 +67,7 @@ class LazyEvalList:
         # The first line in the records contains headers.
       self.conn = sqlite3.connect(fileName)
       self.c = self.conn.cursor()
-      self.c.execute("SELECT Instructions, FullBranches, PartialBranches, NumBranches, UserTime, NumStates, MallocUsage, NumQueries, NumQueryConstructs, 0, WallTime, CoveredInstructions, UncoveredInstructions, QueryTime, SolverTime, CexCacheTime, ForkTime, ResolveTime, QueryCexCacheMisses, QueryCexCacheHits  FROM stats ORDER BY Instructions DESC LIMIT 1")
+      self.c.execute("SELECT Instructions, FullBranches, PartialBranches, NumBranches, UserTime, NumStates, MallocUsage, Queries, QueriesConstructs, 0, WallTime, CoveredInstructions, UncoveredInstructions, QueryTime, SolverTime, CexCacheTime, ForkTime, ResolveTime, QueryCexCacheMisses, QueryCexCacheHits  FROM stats ORDER BY Instructions DESC LIMIT 1")
       self.line = self.c.fetchone()
 
     def aggregateRecords(self):
@@ -302,7 +302,7 @@ def main():
         import csv
         data = data[0]
         c = data.conn.cursor()
-        sql3_cursor = c.execute("SELECT * FROM stats")
+        sql3_cursor = c.execute("SELECT Instructions, FullBranches, PartialBranches, NumBranches, UserTime, NumStates, MallocUsage, Queries, QueriesConstructs, 0, WallTime, CoveredInstructions, UncoveredInstructions, QueryTime, SolverTime, CexCacheTime, ForkTime, ResolveTime, QueryCexCacheMisses, QueryCexCacheHits  FROM stats")
         csv_out = csv.writer(sys.stdout)
         # write header                        
         csv_out.writerow([d[0] for d in sql3_cursor.description])

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -67,7 +67,7 @@ class LazyEvalList:
         # The first line in the records contains headers.
       self.conn = sqlite3.connect(fileName)
       self.c = self.conn.cursor()
-      self.c.execute("SELECT * FROM stats ORDER BY Instructions DESC LIMIT 1")
+      self.c.execute("SELECT Instructions, FullBranches, PartialBranches, NumBranches, UserTime, NumStates, MallocUsage, NumQueries, NumQueryConstructs, 0, WallTime, CoveredInstructions, UncoveredInstructions, QueryTime, SolverTime, CexCacheTime, ForkTime, ResolveTime, QueryCexCacheMisses, QueryCexCacheHits  FROM stats ORDER BY Instructions DESC LIMIT 1")
       self.line = self.c.fetchone()
 
     def aggregateRecords(self):


### PR DESCRIPTION
This patch enables easily adding statistics to the `run.stats` file. This both cleans up StatsTracker a bit and makes adding stats effortless, by simply adidng ad `SQLIntStatistic` variable and incrementing it as desired.

It moves most of the existing stats to this system. Since there are some statistics that are gathered but not used I added a verbosity flag that enables the option of writing those unused statistics too.

A nice property of this is that `klee-stats` should now work with any addition to the stats file and will ignore additional columns. 