### PR TITLE
Remove trailing whitespaces form KLEE code base.

### DIFF
--- a/examples/get_sign/get_sign.c
+++ b/examples/get_sign/get_sign.c
@@ -7,15 +7,15 @@
 int get_sign(int x) {
   if (x == 0)
      return 0;
-  
+
   if (x < 0)
      return -1;
-  else 
+  else
      return 1;
-} 
+}
 
 int main() {
   int a;
   klee_make_symbolic(&a, sizeof(a), "a");
   return get_sign(a);
-} 
+}

--- a/examples/regexp/Regexp.c
+++ b/examples/regexp/Regexp.c
@@ -1,11 +1,11 @@
-/* 
+/*
  * Simple regular expression matching.
  *
  * From:
  *   The Practice of Programming
  *   Brian W. Kernighan, Rob Pike
  *
- */ 
+ */
 
 #include "klee/klee.h"
 
@@ -51,8 +51,8 @@ int match(char *re, char *text) {
 int main() {
   // The input regular expression.
   char re[SIZE];
-  
-  // Make the input symbolic. 
+
+  // Make the input symbolic.
   klee_make_symbolic(re, sizeof re, "re");
 
   // Try to match against a constant string "hello".

--- a/include/klee/Expr/ArrayExprHash.h
+++ b/include/klee/Expr/ArrayExprHash.h
@@ -18,85 +18,85 @@
 #include <unordered_map>
 
 namespace klee {
-  
+
 struct ArrayHashFn  {
   unsigned operator()(const Array* array) const {
     return(array ? array->hash() : 0);
   }
 };
-    
+
 struct ArrayCmpFn {
   bool operator()(const Array* array1, const Array* array2) const {
     return(array1 == array2);
   }
-};  
-  
+};
+
 struct UpdateNodeHashFn  {
   unsigned operator()(const UpdateNode* un) const {
     return(un ? un->hash() : 0);
   }
 };
-    
+
 struct UpdateNodeCmpFn {
   bool operator()(const UpdateNode* un1, const UpdateNode* un2) const {
     return(un1 == un2);
   }
-};  
+};
 
 template<class T>
-class ArrayExprHash {  
+class ArrayExprHash {
 public:
-  
+
   ArrayExprHash() {};
   // Note: Extend the class and overload the destructor if the objects of type T
   // that are to be hashed need to be explicitly destroyed
   // As an example, see class STPArrayExprHash
   virtual ~ArrayExprHash() {};
-   
+
   bool lookupArrayExpr(const Array* array, T& exp) const;
-  void hashArrayExpr(const Array* array, T& exp);  
-  
+  void hashArrayExpr(const Array* array, T& exp);
+
   bool lookupUpdateNodeExpr(const UpdateNode* un, T& exp) const;
-  void hashUpdateNodeExpr(const UpdateNode* un, T& exp);  
-  
+  void hashUpdateNodeExpr(const UpdateNode* un, T& exp);
+
 protected:
   typedef std::unordered_map<const Array*, T, ArrayHashFn, ArrayCmpFn> ArrayHash;
   typedef typename ArrayHash::iterator ArrayHashIter;
   typedef typename ArrayHash::const_iterator ArrayHashConstIter;
-  
+
   typedef std::unordered_map<const UpdateNode*, T, UpdateNodeHashFn, UpdateNodeCmpFn> UpdateNodeHash;
   typedef typename UpdateNodeHash::iterator UpdateNodeHashIter;
   typedef typename UpdateNodeHash::const_iterator UpdateNodeHashConstIter;
-  
+
   ArrayHash      _array_hash;
-  UpdateNodeHash _update_node_hash;  
+  UpdateNodeHash _update_node_hash;
 };
 
 
 template<class T>
 bool ArrayExprHash<T>::lookupArrayExpr(const Array* array, T& exp) const {
   bool res = false;
-  
+
 #ifdef KLEE_ARRAY_DEBUG
   TimerStatIncrementer t(stats::arrayHashTime);
 #endif
-  
-  assert(array);  
+
+  assert(array);
   ArrayHashConstIter it = _array_hash.find(array);
   if (it != _array_hash.end()) {
     exp = it->second;
     res = true;
-  }  
+  }
   return res;
 }
 
 template<class T>
 void ArrayExprHash<T>::hashArrayExpr(const Array* array, T& exp) {
-  
+
 #ifdef KLEE_ARRAY_DEBUG
    TimerStatIncrementer t(stats::arrayHashTime);
 #endif
-   
+
    assert(array);
   _array_hash[array] = exp;
 }
@@ -105,27 +105,27 @@ template<class T>
 bool ArrayExprHash<T>::lookupUpdateNodeExpr(const UpdateNode* un, T& exp) const
 {
   bool res = false;
-  
+
 #ifdef KLEE_ARRAY_DEBUG
   TimerStatIncrementer t(stats::arrayHashTime);
 #endif
-  
+
   assert(un);
   UpdateNodeHashConstIter it = _update_node_hash.find(un);
   if (it != _update_node_hash.end()) {
     exp = it->second;
     res = true;
-  }  
+  }
   return res;
 }
 
 template<class T>
-void ArrayExprHash<T>::hashUpdateNodeExpr(const UpdateNode* un, T& exp) 
+void ArrayExprHash<T>::hashUpdateNodeExpr(const UpdateNode* un, T& exp)
 {
 #ifdef KLEE_ARRAY_DEBUG
   TimerStatIncrementer t(stats::arrayHashTime);
 #endif
-  
+
   assert(un);
   _update_node_hash[un] = exp;
 }

--- a/include/klee/Expr/Assignment.h
+++ b/include/klee/Expr/Assignment.h
@@ -23,15 +23,15 @@ namespace klee {
 
     bool allowFreeValues;
     bindings_ty bindings;
-    
+
   public:
-    Assignment(bool _allowFreeValues=false) 
+    Assignment(bool _allowFreeValues=false)
       : allowFreeValues(_allowFreeValues) {}
     Assignment(const std::vector<const Array*> &objects,
                std::vector< std::vector<unsigned char> > &values,
-               bool _allowFreeValues=false) 
+               bool _allowFreeValues=false)
       : allowFreeValues(_allowFreeValues){
-      std::vector< std::vector<unsigned char> >::iterator valIt = 
+      std::vector< std::vector<unsigned char> >::iterator valIt =
         values.begin();
       for (std::vector<const Array*>::const_iterator it = objects.begin(),
              ie = objects.end(); it != ie; ++it) {
@@ -41,7 +41,7 @@ namespace klee {
         ++valIt;
       }
     }
-    
+
     ref<Expr> evaluate(const Array *mo, unsigned index) const;
     ref<Expr> evaluate(ref<Expr> e);
     void createConstraintsFromAssignment(std::vector<ref<Expr> > &out) const;
@@ -50,7 +50,7 @@ namespace klee {
     bool satisfies(InputIterator begin, InputIterator end);
     void dump();
   };
-  
+
   class AssignmentEvaluator : public ExprEvaluator {
     const Assignment &a;
 
@@ -58,14 +58,14 @@ namespace klee {
     ref<Expr> getInitialValue(const Array &mo, unsigned index) {
       return a.evaluate(&mo, index);
     }
-    
+
   public:
-    AssignmentEvaluator(const Assignment &_a) : a(_a) {}    
+    AssignmentEvaluator(const Assignment &_a) : a(_a) {}
   };
 
   /***/
 
-  inline ref<Expr> Assignment::evaluate(const Array *array, 
+  inline ref<Expr> Assignment::evaluate(const Array *array,
                                         unsigned index) const {
     assert(array);
     bindings_ty::const_iterator it = bindings.find(array);
@@ -73,7 +73,7 @@ namespace klee {
       return ConstantExpr::alloc(it->second[index], array->getRange());
     } else {
       if (allowFreeValues) {
-        return ReadExpr::create(UpdateList(array, 0), 
+        return ReadExpr::create(UpdateList(array, 0),
                                 ConstantExpr::alloc(index, array->getDomain()));
       } else {
         return ConstantExpr::alloc(0, array->getRange());
@@ -81,9 +81,9 @@ namespace klee {
     }
   }
 
-  inline ref<Expr> Assignment::evaluate(ref<Expr> e) { 
+  inline ref<Expr> Assignment::evaluate(ref<Expr> e) {
     AssignmentEvaluator v(*this);
-    return v.visit(e); 
+    return v.visit(e);
   }
 
   template<typename InputIterator>

--- a/include/klee/Expr/Expr.h
+++ b/include/klee/Expr/Expr.h
@@ -57,19 +57,19 @@ The general rules are:
 <li> Booleans:
     <ol type="a">
      <li> \c Ne, \c Ugt, \c Uge, \c Sgt, \c Sge are not used </li>
-     <li> The only acceptable operations with boolean arguments are 
-          \c Not \c And, \c Or, \c Xor, \c Eq, 
+     <li> The only acceptable operations with boolean arguments are
+          \c Not \c And, \c Or, \c Xor, \c Eq,
 	  as well as \c SExt, \c ZExt,
           \c Select and \c NotOptimized. </li>
      <li> The only boolean operation which may involve a constant is boolean not (<tt>== false</tt>). </li>
      </ol>
 </li>
 
-<li> Linear Formulas: 
+<li> Linear Formulas:
    <ol type="a">
    <li> For any subtree representing a linear formula, a constant
-   term must be on the LHS of the root node of the subtree.  In particular, 
-   in a BinaryExpr a constant must always be on the LHS.  For example, subtraction 
+   term must be on the LHS of the root node of the subtree.  In particular,
+   in a BinaryExpr a constant must always be on the LHS.  For example, subtraction
    by a constant c is written as <tt>add(-c, ?)</tt>.  </li>
     </ol>
 </li>
@@ -94,9 +94,9 @@ public:
   static unsigned count;
   static const unsigned MAGIC_HASH_CONSTANT = 39;
 
-  /// The type of an expression is simply its width, in bits. 
-  typedef unsigned Width; 
-  
+  /// The type of an expression is simply its width, in bits.
+  typedef unsigned Width;
+
   static const Width InvalidWidth = 0;
   static const Width Bool = 1;
   static const Width Int8 = 8;
@@ -104,7 +104,7 @@ public:
   static const Width Int32 = 32;
   static const Width Int64 = 64;
   static const Width Fl80 = 80;
-  
+
 
   enum Kind {
     InvalidKind = -1,
@@ -121,7 +121,7 @@ public:
     NotOptimized,
 
     //// Skip old varexpr, just for deserialization, purge at some point
-    Read=NotOptimized+2, 
+    Read=NotOptimized+2,
     Select,
     Concat,
     Extract,
@@ -151,7 +151,7 @@ public:
     Shl,
     LShr,
     AShr,
-    
+
     // Compare
     Eq,
     Ne,  ///< Not used in canonical form
@@ -176,7 +176,7 @@ public:
 
   unsigned refCount;
 
-protected:  
+protected:
   unsigned hashValue;
 
   /// Compares `b` to `this` Expr and determines how they are ordered
@@ -205,14 +205,14 @@ protected:
 
 public:
   Expr() : refCount(0) { Expr::count++; }
-  virtual ~Expr() { Expr::count--; } 
+  virtual ~Expr() { Expr::count--; }
 
   virtual Kind getKind() const = 0;
   virtual Width getWidth() const = 0;
-  
+
   virtual unsigned getNumKids() const = 0;
   virtual ref<Expr> getKid(unsigned i) const = 0;
-    
+
   virtual void print(llvm::raw_ostream &os) const;
 
   /// dump - Print the expression to stderr.
@@ -222,9 +222,9 @@ public:
   virtual unsigned hash() const { return hashValue; }
 
   /// (Re)computes the hash of the current expression.
-  /// Returns the hash value. 
+  /// Returns the hash value.
   virtual unsigned computeHash();
-  
+
   /// Compares `b` to `this` Expr for structural equivalence.
   ///
   /// This method effectively defines a total order over all Expr.
@@ -241,12 +241,12 @@ public:
   int compare(const Expr &b) const;
 
   // Given an array of new kids return a copy of the expression
-  // but using those children. 
+  // but using those children.
   virtual ref<Expr> rebuild(ref<Expr> kids[/* getNumKids() */]) const = 0;
 
   /// isZero - Is this a constant zero.
   bool isZero() const;
-  
+
   /// isTrue - Is this the true expression.
   bool isTrue() const;
 
@@ -274,7 +274,7 @@ public:
   /// Create a little endian read of the given type at offset 0 of the
   /// given object.
   static ref<Expr> createTempRead(const Array *array, Expr::Width w);
-  
+
   static ref<ConstantExpr> createPointer(uint64_t v);
 
   struct CreateArg;
@@ -293,10 +293,10 @@ private:
 struct Expr::CreateArg {
   ref<Expr> expr;
   Width width;
-  
+
   CreateArg(Width w = Bool) : expr(0), width(w) {}
   CreateArg(ref<Expr> e) : expr(e), width(Expr::InvalidWidth) {}
-  
+
   bool isExpr() { return !isWidth(); }
   bool isWidth() { return width != Expr::InvalidWidth; }
 };
@@ -371,14 +371,14 @@ public:
 
 public:
   unsigned getNumKids() const { return 2; }
-  ref<Expr> getKid(unsigned i) const { 
+  ref<Expr> getKid(unsigned i) const {
     if(i == 0)
       return left;
     if(i == 1)
       return right;
     return 0;
   }
- 
+
 protected:
   BinaryExpr(const ref<Expr> &l, const ref<Expr> &r) : left(l), right(r) {}
 
@@ -395,8 +395,8 @@ class CmpExpr : public BinaryExpr {
 
 protected:
   CmpExpr(ref<Expr> l, ref<Expr> r) : BinaryExpr(l,r) {}
-  
-public:                                                       
+
+public:
   Width getWidth() const { return Bool; }
 
   static bool classof(const Expr *E) {
@@ -419,9 +419,9 @@ public:
     r->computeHash();
     return r;
   }
-  
+
   static ref<Expr> create(ref<Expr> src);
-  
+
   Width getWidth() const { return src->getWidth(); }
   Kind getKind() const { return NotOptimized; }
 
@@ -449,7 +449,7 @@ public:
 
 /// Class representing a byte update of an array.
 class UpdateNode {
-  friend class UpdateList;  
+  friend class UpdateList;
 
   mutable unsigned refCount;
   // cache instead of recalc
@@ -458,19 +458,19 @@ class UpdateNode {
 public:
   const UpdateNode *next;
   ref<Expr> index, value;
-  
+
 private:
   /// size of this update sequence, including this update
   unsigned size;
-  
+
 public:
-  UpdateNode(const UpdateNode *_next, 
-             const ref<Expr> &_index, 
+  UpdateNode(const UpdateNode *_next,
+             const ref<Expr> &_index,
              const ref<Expr> &_value);
 
   unsigned getSize() const { return size; }
 
-  int compare(const UpdateNode &b) const;  
+  int compare(const UpdateNode &b) const;
   unsigned hash() const { return hashValue; }
 
 private:
@@ -536,25 +536,25 @@ public:
 };
 
 /// Class representing a complete list of updates into an array.
-class UpdateList { 
+class UpdateList {
   friend class ReadExpr; // for default constructor
 
 public:
   const Array *root;
-  
+
   /// pointer to the most recent update node
   const UpdateNode *head;
-  
+
 public:
   UpdateList(const Array *_root, const UpdateNode *_head);
   UpdateList(const UpdateList &b);
   ~UpdateList();
-  
+
   UpdateList &operator=(const UpdateList &b);
 
   /// size of this update list
   unsigned getSize() const { return (head ? head->getSize() : 0); }
-  
+
   void extend(const ref<Expr> &index, const ref<Expr> &value);
 
   int compare(const UpdateList &b) const;
@@ -563,12 +563,12 @@ private:
   void tryFreeNodes();
 };
 
-/// Class representing a one byte read from an array. 
+/// Class representing a one byte read from an array.
 class ReadExpr : public NonConstantExpr {
 public:
   static const Kind kind = Read;
   static const unsigned numKids = 1;
-  
+
 public:
   UpdateList updates;
   ref<Expr> index;
@@ -579,15 +579,15 @@ public:
     r->computeHash();
     return r;
   }
-  
+
   static ref<Expr> create(const UpdateList &updates, ref<Expr> i);
-  
+
   Width getWidth() const { assert(updates.root); return updates.root->getRange(); }
   Kind getKind() const { return Read; }
-  
+
   unsigned getNumKids() const { return numKids; }
   ref<Expr> getKid(unsigned i) const { return !i ? index : 0; }
-  
+
   int compareContents(const Expr &b) const;
 
   virtual ref<Expr> rebuild(ref<Expr> kids[]) const {
@@ -597,7 +597,7 @@ public:
   virtual unsigned computeHash();
 
 private:
-  ReadExpr(const UpdateList &_updates, const ref<Expr> &_index) : 
+  ReadExpr(const UpdateList &_updates, const ref<Expr> &_index) :
     updates(_updates), index(_index) { assert(updates.root); }
 
 public:
@@ -613,25 +613,25 @@ class SelectExpr : public NonConstantExpr {
 public:
   static const Kind kind = Select;
   static const unsigned numKids = 3;
-  
+
 public:
   ref<Expr> cond, trueExpr, falseExpr;
 
 public:
-  static ref<Expr> alloc(const ref<Expr> &c, const ref<Expr> &t, 
+  static ref<Expr> alloc(const ref<Expr> &c, const ref<Expr> &t,
                          const ref<Expr> &f) {
     ref<Expr> r(new SelectExpr(c, t, f));
     r->computeHash();
     return r;
   }
-  
+
   static ref<Expr> create(ref<Expr> c, ref<Expr> t, ref<Expr> f);
 
   Width getWidth() const { return trueExpr->getWidth(); }
   Kind getKind() const { return Select; }
 
   unsigned getNumKids() const { return numKids; }
-  ref<Expr> getKid(unsigned i) const { 
+  ref<Expr> getKid(unsigned i) const {
         switch(i) {
         case 0: return cond;
         case 1: return trueExpr;
@@ -646,13 +646,13 @@ public:
     else
       return true;
   }
-    
-  virtual ref<Expr> rebuild(ref<Expr> kids[]) const { 
+
+  virtual ref<Expr> rebuild(ref<Expr> kids[]) const {
     return create(kids[0], kids[1], kids[2]);
   }
 
 private:
-  SelectExpr(const ref<Expr> &c, const ref<Expr> &t, const ref<Expr> &f) 
+  SelectExpr(const ref<Expr> &c, const ref<Expr> &t, const ref<Expr> &f)
     : cond(c), trueExpr(t), falseExpr(f) {}
 
 public:
@@ -669,17 +669,17 @@ protected:
 };
 
 
-/** Children of a concat expression can have arbitrary widths.  
+/** Children of a concat expression can have arbitrary widths.
     Kid 0 is the left kid, kid 1 is the right kid.
 */
-class ConcatExpr : public NonConstantExpr { 
-public: 
+class ConcatExpr : public NonConstantExpr {
+public:
   static const Kind kind = Concat;
   static const unsigned numKids = 2;
 
 private:
   Width width;
-  ref<Expr> left, right;  
+  ref<Expr> left, right;
 
 public:
   static ref<Expr> alloc(const ref<Expr> &l, const ref<Expr> &r) {
@@ -687,7 +687,7 @@ public:
     c->computeHash();
     return c;
   }
-  
+
   static ref<Expr> create(const ref<Expr> &l, const ref<Expr> &r);
 
   Width getWidth() const { return width; }
@@ -696,8 +696,8 @@ public:
   ref<Expr> getRight() const { return right; }
 
   unsigned getNumKids() const { return numKids; }
-  ref<Expr> getKid(unsigned i) const { 
-    if (i == 0) return left; 
+  ref<Expr> getKid(unsigned i) const {
+    if (i == 0) return left;
     else if (i == 1) return right;
     else return NULL;
   }
@@ -710,9 +710,9 @@ public:
 			   const ref<Expr> &kid3, const ref<Expr> &kid4,
 			   const ref<Expr> &kid5, const ref<Expr> &kid6,
 			   const ref<Expr> &kid7, const ref<Expr> &kid8);
-  
+
   virtual ref<Expr> rebuild(ref<Expr> kids[]) const { return create(kids[0], kids[1]); }
-  
+
 private:
   ConcatExpr(const ref<Expr> &l, const ref<Expr> &r) : left(l), right(r) {
     width = l->getWidth() + r->getWidth();
@@ -735,26 +735,26 @@ protected:
 
 
 /** This class represents an extract from expression {\tt expr}, at
-    bit offset {\tt offset} of width {\tt width}.  Bit 0 is the right most 
+    bit offset {\tt offset} of width {\tt width}.  Bit 0 is the right most
     bit of the expression.
  */
-class ExtractExpr : public NonConstantExpr { 
+class ExtractExpr : public NonConstantExpr {
 public:
   static const Kind kind = Extract;
   static const unsigned numKids = 1;
-  
+
 public:
   ref<Expr> expr;
   unsigned offset;
   Width width;
 
-public:  
+public:
   static ref<Expr> alloc(const ref<Expr> &e, unsigned o, Width w) {
     ref<Expr> r(new ExtractExpr(e, o, w));
     r->computeHash();
     return r;
   }
-  
+
   /// Creates an ExtractExpr with the given bit offset and width
   static ref<Expr> create(ref<Expr> e, unsigned bitOff, Width w);
 
@@ -771,14 +771,14 @@ public:
     return 0;
   }
 
-  virtual ref<Expr> rebuild(ref<Expr> kids[]) const { 
+  virtual ref<Expr> rebuild(ref<Expr> kids[]) const {
     return create(kids[0], offset, width);
   }
 
   virtual unsigned computeHash();
 
 private:
-  ExtractExpr(const ref<Expr> &e, unsigned b, Width w) 
+  ExtractExpr(const ref<Expr> &e, unsigned b, Width w)
     : expr(e),offset(b),width(w) {}
 
 public:
@@ -789,23 +789,23 @@ public:
 };
 
 
-/** 
-    Bitwise Not 
+/**
+    Bitwise Not
 */
-class NotExpr : public NonConstantExpr { 
+class NotExpr : public NonConstantExpr {
 public:
   static const Kind kind = Not;
   static const unsigned numKids = 1;
-  
+
   ref<Expr> expr;
 
-public:  
+public:
   static ref<Expr> alloc(const ref<Expr> &e) {
     ref<Expr> r(new NotExpr(e));
     r->computeHash();
     return r;
   }
-  
+
   static ref<Expr> create(const ref<Expr> &e);
 
   Width getWidth() const { return expr->getWidth(); }
@@ -814,7 +814,7 @@ public:
   unsigned getNumKids() const { return numKids; }
   ref<Expr> getKid(unsigned i) const { return expr; }
 
-  virtual ref<Expr> rebuild(ref<Expr> kids[]) const { 
+  virtual ref<Expr> rebuild(ref<Expr> kids[]) const {
     return create(kids[0]);
   }
 
@@ -852,9 +852,9 @@ public:
 
   unsigned getNumKids() const { return 1; }
   ref<Expr> getKid(unsigned i) const { return (i==0) ? src : 0; }
-  
+
   static bool needsResultType() { return true; }
-  
+
   int compareContents(const Expr &b) const {
     const CastExpr &eb = static_cast<const CastExpr&>(b);
     if (width != eb.width) return width < eb.width ? -1 : 1;
@@ -1154,14 +1154,14 @@ inline bool Expr::isZero() const {
     return CE->isZero();
   return false;
 }
-  
+
 inline bool Expr::isTrue() const {
   assert(getWidth() == Expr::Bool && "Invalid isTrue() call!");
   if (const ConstantExpr *CE = dyn_cast<ConstantExpr>(this))
     return CE->isTrue();
   return false;
 }
-  
+
 inline bool Expr::isFalse() const {
   assert(getWidth() == Expr::Bool && "Invalid isFalse() call!");
   if (const ConstantExpr *CE = dyn_cast<ConstantExpr>(this))

--- a/include/klee/Expr/ExprBuilder.h
+++ b/include/klee/Expr/ExprBuilder.h
@@ -25,12 +25,12 @@ namespace klee {
 
     virtual ref<Expr> Constant(const llvm::APInt &Value) = 0;
     virtual ref<Expr> NotOptimized(const ref<Expr> &Index) = 0;
-    virtual ref<Expr> Read(const UpdateList &Updates, 
+    virtual ref<Expr> Read(const UpdateList &Updates,
                            const ref<Expr> &Index) = 0;
     virtual ref<Expr> Select(const ref<Expr> &Cond,
                              const ref<Expr> &LHS, const ref<Expr> &RHS) = 0;
     virtual ref<Expr> Concat(const ref<Expr> &LHS, const ref<Expr> &RHS) = 0;
-    virtual ref<Expr> Extract(const ref<Expr> &LHS, 
+    virtual ref<Expr> Extract(const ref<Expr> &LHS,
                               unsigned Offset, Expr::Width W) = 0;
     virtual ref<Expr> ZExt(const ref<Expr> &LHS, Expr::Width W) = 0;
     virtual ref<Expr> SExt(const ref<Expr> &LHS, Expr::Width W) = 0;

--- a/include/klee/Expr/ExprEvaluator.h
+++ b/include/klee/Expr/ExprEvaluator.h
@@ -19,14 +19,14 @@ namespace klee {
     Action evalRead(const UpdateList &ul, unsigned index);
     Action visitRead(const ReadExpr &re);
     Action visitExpr(const Expr &e);
-      
+
     Action protectedDivOperation(const BinaryExpr &e);
     Action visitUDiv(const UDivExpr &e);
     Action visitSDiv(const SDivExpr &e);
     Action visitURem(const URemExpr &e);
     Action visitSRem(const SRemExpr &e);
     Action visitExprPost(const Expr& e);
-      
+
   public:
     ExprEvaluator() {}
 

--- a/include/klee/Expr/ExprHashMap.h
+++ b/include/klee/Expr/ExprHashMap.h
@@ -33,23 +33,23 @@ namespace klee {
         return e->hash();
       }
     };
-    
+
     struct ExprCmp {
       bool operator()(const ref<Expr> &a, const ref<Expr> &b) const {
         return a==b;
       }
     };
   }
-  
-  template<class T> 
-  class ExprHashMap : 
+
+  template<class T>
+  class ExprHashMap :
 
     public unordered_map<ref<Expr>,
                          T,
                          klee::util::ExprHash,
                          klee::util::ExprCmp> {
   };
-  
+
   typedef unordered_set<ref<Expr>,
                         klee::util::ExprHash,
                         klee::util::ExprCmp> ExprHashSet;

--- a/include/klee/Expr/ExprPPrinter.h
+++ b/include/klee/Expr/ExprPPrinter.h
@@ -21,7 +21,7 @@ namespace klee {
   class ExprPPrinter {
   protected:
     ExprPPrinter() {}
-    
+
   public:
     static ExprPPrinter *create(llvm::raw_ostream &os);
 

--- a/include/klee/Expr/ExprRangeEvaluator.h
+++ b/include/klee/Expr/ExprRangeEvaluator.h
@@ -21,10 +21,10 @@ public:
   ValueType(); // empty range
   ValueType(uint64_t value);
   ValueType(uint64_t min, uint64_t max);
-  
+
   bool mustEqual(const uint64_t b);
   bool mustEqual(const ValueType &b);
-  bool mayEqual(const uint64_t b);  
+  bool mayEqual(const uint64_t b);
   bool mayEqual(const ValueType &b);
 
   bool isFullRange(unsigned width);
@@ -82,10 +82,10 @@ T ExprRangeEvaluator<T>::evalRead(const UpdateList &ul,
       res = res.set_union(evaluate(un->value));
       if (res.isFullRange(8)) {
         return res;
-      } 
+      }
     }
   }
-  
+
   return res.set_union(getInitialReadRange(*ul.root, index));
 }
 
@@ -95,7 +95,7 @@ T ExprRangeEvaluator<T>::evaluate(const ref<Expr> &e) {
   case Expr::Constant:
     return T(cast<ConstantExpr>(e));
 
-  case Expr::NotOptimized: 
+  case Expr::NotOptimized:
     break;
 
   case Expr::Read: {
@@ -110,7 +110,7 @@ T ExprRangeEvaluator<T>::evaluate(const ref<Expr> &e) {
   case Expr::Select: {
     const SelectExpr *se = cast<SelectExpr>(e);
     T cond = evaluate(se->cond);
-      
+
     if (cond.mustEqual(1)) {
       return evaluate(se->trueExpr);
     } else if (cond.mustEqual(0)) {
@@ -206,7 +206,7 @@ T ExprRangeEvaluator<T>::evaluate(const ref<Expr> &e) {
     const BinaryExpr *be = cast<BinaryExpr>(e);
     T left = evaluate(be->left);
     T right = evaluate(be->right);
-      
+
     if (left.mustEqual(right)) {
       return T(1);
     } else if (!left.mayEqual(right)) {
@@ -219,7 +219,7 @@ T ExprRangeEvaluator<T>::evaluate(const ref<Expr> &e) {
     const BinaryExpr *be = cast<BinaryExpr>(e);
     T left = evaluate(be->left);
     T right = evaluate(be->right);
-      
+
     if (left.max() < right.min()) {
       return T(1);
     } else if (left.min() >= right.max()) {
@@ -231,7 +231,7 @@ T ExprRangeEvaluator<T>::evaluate(const ref<Expr> &e) {
     const BinaryExpr *be = cast<BinaryExpr>(e);
     T left = evaluate(be->left);
     T right = evaluate(be->right);
-      
+
     if (left.max() <= right.min()) {
       return T(1);
     } else if (left.min() > right.max()) {
@@ -257,7 +257,7 @@ T ExprRangeEvaluator<T>::evaluate(const ref<Expr> &e) {
     T left = evaluate(be->left);
     T right = evaluate(be->right);
     unsigned bits = be->left->getWidth();
-      
+
     if (left.maxSigned(bits) <= right.minSigned(bits)) {
       return T(1);
     } else if (left.minSigned(bits) > right.maxSigned(bits)) {

--- a/include/klee/Expr/ExprUtil.h
+++ b/include/klee/Expr/ExprUtil.h
@@ -24,10 +24,10 @@ namespace klee {
   /// is true then this will including those reachable by traversing
   /// update lists. Note that this may be slow and return a large
   /// number of results.
-  void findReads(ref<Expr> e, 
+  void findReads(ref<Expr> e,
                  bool visitUpdates,
                  std::vector< ref<ReadExpr> > &result);
-  
+
   /// Return a list of all unique symbolic objects referenced by the given
   /// expression.
   void findSymbolicObjects(ref<Expr> e,
@@ -36,7 +36,7 @@ namespace klee {
   /// Return a list of all unique symbolic objects referenced by the
   /// given expression range.
   template<typename InputIterator>
-  void findSymbolicObjects(InputIterator begin, 
+  void findSymbolicObjects(InputIterator begin,
                            InputIterator end,
                            std::vector<const Array*> &results);
 

--- a/include/klee/Expr/ExprVisitor.h
+++ b/include/klee/Expr/ExprVisitor.h
@@ -22,9 +22,9 @@ namespace klee {
 
     private:
       //      Action() {}
-      Action(Kind _kind) 
+      Action(Kind _kind)
         : kind(_kind), argument(nullptr) {}
-      Action(Kind _kind, const ref<Expr> &_argument) 
+      Action(Kind _kind, const ref<Expr> &_argument)
         : kind(_kind), argument(_argument) {}
 
       friend class ExprVisitor;
@@ -33,8 +33,8 @@ namespace klee {
       Kind kind;
       ref<Expr> argument;
 
-      static Action changeTo(const ref<Expr> &expr) { 
-        return Action(ChangeTo,expr); 
+      static Action changeTo(const ref<Expr> &expr) {
+        return Action(ChangeTo,expr);
       }
       static Action doChildren() { return Action(DoChildren); }
       static Action skipChildren() { return Action(SkipChildren); }
@@ -86,7 +86,7 @@ namespace klee {
     bool recursive;
 
     ref<Expr> visitActual(const ref<Expr> &e);
-    
+
   public:
     // apply the visitor to the expression and return a possibly
     // modified new expression.

--- a/include/klee/Expr/Parser/Lexer.h
+++ b/include/klee/Expr/Parser/Lexer.h
@@ -44,13 +44,13 @@ namespace expr {
       RSquare,                  ///< ']'
       Semicolon,                ///< ';'
       Unknown,                  ///< <other>
-      
+
       KWKindFirst=KWArray,
       KWKindLast=KWWidth
     };
 
     Kind        kind;           /// The token kind.
-    const char *start;          /// The beginning of the token string. 
+    const char *start;          /// The beginning of the token string.
     unsigned    length;         /// The length of the token.
     unsigned    line;           /// The line number of the start of this token.
     unsigned    column;         /// The column number at the start of
@@ -64,8 +64,8 @@ namespace expr {
     std::string getString() const { return std::string(start, length); }
 
     /// isKeyword - True if this token is a keyword.
-    bool isKeyword() const { 
-      return kind >= KWKindFirst && kind <= KWKindLast; 
+    bool isKeyword() const {
+      return kind >= KWKindFirst && kind <= KWKindLast;
     }
 
     // dump - Dump the token to stderr.
@@ -97,7 +97,7 @@ namespace expr {
     /// same requirements as SetTokenKind and additionally takes care
     /// of keyword recognition.
     Token &SetIdentifierTokenKind(Token &Result);
-  
+
     void SkipToEndOfLine();
 
     /// LexNumber - Lex a number which does not have a base specifier.

--- a/include/klee/Expr/Parser/Parser.h
+++ b/include/klee/Expr/Parser/Parser.h
@@ -26,7 +26,7 @@ namespace expr {
   // These are the language types we manipulate.
   typedef ref<Expr> ExprHandle;
   typedef UpdateList VersionHandle;
-  
+
   /// Identifier - Wrapper for a uniqued string.
   struct Identifier {
     const std::string Name;
@@ -45,7 +45,7 @@ namespace expr {
       ExprVarDeclKind,
       VersionVarDeclKind,
       QueryCommandDeclKind,
-      
+
       DeclKindLast = QueryCommandDeclKind,
       VarDeclKindFirst = ExprVarDeclKind,
       VarDeclKindLast = VersionVarDeclKind,
@@ -89,11 +89,11 @@ namespace expr {
     const Array *Root;
 
   public:
-    ArrayDecl(const Identifier *_Name, uint64_t _Size, 
+    ArrayDecl(const Identifier *_Name, uint64_t _Size,
               unsigned _Domain, unsigned _Range,
               const Array *_Root)
-      : Decl(ArrayDeclKind), Name(_Name), 
-        Domain(_Domain), Range(_Range), 
+      : Decl(ArrayDeclKind), Name(_Name),
+        Domain(_Domain), Range(_Range),
         Root(_Root) {
     }
 
@@ -107,12 +107,12 @@ namespace expr {
 
   /// VarDecl - Variable declarations, used to associate names to
   /// expressions or array versions outside of expressions.
-  /// 
+  ///
   /// For example:
   // FIXME: What syntax are we going to use for this? We need it.
   class VarDecl : public Decl {
   public:
-    const Identifier *Name;    
+    const Identifier *Name;
 
     static bool classof(const Decl *D) {
       return (Decl::VarDeclKindFirst <= D->getKind() &&
@@ -170,7 +170,7 @@ namespace expr {
     /// Constraints - The list of constraints to assume for this
     /// expression.
     const std::vector<ExprHandle> Constraints;
-    
+
     /// Query - The expression being queried.
     ExprHandle Query;
 
@@ -201,7 +201,7 @@ namespace expr {
     }
     static bool classof(const QueryCommand *) { return true; }
   };
-  
+
   /// Parser - Public interface for parsing a .kquery language file.
   class Parser {
   protected:
@@ -211,7 +211,7 @@ namespace expr {
 
     /// SetMaxErrors - Suppress anything beyond the first N errors.
     virtual void SetMaxErrors(unsigned N) = 0;
-    
+
     /// GetNumErrors - Return the number of encountered errors.
     virtual unsigned GetNumErrors() const = 0;
 

--- a/include/klee/Internal/ADT/DiscretePDF.h
+++ b/include/klee/Internal/ADT/DiscretePDF.h
@@ -28,16 +28,16 @@ namespace klee {
     void remove(T item);
     bool inTree(T item);
     weight_type getWeight(T item);
-	
+
     /* pick a tree element according to its
      * weight. p should be in [0,1).
      */
     T choose(double p);
-    
+
   private:
     class Node;
     Node *m_root;
-    
+
     Node **lookup(T item, Node **parent_out);
     void split(Node *node);
     void rotate(Node *node);

--- a/include/klee/Internal/ADT/ImmutableMap.h
+++ b/include/klee/Internal/ADT/ImmutableMap.h
@@ -20,7 +20,7 @@ namespace klee {
     D &operator()(V &a) const { return a.first; }
     const D &operator()(const V &a) const { return a.first; }
   };
-  
+
   template<class K, class D, class CMP=std::less<K> >
   class ImmutableMap {
   public:
@@ -41,59 +41,59 @@ namespace klee {
     ~ImmutableMap() {}
 
     ImmutableMap &operator=(const ImmutableMap &b) { elts = b.elts; return *this; }
-    
-    bool empty() const { 
-      return elts.empty(); 
+
+    bool empty() const {
+      return elts.empty();
     }
-    size_t count(const key_type &key) const { 
-      return elts.count(key); 
+    size_t count(const key_type &key) const {
+      return elts.count(key);
     }
-    const value_type *lookup(const key_type &key) const { 
-      return elts.lookup(key); 
+    const value_type *lookup(const key_type &key) const {
+      return elts.lookup(key);
     }
-    const value_type *lookup_previous(const key_type &key) const { 
-      return elts.lookup_previous(key); 
+    const value_type *lookup_previous(const key_type &key) const {
+      return elts.lookup_previous(key);
     }
-    const value_type &min() const { 
-      return elts.min(); 
+    const value_type &min() const {
+      return elts.min();
     }
-    const value_type &max() const { 
-      return elts.max(); 
+    const value_type &max() const {
+      return elts.max();
     }
-    size_t size() const { 
-      return elts.size(); 
+    size_t size() const {
+      return elts.size();
     }
 
-    ImmutableMap insert(const value_type &value) const { 
-      return elts.insert(value); 
+    ImmutableMap insert(const value_type &value) const {
+      return elts.insert(value);
     }
-    ImmutableMap replace(const value_type &value) const { 
-      return elts.replace(value); 
+    ImmutableMap replace(const value_type &value) const {
+      return elts.replace(value);
     }
-    ImmutableMap remove(const key_type &key) const { 
-      return elts.remove(key); 
+    ImmutableMap remove(const key_type &key) const {
+      return elts.remove(key);
     }
-    ImmutableMap popMin(const value_type &valueOut) const { 
-      return elts.popMin(valueOut); 
+    ImmutableMap popMin(const value_type &valueOut) const {
+      return elts.popMin(valueOut);
     }
-    ImmutableMap popMax(const value_type &valueOut) const { 
-      return elts.popMax(valueOut); 
+    ImmutableMap popMax(const value_type &valueOut) const {
+      return elts.popMax(valueOut);
     }
 
-    iterator begin() const { 
-      return elts.begin(); 
+    iterator begin() const {
+      return elts.begin();
     }
-    iterator end() const { 
-      return elts.end(); 
+    iterator end() const {
+      return elts.end();
     }
-    iterator find(const key_type &key) const { 
-      return elts.find(key); 
+    iterator find(const key_type &key) const {
+      return elts.find(key);
     }
-    iterator lower_bound(const key_type &key) const { 
-      return elts.lower_bound(key); 
+    iterator lower_bound(const key_type &key) const {
+      return elts.lower_bound(key);
     }
-    iterator upper_bound(const key_type &key) const { 
-      return elts.upper_bound(key); 
+    iterator upper_bound(const key_type &key) const {
+      return elts.upper_bound(key);
     }
 
     static size_t getAllocated() { return Tree::allocated; }

--- a/include/klee/Internal/ADT/ImmutableSet.h
+++ b/include/klee/Internal/ADT/ImmutableSet.h
@@ -20,7 +20,7 @@ namespace klee {
     T &operator()(T &a) const { return a; }
     const T &operator()(const T &a) const { return a; }
   };
-  
+
   template<class T, class CMP=std::less<T> >
   class ImmutableSet {
   public:
@@ -41,56 +41,56 @@ namespace klee {
     ~ImmutableSet() {}
 
     ImmutableSet &operator=(const ImmutableSet &b) { elts = b.elts; return *this; }
-    
-    bool empty() const { 
-      return elts.empty(); 
+
+    bool empty() const {
+      return elts.empty();
     }
-    size_t count(const key_type &key) const { 
-      return elts.count(key); 
+    size_t count(const key_type &key) const {
+      return elts.count(key);
     }
-    const value_type *lookup(const key_type &key) const { 
-      return elts.lookup(key); 
+    const value_type *lookup(const key_type &key) const {
+      return elts.lookup(key);
     }
-    const value_type &min() const { 
-      return elts.min(); 
+    const value_type &min() const {
+      return elts.min();
     }
-    const value_type &max() const { 
-      return elts.max(); 
+    const value_type &max() const {
+      return elts.max();
     }
-    size_t size() { 
-      return elts.size(); 
+    size_t size() {
+      return elts.size();
     }
 
     ImmutableSet insert(const value_type &value) const {
-      return elts.insert(value); 
+      return elts.insert(value);
     }
     ImmutableSet replace(const value_type &value) const {
-      return elts.replace(value); 
+      return elts.replace(value);
     }
-    ImmutableSet remove(const key_type &key) const { 
-      return elts.remove(key); 
+    ImmutableSet remove(const key_type &key) const {
+      return elts.remove(key);
     }
-    ImmutableSet popMin(const value_type &valueOut) const { 
-      return elts.popMin(valueOut); 
+    ImmutableSet popMin(const value_type &valueOut) const {
+      return elts.popMin(valueOut);
     }
-    ImmutableSet popMax(const value_type &valueOut) const { 
-      return elts.popMax(valueOut); 
+    ImmutableSet popMax(const value_type &valueOut) const {
+      return elts.popMax(valueOut);
     }
 
-    iterator begin() const { 
-      return elts.begin(); 
+    iterator begin() const {
+      return elts.begin();
     }
-    iterator end() const { 
-      return elts.end(); 
+    iterator end() const {
+      return elts.end();
     }
-    iterator find(const key_type &key) const { 
-      return elts.find(key); 
+    iterator find(const key_type &key) const {
+      return elts.find(key);
     }
-    iterator lower_bound(const key_type &key) const { 
-      return elts.lower_bound(key); 
+    iterator lower_bound(const key_type &key) const {
+      return elts.lower_bound(key);
     }
-    iterator upper_bound(const key_type &key) const { 
-      return elts.upper_bound(key); 
+    iterator upper_bound(const key_type &key) const {
+      return elts.upper_bound(key);
     }
 
     static size_t getAllocated() { return Tree::allocated; }

--- a/include/klee/Internal/ADT/ImmutableTree.h
+++ b/include/klee/Internal/ADT/ImmutableTree.h
@@ -123,7 +123,7 @@ namespace klee {
 
 
     FixedStack &operator=(const FixedStack &b) {
-      assert(max == b.max); 
+      assert(max == b.max);
       pos = b.pos;
       std::copy(b.elts, b.elts+pos, elts);
       return *this;
@@ -142,7 +142,7 @@ namespace klee {
   private:
     Node *root; // so can back up from end
     FixedStack<Node*> stack;
-    
+
   public:
     iterator(Node *_root, bool atBeginning) : root(_root->incref()),
                                               stack(root->height) {
@@ -182,7 +182,7 @@ namespace klee {
     bool operator!=(const iterator &b) {
       return stack!=b.stack;
     }
-    
+
     iterator &operator--() {
       if (stack.empty()) {
         for (Node *n=root; !n->isTerminator(); n=n->right)
@@ -236,29 +236,29 @@ namespace klee {
 
   /***/
 
-  template<class K, class V, class KOV, class CMP> 
-  typename ImmutableTree<K,V,KOV,CMP>::Node 
+  template<class K, class V, class KOV, class CMP>
+  typename ImmutableTree<K,V,KOV,CMP>::Node
   ImmutableTree<K,V,KOV,CMP>::Node::terminator;
 
-  template<class K, class V, class KOV, class CMP> 
+  template<class K, class V, class KOV, class CMP>
   size_t ImmutableTree<K,V,KOV,CMP>::allocated = 0;
 
   template<class K, class V, class KOV, class CMP>
-  ImmutableTree<K,V,KOV,CMP>::Node::Node() 
-    : left(&terminator), 
-      right(&terminator), 
-      height(0), 
-      references(3) { 
+  ImmutableTree<K,V,KOV,CMP>::Node::Node()
+    : left(&terminator),
+      right(&terminator),
+      height(0),
+      references(3) {
     assert(this==&terminator);
   }
 
   template<class K, class V, class KOV, class CMP>
   ImmutableTree<K,V,KOV,CMP>::Node::Node(Node *_left, Node *_right, const value_type &_value)
-    : left(_left), 
-      right(_right), 
-      value(_value), 
+    : left(_left),
+      right(_right),
+      value(_value),
       height(std::max(left->height, right->height) + 1),
-      references(1) 
+      references(1)
   {
     ++allocated;
   }
@@ -421,23 +421,23 @@ namespace klee {
   /***/
 
   template<class K, class V, class KOV, class CMP>
-  ImmutableTree<K,V,KOV,CMP>::ImmutableTree() 
+  ImmutableTree<K,V,KOV,CMP>::ImmutableTree()
     : node(Node::terminator.incref()) {
   }
 
   template<class K, class V, class KOV, class CMP>
-  ImmutableTree<K,V,KOV,CMP>::ImmutableTree(Node *_node) 
+  ImmutableTree<K,V,KOV,CMP>::ImmutableTree(Node *_node)
     : node(_node) {
   }
 
   template<class K, class V, class KOV, class CMP>
-  ImmutableTree<K,V,KOV,CMP>::ImmutableTree(const ImmutableTree &s) 
+  ImmutableTree<K,V,KOV,CMP>::ImmutableTree(const ImmutableTree &s)
     : node(s.node->incref()) {
   }
 
   template<class K, class V, class KOV, class CMP>
   ImmutableTree<K,V,KOV,CMP>::~ImmutableTree() {
-    node->decref(); 
+    node->decref();
   }
 
   template<class K, class V, class KOV, class CMP>
@@ -507,7 +507,7 @@ namespace klee {
 
   template<class K, class V, class KOV, class CMP>
   const typename ImmutableTree<K,V,KOV,CMP>::value_type &
-  ImmutableTree<K,V,KOV,CMP>::min() const { 
+  ImmutableTree<K,V,KOV,CMP>::min() const {
     Node *n = node;
     assert(!n->isTerminator());
     while (!n->left->isTerminator()) n = n->left;
@@ -529,49 +529,49 @@ namespace klee {
   }
 
   template<class K, class V, class KOV, class CMP>
-  ImmutableTree<K,V,KOV,CMP> 
-  ImmutableTree<K,V,KOV,CMP>::insert(const value_type &value) const { 
-    return ImmutableTree(node->insert(value)); 
+  ImmutableTree<K,V,KOV,CMP>
+  ImmutableTree<K,V,KOV,CMP>::insert(const value_type &value) const {
+    return ImmutableTree(node->insert(value));
   }
 
   template<class K, class V, class KOV, class CMP>
-  ImmutableTree<K,V,KOV,CMP> 
-  ImmutableTree<K,V,KOV,CMP>::replace(const value_type &value) const { 
-    return ImmutableTree(node->replace(value)); 
+  ImmutableTree<K,V,KOV,CMP>
+  ImmutableTree<K,V,KOV,CMP>::replace(const value_type &value) const {
+    return ImmutableTree(node->replace(value));
   }
 
   template<class K, class V, class KOV, class CMP>
-  ImmutableTree<K,V,KOV,CMP> 
-  ImmutableTree<K,V,KOV,CMP>::remove(const key_type &key) const { 
-    return ImmutableTree(node->remove(key)); 
+  ImmutableTree<K,V,KOV,CMP>
+  ImmutableTree<K,V,KOV,CMP>::remove(const key_type &key) const {
+    return ImmutableTree(node->remove(key));
   }
 
   template<class K, class V, class KOV, class CMP>
-  ImmutableTree<K,V,KOV,CMP> 
-  ImmutableTree<K,V,KOV,CMP>::popMin(value_type &valueOut) const { 
-    return ImmutableTree(node->popMin(valueOut)); 
+  ImmutableTree<K,V,KOV,CMP>
+  ImmutableTree<K,V,KOV,CMP>::popMin(value_type &valueOut) const {
+    return ImmutableTree(node->popMin(valueOut));
   }
 
   template<class K, class V, class KOV, class CMP>
-  ImmutableTree<K,V,KOV,CMP> 
-  ImmutableTree<K,V,KOV,CMP>::popMax(value_type &valueOut) const { 
-    return ImmutableTree(node->popMax(valueOut)); 
+  ImmutableTree<K,V,KOV,CMP>
+  ImmutableTree<K,V,KOV,CMP>::popMax(value_type &valueOut) const {
+    return ImmutableTree(node->popMax(valueOut));
   }
 
   template<class K, class V, class KOV, class CMP>
-  inline typename ImmutableTree<K,V,KOV,CMP>::iterator 
+  inline typename ImmutableTree<K,V,KOV,CMP>::iterator
   ImmutableTree<K,V,KOV,CMP>::begin() const {
     return iterator(node, true);
   }
 
   template<class K, class V, class KOV, class CMP>
-  inline typename ImmutableTree<K,V,KOV,CMP>::iterator 
+  inline typename ImmutableTree<K,V,KOV,CMP>::iterator
   ImmutableTree<K,V,KOV,CMP>::end() const {
     return iterator(node, false);
   }
 
   template<class K, class V, class KOV, class CMP>
-  inline typename ImmutableTree<K,V,KOV,CMP>::iterator 
+  inline typename ImmutableTree<K,V,KOV,CMP>::iterator
   ImmutableTree<K,V,KOV,CMP>::find(const key_type &key) const {
     iterator end(node,false), it = lower_bound(key);
     if (it==end || key_compare()(key,key_of_value()(*it))) {
@@ -582,7 +582,7 @@ namespace klee {
   }
 
   template<class K, class V, class KOV, class CMP>
-  inline typename ImmutableTree<K,V,KOV,CMP>::iterator 
+  inline typename ImmutableTree<K,V,KOV,CMP>::iterator
   ImmutableTree<K,V,KOV,CMP>::lower_bound(const key_type &k) const {
     // XXX ugh this doesn't have to be so ugly does it?
     iterator it(node,false);
@@ -606,10 +606,10 @@ namespace klee {
   }
 
   template<class K, class V, class KOV, class CMP>
-  typename ImmutableTree<K,V,KOV,CMP>::iterator 
+  typename ImmutableTree<K,V,KOV,CMP>::iterator
   ImmutableTree<K,V,KOV,CMP>::upper_bound(const key_type &key) const {
     iterator end(node,false),it = lower_bound(key);
-    if (it!=end && 
+    if (it!=end &&
         !key_compare()(key,key_of_value()(*it))) // no need to loop, no duplicates
       ++it;
     return it;

--- a/include/klee/Internal/ADT/KTest.h
+++ b/include/klee/Internal/ADT/KTest.h
@@ -20,12 +20,12 @@ extern "C" {
     unsigned numBytes;
     unsigned char *bytes;
   };
-  
+
   typedef struct KTest KTest;
   struct KTest {
     /* file format version */
-    unsigned version; 
-    
+    unsigned version;
+
     unsigned numArgs;
     char **args;
 
@@ -36,10 +36,10 @@ extern "C" {
     KTestObject *objects;
   };
 
-  
+
   /* returns the current .ktest file format version */
   unsigned kTest_getCurrentVersion();
-  
+
   /* return true iff file at path matches KTest header */
   int   kTest_isKTestFile(const char *path);
 
@@ -48,7 +48,7 @@ extern "C" {
 
   /* returns 1 on success, 0 on (unspecified) error */
   int   kTest_toFile(KTest *, const char *path);
-  
+
   /* returns total number of object bytes */
   unsigned kTest_numBytes(KTest *);
 

--- a/include/klee/Internal/ADT/MapOfSets.h
+++ b/include/klee/Internal/ADT/MapOfSets.h
@@ -43,11 +43,11 @@ namespace klee {
     iterator begin();
     iterator end();
 
-    void subsets(const std::set<K> &set, 
+    void subsets(const std::set<K> &set,
                  std::vector< std::pair<std::set<K>, V> > &resultOut);
-    void supersets(const std::set<K> &set, 
+    void supersets(const std::set<K> &set,
                    std::vector< std::pair<std::set<K>, V> > &resultOut);
-    
+
     template<class Predicate>
     V *findSuperset(const std::set<K> &set, const Predicate &p);
     template<class Predicate>
@@ -59,25 +59,25 @@ namespace klee {
     Node root;
 
     template<class Iterator, class Vector>
-    void findSubsets(Node *n, 
+    void findSubsets(Node *n,
                      const std::set<K> &accum,
-                     Iterator begin, 
+                     Iterator begin,
                      Iterator end,
                      Vector &resultsOut);
     template<class Iterator, class Vector>
-    void findSupersets(Node *n, 
+    void findSupersets(Node *n,
                        const std::set<K> &accum,
-                       Iterator begin, 
+                       Iterator begin,
                        Iterator end,
                        Vector &resultsOut);
     template<class Predicate>
-    V *findSuperset(Node *n, 
-                    typename std::set<K>::iterator begin, 
+    V *findSuperset(Node *n,
+                    typename std::set<K>::iterator begin,
                     typename std::set<K>::iterator end,
                     const Predicate &p);
     template<class Predicate>
-    V *findSubset(Node *n, 
-                  typename std::set<K>::iterator begin, 
+    V *findSubset(Node *n,
+                  typename std::set<K>::iterator begin,
                   typename std::set<K>::iterator end,
                   const Predicate &p);
   };
@@ -97,11 +97,11 @@ namespace klee {
   private:
     bool isEndOfSet;
     std::map<K, Node> children;
-    
+
   public:
     Node() : value(), isEndOfSet(false) {}
   };
-  
+
   template<class K, class V>
   class MapOfSets<K,V>::iterator {
     typedef std::vector< typename std::map<K, Node>::iterator > stack_ty;
@@ -122,7 +122,7 @@ namespace klee {
             onEntry = true;
             return;
           }
-        } 
+        }
       }
 
       while (!stack.empty()) {
@@ -144,12 +144,12 @@ namespace klee {
           onEntry = true;
           break;
         }
-      } 
+      }
     }
 
   public:
     // end()
-    iterator() : onEntry(false) {} 
+    iterator() : onEntry(false) {}
     // begin()
     iterator(Node *_n) : root(_n), onEntry(true) {
       if (!root->isEndOfSet)
@@ -182,7 +182,7 @@ namespace klee {
   /***/
 
   template<class K, class V>
-  MapOfSets<K,V>::MapOfSets() {}  
+  MapOfSets<K,V>::MapOfSets() {}
 
   template<class K, class V>
   void MapOfSets<K,V>::insert(const std::set<K> &set, const V &value) {
@@ -214,24 +214,24 @@ namespace klee {
   }
 
   template<class K, class V>
-  typename MapOfSets<K,V>::iterator 
+  typename MapOfSets<K,V>::iterator
   MapOfSets<K,V>::begin() { return iterator(&root); }
-  
+
   template<class K, class V>
-  typename MapOfSets<K,V>::iterator 
+  typename MapOfSets<K,V>::iterator
   MapOfSets<K,V>::end() { return iterator(); }
 
   template<class K, class V>
   template<class Iterator, class Vector>
-  void MapOfSets<K,V>::findSubsets(Node *n, 
+  void MapOfSets<K,V>::findSubsets(Node *n,
                                   const std::set<K> &accum,
-                                  Iterator begin, 
+                                  Iterator begin,
                                   Iterator end,
                                   Vector &resultsOut) {
     if (n->isEndOfSet) {
       resultsOut.push_back(std::make_pair(accum, n->value));
     }
-    
+
     for (Iterator it=begin; it!=end;) {
       K elt = *it;
       typename Node::children_ty::iterator kit = n->children.find(elt);
@@ -246,16 +246,16 @@ namespace klee {
 
   template<class K, class V>
   void MapOfSets<K,V>::subsets(const std::set<K> &set,
-                               std::vector< std::pair<std::set<K>, 
+                               std::vector< std::pair<std::set<K>,
                                                       V> > &resultOut) {
     findSubsets(&root, std::set<K>(), set.begin(), set.end(), resultOut);
   }
 
   template<class K, class V>
   template<class Iterator, class Vector>
-  void MapOfSets<K,V>::findSupersets(Node *n, 
+  void MapOfSets<K,V>::findSupersets(Node *n,
                                      const std::set<K> &accum,
-                                     Iterator begin, 
+                                     Iterator begin,
                                      Iterator end,
                                      Vector &resultsOut) {
     if (begin==end) {
@@ -294,17 +294,17 @@ namespace klee {
 
   template<class K, class V>
   template<class Predicate>
-  V *MapOfSets<K,V>::findSubset(Node *n, 
-                                typename std::set<K>::iterator begin, 
+  V *MapOfSets<K,V>::findSubset(Node *n,
+                                typename std::set<K>::iterator begin,
                                 typename std::set<K>::iterator end,
-                                const Predicate &p) {   
+                                const Predicate &p) {
     if (n->isEndOfSet && p(n->value)) {
       return &n->value;
     } else if (begin==end) {
       return 0;
     } else {
       typename Node::children_ty::iterator kend = n->children.end();
-      typename Node::children_ty::iterator 
+      typename Node::children_ty::iterator
         kbegin = n->children.lower_bound(*begin);
       typename std::set<K>::iterator it = begin;
       if (kbegin==kend)
@@ -329,13 +329,13 @@ namespace klee {
       }
     }
   }
-  
+
   template<class K, class V>
   template<class Predicate>
-  V *MapOfSets<K,V>::findSuperset(Node *n, 
-                                  typename std::set<K>::iterator begin, 
+  V *MapOfSets<K,V>::findSuperset(Node *n,
+                                  typename std::set<K>::iterator begin,
                                   typename std::set<K>::iterator end,
-                                  const Predicate &p) {   
+                                  const Predicate &p) {
     if (begin==end) {
       if (n->isEndOfSet && p(n->value))
         return &n->value;
@@ -345,7 +345,7 @@ namespace klee {
         if (res) return res;
       }
     } else {
-      typename Node::children_ty::iterator kmid = 
+      typename Node::children_ty::iterator kmid =
         n->children.lower_bound(*begin);
       for (typename Node::children_ty::iterator it = n->children.begin(),
              ie = n->children.end(); it != ie; ++it) {
@@ -362,13 +362,13 @@ namespace klee {
 
   template<class K, class V>
   template<class Predicate>
-  V *MapOfSets<K,V>::findSuperset(const std::set<K> &set, const Predicate &p) {    
+  V *MapOfSets<K,V>::findSuperset(const std::set<K> &set, const Predicate &p) {
     return findSuperset(&root, set.begin(), set.end(), p);
   }
 
   template<class K, class V>
   template<class Predicate>
-  V *MapOfSets<K,V>::findSubset(const std::set<K> &set, const Predicate &p) {    
+  V *MapOfSets<K,V>::findSubset(const std::set<K> &set, const Predicate &p) {
     return findSubset(&root, set.begin(), set.end(), p);
   }
 

--- a/include/klee/Internal/ADT/RNG.h
+++ b/include/klee/Internal/ADT/RNG.h
@@ -13,22 +13,22 @@
 namespace klee {
   class RNG {
   private:
-    /* Period parameters */  
+    /* Period parameters */
     static const int N = 624;
     static const int M = 397;
     static const unsigned int MATRIX_A = 0x9908b0dfUL;   /* constant vector a */
     static const unsigned int UPPER_MASK = 0x80000000UL; /* most significant w-r bits */
     static const unsigned int LOWER_MASK = 0x7fffffffUL; /* least significant r bits */
-      
+
   private:
     unsigned int mt[N]; /* the array for the state vector  */
     int mti;
-    
+
   public:
     RNG(unsigned int seed=5489UL);
-  
+
     void seed(unsigned int seed);
-    
+
     /* generates a random number on [0,0xffffffff]-interval */
     unsigned int getInt32();
     /* generates a random number on [0,0x7fffffff]-interval */

--- a/include/klee/Internal/ADT/TreeStream.h
+++ b/include/klee/Internal/ADT/TreeStream.h
@@ -56,7 +56,7 @@ namespace klee {
   private:
     TreeStreamWriter *writer;
     unsigned id;
-    
+
     TreeOStream(TreeStreamWriter &_writer, unsigned _id);
 
   public:

--- a/include/klee/Internal/Module/InstructionInfoTable.h
+++ b/include/klee/Internal/Module/InstructionInfoTable.h
@@ -18,7 +18,7 @@
 namespace llvm {
   class Function;
   class Instruction;
-  class Module; 
+  class Module;
 }
 
 namespace klee {

--- a/include/klee/Internal/Module/KInstruction.h
+++ b/include/klee/Internal/Module/KInstruction.h
@@ -31,7 +31,7 @@ namespace klee {
   /// KInstruction - Intermediate instruction representation used
   /// during execution.
   struct KInstruction {
-    llvm::Instruction *inst;    
+    llvm::Instruction *inst;
     const InstructionInfo *info;
 
     /// Value numbers for each operand. -1 is an invalid value,

--- a/include/klee/Internal/Support/IntEvaluation.h
+++ b/include/klee/Internal/Support/IntEvaluation.h
@@ -16,7 +16,7 @@
 
 // ASSUMPTION: invalid bits in each uint64_t are 0. the trade-off here is
 // between making trunc/zext/sext fast and making operations that depend
-// on the invalid bits being 0 fast. 
+// on the invalid bits being 0 fast.
 
 namespace klee {
 namespace ints {

--- a/include/klee/MergeHandler.h
+++ b/include/klee/MergeHandler.h
@@ -7,42 +7,42 @@
 //
 //===----------------------------------------------------------------------===//
 
-/** 
+/**
  * @file MergeHandler.h
  * @brief Implementation of the region based merging
  *
  * ## Basic usage:
- * 
+ *
  * @code{.cpp}
  * klee_open_merge();
- * 
- * code containing branches etc. 
- * 
+ *
+ * code containing branches etc.
+ *
  * klee_close_merge();
  * @endcode
- * 
+ *
  * Will lead to all states that forked from the state that executed the
  * klee_open_merge() being merged in the klee_close_merge(). This allows for
  * fine-grained regions to be specified for merging.
- * 
+ *
  * # Implementation Structure
- * 
+ *
  * The main part of the new functionality is implemented in the class
  * klee::MergeHandler. The Special Function Handler generates an instance of
  * this class every time a state runs into a klee_open_merge() call.
- * 
+ *
  * This instance is appended to a `std::vector<klee::ref<klee::MergeHandler>>`
  * in the ExecutionState that passed the merge open point. This stack is also
  * copied during forks. We use a stack instead of a single instance to support
  * nested merge regions.
- * 
+ *
  * Once a state runs into a `klee_close_merge()`, the Special Function Handler
  * notifies the top klee::MergeHandler in the state's stack, pauses the state
  * from scheduling, and tries to merge it with all other states that already
  * arrived at the same close merge point. This top instance is then popped from
  * the stack, resulting in a decrease of the ref count of the
  * klee::MergeHandler.
- * 
+ *
  * Since the only references to this MergeHandler are in the stacks of
  * the ExecutionStates currently in the merging region, once the ref count
  * reaches zero, every state which ran into the same `klee_open_merge()` is now
@@ -90,7 +90,7 @@ extern llvm::cl::opt<bool> DebugLogIncompleteMerge;
 class Executor;
 class ExecutionState;
 
-/// @brief Represents one `klee_open_merge()` call. 
+/// @brief Represents one `klee_open_merge()` call.
 /// Handles merging of states that branched from it
 class MergeHandler {
 private:
@@ -136,7 +136,7 @@ public:
   /// @brief True, if any states have run into 'klee_close_merge()' and have
   /// not been released yet
   bool hasMergedStates();
-  
+
   /// @brief Immediately release the merged states that have run into a
   /// 'klee_merge_close()'
   void releaseStates();

--- a/include/klee/Solver/IncompleteSolver.h
+++ b/include/klee/Solver/IncompleteSolver.h
@@ -67,7 +67,7 @@ public:
   ///
   /// The passed expression is non-constant with bool type.
   virtual IncompleteSolver::PartialValidity computeTruth(const Query&) = 0;
-  
+
   /// computeValue - Attempt to compute a value for the given expression.
   virtual bool computeValue(const Query&, ref<Expr> &result) = 0;
 
@@ -75,9 +75,9 @@ public:
   /// for the initial state of each given object. If a correct result
   /// is not found, then the values array must be unmodified.
   virtual bool computeInitialValues(const Query&,
-                                    const std::vector<const Array*> 
+                                    const std::vector<const Array*>
                                       &objects,
-                                    std::vector< std::vector<unsigned char> > 
+                                    std::vector< std::vector<unsigned char> >
                                       &values,
                                     bool &hasSolution) = 0;
 };
@@ -89,11 +89,11 @@ class StagedSolverImpl : public SolverImpl {
 private:
   IncompleteSolver *primary;
   Solver *secondary;
-  
+
 public:
   StagedSolverImpl(IncompleteSolver *_primary, Solver *_secondary);
   ~StagedSolverImpl();
-    
+
   bool computeTruth(const Query&, bool &isValid);
   bool computeValidity(const Query&, Solver::Validity &result);
   bool computeValue(const Query&, ref<Expr> &result);

--- a/include/klee/Solver/Solver.h
+++ b/include/klee/Solver/Solver.h
@@ -60,7 +60,7 @@ namespace klee {
       False = -1,
       Unknown = 0
     };
-  
+
   public:
     /// validity_to_str - Return the name of given Validity enum value.
     static const char *validity_to_str(Validity v);
@@ -86,9 +86,9 @@ namespace klee {
     ///
     /// \return True on success.
     bool evaluate(const Query&, Validity &result);
-  
+
     /// mustBeTrue - Determine if the expression is provably true.
-    /// 
+    ///
     /// This evaluates the following logical formula:
     ///
     /// \f[ \forall X constraints(X) \to query(X) \f]
@@ -184,7 +184,7 @@ namespace klee {
     // FIXME: This API is lame. We should probably just provide an API which
     // returns an Assignment object, then clients can get out whatever values
     // they want. This also allows us to optimize the representation.
-    bool getInitialValues(const Query&, 
+    bool getInitialValues(const Query&,
                           const std::vector<const Array*> &objects,
                           std::vector< std::vector<unsigned char> > &result);
 
@@ -193,13 +193,13 @@ namespace klee {
     ///
     /// \return - A pair with (min, max) values for the expression.
     ///
-    /// \post(mustBeTrue(min <= e <= max) && 
+    /// \post(mustBeTrue(min <= e <= max) &&
     ///       mayBeTrue(min == e) &&
     ///       mayBeTrue(max == e))
     //
     // FIXME: This should go into a helper class, and should handle failure.
     virtual std::pair< ref<Expr>, ref<Expr> > getRange(const Query&);
-    
+
     virtual char *getConstraintLog(const Query& query);
     virtual void setCoreSolverTimeout(time::Span timeout);
   };
@@ -248,7 +248,7 @@ namespace klee {
   ///
   /// \param s - The underlying solver to use.
   Solver *createIndependentSolver(Solver *s);
-  
+
   /// createKQueryLoggingSolver - Create a solver which will forward all queries
   /// after writing them to the given path in .kquery format.
   Solver *createKQueryLoggingSolver(Solver *s, std::string path,

--- a/include/klee/Solver/SolverImpl.h
+++ b/include/klee/Solver/SolverImpl.h
@@ -26,7 +26,7 @@ namespace klee {
     // DO NOT IMPLEMENT.
     SolverImpl(const SolverImpl&);
     void operator=(const SolverImpl&);
-    
+
   public:
     SolverImpl() {}
     virtual ~SolverImpl();
@@ -61,7 +61,7 @@ namespace klee {
     ///
     /// \return True on success
     virtual bool computeValidity(const Query& query, Solver::Validity &result);
-    
+
     /// computeTruth - Determine whether the given query expression is provably true
     /// given the constraints.
     ///
@@ -85,15 +85,15 @@ namespace klee {
     ///
     /// \return True on success
     virtual bool computeValue(const Query& query, ref<Expr> &result) = 0;
-    
+
     /// \sa Solver::getInitialValues()
     virtual bool computeInitialValues(const Query& query,
-                                      const std::vector<const Array*> 
+                                      const std::vector<const Array*>
                                         &objects,
-                                      std::vector< std::vector<unsigned char> > 
+                                      std::vector< std::vector<unsigned char> >
                                         &values,
                                       bool &hasSolution) = 0;
-    
+
     /// getOperationStatusCode - get the status of the last solver operation
     virtual SolverRunStatus getOperationStatusCode() = 0;
 

--- a/include/klee/Solver/SolverStats.h
+++ b/include/klee/Solver/SolverStats.h
@@ -27,7 +27,7 @@ namespace stats {
   extern Statistic queryConstructs;
   extern Statistic queryCounterexamples;
   extern Statistic queryTime;
-  
+
 #ifdef KLEE_ARRAY_DEBUG
   extern Statistic arrayHashTime;
 #endif

--- a/include/klee/Statistic.h
+++ b/include/klee/Statistic.h
@@ -35,7 +35,7 @@ namespace klee {
     const std::string shortName;
 
   public:
-    Statistic(const std::string &_name, 
+    Statistic(const std::string &_name,
               const std::string &_shortName);
     ~Statistic();
 

--- a/include/klee/Statistics.h
+++ b/include/klee/Statistics.h
@@ -24,14 +24,14 @@ namespace klee {
   private:
     uint64_t *data;
 
-  public:    
+  public:
     StatisticRecord();
     StatisticRecord(const StatisticRecord &s);
     ~StatisticRecord() { delete[] data; }
-    
+
     void zero();
 
-    uint64_t getValue(const Statistic &s) const; 
+    uint64_t getValue(const Statistic &s) const;
     void incrementValue(const Statistic &s, uint64_t addend) const;
     StatisticRecord &operator =(const StatisticRecord &s);
     StatisticRecord &operator +=(const StatisticRecord &sr);
@@ -59,11 +59,11 @@ namespace klee {
     unsigned getIndex() { return index; }
     unsigned getNumStatistics() { return stats.size(); }
     Statistic &getStatistic(unsigned i) { return *stats[i]; }
-    
+
     void registerStatistic(Statistic &s);
     void incrementStatistic(Statistic &s, uint64_t addend);
     uint64_t getValue(const Statistic &s) const;
-    void incrementIndexedValue(const Statistic &s, unsigned index, 
+    void incrementIndexedValue(const Statistic &s, unsigned index,
                                uint64_t addend) const;
     uint64_t getIndexedValue(const Statistic &s, unsigned index) const;
     void setIndexedValue(const Statistic &s, unsigned index, uint64_t value);
@@ -73,7 +73,7 @@ namespace klee {
 
   extern StatisticManager *theStatisticManager;
 
-  inline void StatisticManager::incrementStatistic(Statistic &s, 
+  inline void StatisticManager::incrementStatistic(Statistic &s,
                                                    uint64_t addend) {
     if (enabled) {
       globalStats[s.id] += addend;
@@ -96,29 +96,29 @@ namespace klee {
     ::memset(data, 0, sizeof(*data)*theStatisticManager->getNumStatistics());
   }
 
-  inline StatisticRecord::StatisticRecord() 
+  inline StatisticRecord::StatisticRecord()
     : data(new uint64_t[theStatisticManager->getNumStatistics()]) {
     zero();
   }
 
-  inline StatisticRecord::StatisticRecord(const StatisticRecord &s) 
+  inline StatisticRecord::StatisticRecord(const StatisticRecord &s)
     : data(new uint64_t[theStatisticManager->getNumStatistics()]) {
-    ::memcpy(data, s.data, 
+    ::memcpy(data, s.data,
              sizeof(*data)*theStatisticManager->getNumStatistics());
   }
 
   inline StatisticRecord &StatisticRecord::operator=(const StatisticRecord &s) {
-    ::memcpy(data, s.data, 
+    ::memcpy(data, s.data,
              sizeof(*data)*theStatisticManager->getNumStatistics());
     return *this;
   }
 
-  inline void StatisticRecord::incrementValue(const Statistic &s, 
+  inline void StatisticRecord::incrementValue(const Statistic &s,
                                               uint64_t addend) const {
     data[s.id] += addend;
   }
-  inline uint64_t StatisticRecord::getValue(const Statistic &s) const { 
-    return data[s.id]; 
+  inline uint64_t StatisticRecord::getValue(const Statistic &s) const {
+    return data[s.id];
   }
 
   inline StatisticRecord &
@@ -133,18 +133,18 @@ namespace klee {
     return globalStats[s.id];
   }
 
-  inline void StatisticManager::incrementIndexedValue(const Statistic &s, 
+  inline void StatisticManager::incrementIndexedValue(const Statistic &s,
                                                       unsigned index,
                                                       uint64_t addend) const {
     indexedStats[index*stats.size() + s.id] += addend;
   }
 
-  inline uint64_t StatisticManager::getIndexedValue(const Statistic &s, 
+  inline uint64_t StatisticManager::getIndexedValue(const Statistic &s,
                                                     unsigned index) const {
     return indexedStats[index*stats.size() + s.id];
   }
 
-  inline void StatisticManager::setIndexedValue(const Statistic &s, 
+  inline void StatisticManager::setIndexedValue(const Statistic &s,
                                                 unsigned index,
                                                 uint64_t value) {
     indexedStats[index*stats.size() + s.id] = value;

--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -16,7 +16,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  
+
   /* Add an accesible memory object at a user specified location. It
    * is the users responsibility to make sure that these memory
    * objects do not overlap. These memory objects will also
@@ -59,7 +59,7 @@ extern "C" {
 
   /* klee_abort - Abort the current KLEE process. */
   __attribute__((noreturn))
-  void klee_abort(void);  
+  void klee_abort(void);
 
   /* klee_report_error - Report a user defined error and terminate the current
    * KLEE process.
@@ -70,22 +70,22 @@ extern "C" {
    * \arg suffix - The suffix to use for error files.
    */
   __attribute__((noreturn))
-  void klee_report_error(const char *file, 
-			 int line, 
-			 const char *message, 
+  void klee_report_error(const char *file,
+			 int line,
+			 const char *message,
 			 const char *suffix);
-  
+
   /* called by checking code to get size of memory. */
   size_t klee_get_obj_size(void *ptr);
-  
+
   /* print the tree associated w/ a given expression. */
   void klee_print_expr(const char *msg, ...);
-  
+
   /* NB: this *does not* fork n times and return [0,n) in children.
    * It makes n be symbolic and returns: caller must compare N times.
    */
   uintptr_t klee_choose(uintptr_t n);
-  
+
   /* special klee assert macro. this assert should be used when path consistency
    * across platforms is desired (e.g., in tests).
    * NB: __assert_fail is a klee "special" function
@@ -129,8 +129,8 @@ extern "C" {
   /* Ensure that memory in the range [address, address+size) is
      accessible to the program. If some byte in the range is not
      accessible an error will be generated and the state
-     terminated. 
-  
+     terminated.
+
      The current implementation requires both address and size to be
      constants and that the range lie within a single object. */
   void klee_check_memory_access(const void *address, size_t size);

--- a/include/klee/util/BitArray.h
+++ b/include/klee/util/BitArray.h
@@ -18,7 +18,7 @@ namespace klee {
 class BitArray {
 private:
   uint32_t *bits;
-  
+
 protected:
   static uint32_t length(unsigned size) { return (size+31)/32; }
 

--- a/include/klee/util/Bits.h
+++ b/include/klee/util/Bits.h
@@ -57,7 +57,7 @@ namespace klee {
       assert(res < 32);
       assert((UINT32_C(1) << res) == x);
       return res;
-    } 
+    }
 
     inline unsigned indexOfRightmostBit(unsigned x) {
       return indexOfSingleBit(isolateRightmostBit(x));
@@ -73,7 +73,7 @@ namespace klee {
         return 0;
       return ((UINT64_C(-1)) >> (64 - N));
     }
-    
+
     // @pre(0 < N <= 64)
     inline uint64_t truncateToNBits(uint64_t x, unsigned N) {
       assert(N > 0 && N <= 64);
@@ -103,7 +103,7 @@ namespace klee {
       assert(res < 64);
       assert((UINT64_C(1) << res) == x);
       return res;
-    } 
+    }
 
     inline uint64_t indexOfRightmostBit(uint64_t x) {
       return indexOfSingleBit(isolateRightmostBit(x));

--- a/lib/Basic/KTest.cpp
+++ b/lib/Basic/KTest.cpp
@@ -87,7 +87,7 @@ int kTest_isKTestFile(const char *path) {
     return 0;
   res = kTest_checkHeader(f);
   fclose(f);
-  
+
   return res;
 }
 
@@ -96,37 +96,37 @@ KTest *kTest_fromFile(const char *path) {
   KTest *res = 0;
   unsigned i, version;
 
-  if (!f) 
+  if (!f)
     goto error;
-  if (!kTest_checkHeader(f)) 
+  if (!kTest_checkHeader(f))
     goto error;
 
   res = (KTest*) calloc(1, sizeof(*res));
-  if (!res) 
+  if (!res)
     goto error;
 
-  if (!read_uint32(f, &version)) 
+  if (!read_uint32(f, &version))
     goto error;
-  
+
   if (version > kTest_getCurrentVersion())
     goto error;
 
   res->version = version;
 
-  if (!read_uint32(f, &res->numArgs)) 
+  if (!read_uint32(f, &res->numArgs))
     goto error;
   res->args = (char**) calloc(res->numArgs, sizeof(*res->args));
-  if (!res->args) 
+  if (!res->args)
     goto error;
-  
+
   for (i=0; i<res->numArgs; i++)
     if (!read_string(f, &res->args[i]))
       goto error;
 
   if (version >= 2) {
-    if (!read_uint32(f, &res->symArgvs)) 
+    if (!read_uint32(f, &res->symArgvs))
       goto error;
-    if (!read_uint32(f, &res->symArgvLen)) 
+    if (!read_uint32(f, &res->symArgvLen))
       goto error;
   }
 
@@ -179,13 +179,13 @@ int kTest_toFile(KTest *bo, const char *path) {
   FILE *f = fopen(path, "wb");
   unsigned i;
 
-  if (!f) 
+  if (!f)
     goto error;
   if (fwrite(KTEST_MAGIC, strlen(KTEST_MAGIC), 1, f)!=1)
     goto error;
   if (!write_uint32(f, KTEST_VERSION))
     goto error;
-      
+
   if (!write_uint32(f, bo->numArgs))
     goto error;
   for (i=0; i<bo->numArgs; i++) {
@@ -197,7 +197,7 @@ int kTest_toFile(KTest *bo, const char *path) {
     goto error;
   if (!write_uint32(f, bo->symArgvLen))
     goto error;
-  
+
   if (!write_uint32(f, bo->numObjects))
     goto error;
   for (i=0; i<bo->numObjects; i++) {
@@ -215,7 +215,7 @@ int kTest_toFile(KTest *bo, const char *path) {
   return 1;
  error:
   if (f) fclose(f);
-  
+
   return 0;
 }
 

--- a/lib/Basic/Statistics.cpp
+++ b/lib/Basic/Statistics.cpp
@@ -26,7 +26,7 @@ StatisticManager::~StatisticManager() {
   delete[] indexedStats;
 }
 
-void StatisticManager::useIndexedStats(unsigned totalIndices) {  
+void StatisticManager::useIndexedStats(unsigned totalIndices) {
   delete[] indexedStats;
   indexedStats = new uint64_t[totalIndices * stats.size()];
   memset(indexedStats, 0, sizeof(*indexedStats) * totalIndices * stats.size());
@@ -64,9 +64,9 @@ static StatisticManager &getStatisticManager() {
 
 /* *** */
 
-Statistic::Statistic(const std::string &_name, 
-                     const std::string &_shortName) 
-  : name(_name), 
+Statistic::Statistic(const std::string &_name,
+                     const std::string &_shortName)
+  : name(_name),
     shortName(_shortName) {
   getStatisticManager().registerStatistic(*this);
 }

--- a/lib/Core/AddressSpace.cpp
+++ b/lib/Core/AddressSpace.cpp
@@ -31,7 +31,7 @@ void AddressSpace::unbindObject(const MemoryObject *mo) {
 
 const ObjectState *AddressSpace::findObject(const MemoryObject *mo) const {
   const MemoryMap::value_type *res = objects.lookup(mo);
-  
+
   return res ? res->second : 0;
 }
 
@@ -45,13 +45,13 @@ ObjectState *AddressSpace::getWriteable(const MemoryObject *mo,
     ObjectState *n = new ObjectState(*os);
     n->copyOnWriteOwner = cowKey;
     objects = objects.replace(std::make_pair(mo, n));
-    return n;    
+    return n;
   }
 }
 
-/// 
+///
 
-bool AddressSpace::resolveOne(const ref<ConstantExpr> &addr, 
+bool AddressSpace::resolveOne(const ref<ConstantExpr> &addr,
                               ObjectPair &result) const {
   uint64_t address = addr->getZExtValue();
   MemoryObject hack(address);
@@ -89,7 +89,7 @@ bool AddressSpace::resolveOne(ExecutionState &state,
     uint64_t example = cex->getZExtValue();
     MemoryObject hack(example);
     const MemoryMap::value_type *res = objects.lookup_previous(&hack);
-    
+
     if (res) {
       const MemoryObject *mo = res->first;
       if (example - mo->address < mo->size) {
@@ -100,18 +100,18 @@ bool AddressSpace::resolveOne(ExecutionState &state,
     }
 
     // didn't work, now we have to search
-       
+
     MemoryMap::iterator oi = objects.upper_bound(&hack);
     MemoryMap::iterator begin = objects.begin();
     MemoryMap::iterator end = objects.end();
-      
+
     MemoryMap::iterator start = oi;
     while (oi!=begin) {
       --oi;
       const MemoryObject *mo = oi->first;
-        
+
       bool mayBeTrue;
-      if (!solver->mayBeTrue(state, 
+      if (!solver->mayBeTrue(state,
                              mo->getBoundsCheckPointer(address), mayBeTrue))
         return false;
       if (mayBeTrue) {
@@ -120,7 +120,7 @@ bool AddressSpace::resolveOne(ExecutionState &state,
         return true;
       } else {
         bool mustBeTrue;
-        if (!solver->mustBeTrue(state, 
+        if (!solver->mustBeTrue(state,
                                 UgeExpr::create(address, mo->getBaseExpr()),
                                 mustBeTrue))
           return false;
@@ -134,7 +134,7 @@ bool AddressSpace::resolveOne(ExecutionState &state,
       const MemoryObject *mo = oi->first;
 
       bool mustBeTrue;
-      if (!solver->mustBeTrue(state, 
+      if (!solver->mustBeTrue(state,
                               UltExpr::create(address, mo->getBaseExpr()),
                               mustBeTrue))
         return false;
@@ -143,7 +143,7 @@ bool AddressSpace::resolveOne(ExecutionState &state,
       } else {
         bool mayBeTrue;
 
-        if (!solver->mayBeTrue(state, 
+        if (!solver->mayBeTrue(state,
                                mo->getBoundsCheckPointer(address),
                                mayBeTrue))
           return false;
@@ -283,7 +283,7 @@ bool AddressSpace::resolve(ExecutionState &state, TimingSolver *solver,
 // then its concrete cache byte isn't being used) but is just a hack.
 
 void AddressSpace::copyOutConcretes() {
-  for (MemoryMap::iterator it = objects.begin(), ie = objects.end(); 
+  for (MemoryMap::iterator it = objects.begin(), ie = objects.end();
        it != ie; ++it) {
     const MemoryObject *mo = it->first;
 
@@ -298,7 +298,7 @@ void AddressSpace::copyOutConcretes() {
 }
 
 bool AddressSpace::copyInConcretes() {
-  for (MemoryMap::iterator it = objects.begin(), ie = objects.end(); 
+  for (MemoryMap::iterator it = objects.begin(), ie = objects.end();
        it != ie; ++it) {
     const MemoryObject *mo = it->first;
 

--- a/lib/Core/AddressSpace.h
+++ b/lib/Core/AddressSpace.h
@@ -25,13 +25,13 @@ namespace klee {
   template<class T> class ref;
 
   typedef std::pair<const MemoryObject*, const ObjectState*> ObjectPair;
-  typedef std::vector<ObjectPair> ResolutionList;  
+  typedef std::vector<ObjectPair> ResolutionList;
 
   /// Function object ordering MemoryObject's by address.
   struct MemoryObjectLT {
     bool operator()(const MemoryObject *a, const MemoryObject *b) const;
   };
-  
+
   typedef ImmutableMap<const MemoryObject*, ObjectHolder, MemoryObjectLT> MemoryMap;
 
   class AddressSpace {
@@ -69,19 +69,19 @@ namespace klee {
 
     /// Resolve address to an ObjectPair in result.
     /// \return true iff an object was found.
-    bool resolveOne(const ref<ConstantExpr> &address, 
+    bool resolveOne(const ref<ConstantExpr> &address,
                     ObjectPair &result) const;
 
     /// Resolve address to an ObjectPair in result.
     ///
     /// \param state The state this address space is part of.
-    /// \param solver A solver used to determine possible 
+    /// \param solver A solver used to determine possible
     ///               locations of the \a address.
     /// \param address The address to search for.
-    /// \param[out] result An ObjectPair this address can resolve to 
+    /// \param[out] result An ObjectPair this address can resolve to
     ///               (when returning true).
     /// \return true iff an object was found at \a address.
-    bool resolveOne(ExecutionState &state, 
+    bool resolveOne(ExecutionState &state,
                     TimingSolver *solver,
                     ref<Expr> address,
                     ObjectPair &result,
@@ -96,7 +96,7 @@ namespace klee {
     bool resolve(ExecutionState &state,
                  TimingSolver *solver,
                  ref<Expr> p,
-                 ResolutionList &rl, 
+                 ResolutionList &rl,
                  unsigned maxResolutions=0,
                  time::Span timeout=time::Span()) const;
 
@@ -133,7 +133,7 @@ namespace klee {
     /// potentially copied) if the memory values are different from
     /// the current concrete values.
     ///
-    /// \retval true The copy succeeded. 
+    /// \retval true The copy succeeded.
     /// \retval false The copy failed because a read-only object was modified.
     bool copyInConcretes();
 

--- a/lib/Core/Context.h
+++ b/lib/Core/Context.h
@@ -25,7 +25,7 @@ namespace klee {
   protected:
     Context(bool _IsLittleEndian, Expr::Width _PointerWidth)
       : IsLittleEndian(_IsLittleEndian), PointerWidth(_PointerWidth) {}
-    
+
   public:
     Context() {}
 
@@ -40,7 +40,7 @@ namespace klee {
     /// Returns width of the pointer in bits
     Expr::Width getPointerWidth() const { return PointerWidth; }
   };
-  
+
 } // End klee namespace
 
 #endif /* KLEE_CONTEXT_H */

--- a/lib/Core/CoreStats.h
+++ b/lib/Core/CoreStats.h
@@ -21,7 +21,7 @@ namespace stats {
   extern Statistic instructionTime;
   extern Statistic instructionRealTime;
   extern Statistic coveredInstructions;
-  extern Statistic uncoveredInstructions;  
+  extern Statistic uncoveredInstructions;
   extern Statistic trueBranches;
   extern Statistic falseBranches;
   extern Statistic forkTime;

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -42,12 +42,12 @@ cl::opt<bool> DebugLogStateMerge(
 /***/
 
 StackFrame::StackFrame(KInstIterator _caller, KFunction *_kf)
-  : caller(_caller), kf(_kf), callPathNode(0), 
+  : caller(_caller), kf(_kf), callPathNode(0),
     minDistToUncoveredOnReturn(0), varargs(0) {
   locals = new Cell[kf->numRegisters];
 }
 
-StackFrame::StackFrame(const StackFrame &s) 
+StackFrame::StackFrame(const StackFrame &s)
   : caller(s.caller),
     kf(s.kf),
     callPathNode(s.callPathNode),
@@ -59,8 +59,8 @@ StackFrame::StackFrame(const StackFrame &s)
     locals[i] = s.locals[i];
 }
 
-StackFrame::~StackFrame() { 
-  delete[] locals; 
+StackFrame::~StackFrame() {
+  delete[] locals;
 }
 
 /***/
@@ -153,13 +153,13 @@ void ExecutionState::pushFrame(KInstIterator caller, KFunction *kf) {
 
 void ExecutionState::popFrame() {
   StackFrame &sf = stack.back();
-  for (std::vector<const MemoryObject*>::iterator it = sf.allocas.begin(), 
+  for (std::vector<const MemoryObject*>::iterator it = sf.allocas.begin(),
          ie = sf.allocas.end(); it != ie; ++it)
     addressSpace.unbindObject(*it);
   stack.pop_back();
 }
 
-void ExecutionState::addSymbolic(const MemoryObject *mo, const Array *array) { 
+void ExecutionState::addSymbolic(const MemoryObject *mo, const Array *array) {
   mo->refCount++;
   symbolics.push_back(std::make_pair(mo, array));
 }
@@ -206,7 +206,7 @@ bool ExecutionState::merge(const ExecutionState &b) {
   }
 
   std::set< ref<Expr> > aConstraints(constraints.begin(), constraints.end());
-  std::set< ref<Expr> > bConstraints(b.constraints.begin(), 
+  std::set< ref<Expr> > bConstraints(b.constraints.begin(),
                                      b.constraints.end());
   std::set< ref<Expr> > commonConstraints, aSuffix, bSuffix;
   std::set_intersection(aConstraints.begin(), aConstraints.end(),
@@ -241,7 +241,7 @@ bool ExecutionState::merge(const ExecutionState &b) {
 
   // We cannot merge if addresses would resolve differently in the
   // states. This means:
-  // 
+  //
   // 1. Any objects created since the branch in either object must
   // have been free'd.
   //
@@ -253,7 +253,7 @@ bool ExecutionState::merge(const ExecutionState &b) {
     llvm::errs() << "A: " << addressSpace.objects << "\n";
     llvm::errs() << "B: " << b.addressSpace.objects << "\n";
   }
-    
+
   std::set<const MemoryObject*> mutated;
   MemoryMap::iterator ai = addressSpace.objects.begin();
   MemoryMap::iterator bi = b.addressSpace.objects.begin();
@@ -281,15 +281,15 @@ bool ExecutionState::merge(const ExecutionState &b) {
       llvm::errs() << "\t\tmappings differ\n";
     return false;
   }
-  
+
   // merge stack
 
   ref<Expr> inA = ConstantExpr::alloc(1, Expr::Bool);
   ref<Expr> inB = ConstantExpr::alloc(1, Expr::Bool);
-  for (std::set< ref<Expr> >::iterator it = aSuffix.begin(), 
+  for (std::set< ref<Expr> >::iterator it = aSuffix.begin(),
          ie = aSuffix.end(); it != ie; ++it)
     inA = AndExpr::create(inA, *it);
-  for (std::set< ref<Expr> >::iterator it = bSuffix.begin(), 
+  for (std::set< ref<Expr> >::iterator it = bSuffix.begin(),
          ie = bSuffix.end(); it != ie; ++it)
     inB = AndExpr::create(inB, *it);
 
@@ -314,12 +314,12 @@ bool ExecutionState::merge(const ExecutionState &b) {
     }
   }
 
-  for (std::set<const MemoryObject*>::iterator it = mutated.begin(), 
+  for (std::set<const MemoryObject*>::iterator it = mutated.begin(),
          ie = mutated.end(); it != ie; ++it) {
     const MemoryObject *mo = *it;
     const ObjectState *os = addressSpace.findObject(mo);
     const ObjectState *otherOS = b.addressSpace.findObject(mo);
-    assert(os && !os->readOnly && 
+    assert(os && !os->readOnly &&
            "objects mutated but not writable in merging state");
     assert(otherOS);
 
@@ -332,7 +332,7 @@ bool ExecutionState::merge(const ExecutionState &b) {
   }
 
   constraints = ConstraintManager();
-  for (std::set< ref<Expr> >::iterator it = commonConstraints.begin(), 
+  for (std::set< ref<Expr> >::iterator it = commonConstraints.begin(),
          ie = commonConstraints.end(); it != ie; ++it)
     constraints.addConstraint(*it);
   constraints.addConstraint(OrExpr::create(inA, inB));

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -544,7 +544,7 @@ Executor::setModule(std::vector<std::unique_ptr<llvm::Module>> &modules,
   specialFunctionHandler->bind();
 
   if (StatsTracker::useStatistics() || userSearcherRequiresMD2U()) {
-    statsTracker = 
+    statsTracker =
       new StatsTracker(*this,
                        interpreterHandler->getOutputFilename("assembly.ll"),
                        userSearcherRequiresMD2U());
@@ -569,14 +569,14 @@ Executor::~Executor() {
 /***/
 
 void Executor::initializeGlobalObject(ExecutionState &state, ObjectState *os,
-                                      const Constant *c, 
+                                      const Constant *c,
                                       unsigned offset) {
   const auto targetData = kmodule->targetData.get();
   if (const ConstantVector *cp = dyn_cast<ConstantVector>(c)) {
     unsigned elementSize =
       targetData->getTypeStoreSize(cp->getType()->getElementType());
     for (unsigned i=0, e=cp->getNumOperands(); i != e; ++i)
-      initializeGlobalObject(state, os, cp->getOperand(i), 
+      initializeGlobalObject(state, os, cp->getOperand(i),
 			     offset + i*elementSize);
   } else if (isa<ConstantAggregateZero>(c)) {
     unsigned i, size = targetData->getTypeStoreSize(c->getType());
@@ -586,13 +586,13 @@ void Executor::initializeGlobalObject(ExecutionState &state, ObjectState *os,
     unsigned elementSize =
       targetData->getTypeStoreSize(ca->getType()->getElementType());
     for (unsigned i=0, e=ca->getNumOperands(); i != e; ++i)
-      initializeGlobalObject(state, os, ca->getOperand(i), 
+      initializeGlobalObject(state, os, ca->getOperand(i),
 			     offset + i*elementSize);
   } else if (const ConstantStruct *cs = dyn_cast<ConstantStruct>(c)) {
     const StructLayout *sl =
       targetData->getStructLayout(cast<StructType>(cs->getType()));
     for (unsigned i=0, e=cs->getNumOperands(); i != e; ++i)
-      initializeGlobalObject(state, os, cs->getOperand(i), 
+      initializeGlobalObject(state, os, cs->getOperand(i),
 			     offset + sl->getElementOffset(i));
   } else if (const ConstantDataSequential *cds =
                dyn_cast<ConstantDataSequential>(c)) {
@@ -614,8 +614,8 @@ void Executor::initializeGlobalObject(ExecutionState &state, ObjectState *os,
   }
 }
 
-MemoryObject * Executor::addExternalObject(ExecutionState &state, 
-                                           void *addr, unsigned size, 
+MemoryObject * Executor::addExternalObject(ExecutionState &state,
+                                           void *addr, unsigned size,
                                            bool isReadOnly) {
   auto mo = memory->allocateFixed(reinterpret_cast<std::uint64_t>(addr),
                                   size, nullptr);
@@ -623,7 +623,7 @@ MemoryObject * Executor::addExternalObject(ExecutionState &state,
   for(unsigned i = 0; i < size; i++)
     os->write8(i, ((uint8_t*)addr)[i]);
   if(isReadOnly)
-    os->setReadOnly(true);  
+    os->setReadOnly(true);
   return mo;
 }
 
@@ -646,14 +646,14 @@ void Executor::initializeGlobals(ExecutionState &state) {
     // If the symbol has external weak linkage then it is implicitly
     // not defined in this module; if it isn't resolvable then it
     // should be null.
-    if (f->hasExternalWeakLinkage() && 
+    if (f->hasExternalWeakLinkage() &&
         !externalDispatcher->resolveSymbol(f->getName())) {
       addr = Expr::createPointer(0);
     } else {
       addr = Expr::createPointer(reinterpret_cast<std::uint64_t>(f));
       legalFunctions.insert(reinterpret_cast<std::uint64_t>(f));
     }
-    
+
     globalAddresses.insert(std::make_pair(f, addr));
   }
 
@@ -677,12 +677,12 @@ void Executor::initializeGlobals(ExecutionState &state) {
   addExternalObject(state, const_cast<uint16_t*>(*addr-128),
                     384 * sizeof **addr, true);
   addExternalObject(state, addr, sizeof(*addr), true);
-    
+
   const int32_t **lower_addr = __ctype_tolower_loc();
   addExternalObject(state, const_cast<int32_t*>(*lower_addr-128),
                     384 * sizeof **lower_addr, true);
   addExternalObject(state, lower_addr, sizeof(*lower_addr), true);
-  
+
   const int32_t **upper_addr = __ctype_toupper_loc();
   addExternalObject(state, const_cast<int32_t*>(*upper_addr-128),
                     384 * sizeof **upper_addr, true);
@@ -748,7 +748,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
           addr = externalDispatcher->resolveSymbol(i->getName());
         }
         if (!addr)
-          klee_error("unable to load symbol(%s) while initializing globals.", 
+          klee_error("unable to load symbol(%s) while initializing globals.",
                      i->getName().data());
 
         for (unsigned offset=0; offset<mo->size; offset++)
@@ -770,7 +770,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
           os->initializeToRandom();
     }
   }
-  
+
   // link aliases to their definitions (if bound)
   for (auto i = m->alias_begin(), ie = m->alias_end(); i != ie; ++i) {
     // Map the alias to its aliasee's address. This works because we have
@@ -800,7 +800,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
       const ObjectState *os = state.addressSpace.findObject(mo);
       assert(os);
       ObjectState *wos = state.addressSpace.getWriteable(mo, os);
-      
+
       initializeGlobalObject(state, wos, i->getInitializer(), 0);
       if (i->isConstant())
         constantObjects.emplace_back(wos);
@@ -818,7 +818,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
   }
 }
 
-void Executor::branch(ExecutionState &state, 
+void Executor::branch(ExecutionState &state,
                       const std::vector< ref<Expr> > &conditions,
                       std::vector<ExecutionState*> &result) {
   TimerStatIncrementer timer(stats::forkTime);
@@ -851,8 +851,8 @@ void Executor::branch(ExecutionState &state,
   // If necessary redistribute seeds to match conditions, killing
   // states if necessary due to OnlyReplaySeeds (inefficient but
   // simple).
-  
-  std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it = 
+
+  std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it =
     seedMap.find(&state);
   if (it != seedMap.end()) {
     std::vector<SeedInfo> seeds = it->second;
@@ -861,20 +861,20 @@ void Executor::branch(ExecutionState &state,
     // Assume each seed only satisfies one condition (necessarily true
     // when conditions are mutually exclusive and their conjunction is
     // a tautology).
-    for (std::vector<SeedInfo>::iterator siit = seeds.begin(), 
+    for (std::vector<SeedInfo>::iterator siit = seeds.begin(),
            siie = seeds.end(); siit != siie; ++siit) {
       unsigned i;
       for (i=0; i<N; ++i) {
         ref<ConstantExpr> res;
-        bool success = 
-          solver->getValue(state, siit->assignment.evaluate(conditions[i]), 
+        bool success =
+          solver->getValue(state, siit->assignment.evaluate(conditions[i]),
                            res);
         assert(success && "FIXME: Unhandled solver failure");
         (void) success;
         if (res->isTrue())
           break;
       }
-      
+
       // If we didn't find a satisfying condition randomly pick one
       // (the seed will be patched).
       if (i==N)
@@ -891,7 +891,7 @@ void Executor::branch(ExecutionState &state,
           terminateState(*result[i]);
           result[i] = NULL;
         }
-      } 
+      }
     }
   }
 
@@ -900,32 +900,32 @@ void Executor::branch(ExecutionState &state,
       addConstraint(*result[i], conditions[i]);
 }
 
-Executor::StatePair 
+Executor::StatePair
 Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
   Solver::Validity res;
-  std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it = 
+  std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it =
     seedMap.find(&current);
   bool isSeeding = it != seedMap.end();
 
-  if (!isSeeding && !isa<ConstantExpr>(condition) && 
+  if (!isSeeding && !isa<ConstantExpr>(condition) &&
       (MaxStaticForkPct!=1. || MaxStaticSolvePct != 1. ||
        MaxStaticCPForkPct!=1. || MaxStaticCPSolvePct != 1.) &&
       statsTracker->elapsed() > time::seconds(60)) {
     StatisticManager &sm = *theStatisticManager;
     CallPathNode *cpn = current.stack.back().callPathNode;
     if ((MaxStaticForkPct<1. &&
-         sm.getIndexedValue(stats::forks, sm.getIndex()) > 
+         sm.getIndexedValue(stats::forks, sm.getIndex()) >
          stats::forks*MaxStaticForkPct) ||
         (MaxStaticCPForkPct<1. &&
-         cpn && (cpn->statistics.getValue(stats::forks) > 
+         cpn && (cpn->statistics.getValue(stats::forks) >
                  stats::forks*MaxStaticCPForkPct)) ||
         (MaxStaticSolvePct<1 &&
-         sm.getIndexedValue(stats::solverTime, sm.getIndex()) > 
+         sm.getIndexedValue(stats::solverTime, sm.getIndex()) >
          stats::solverTime*MaxStaticSolvePct) ||
         (MaxStaticCPForkPct<1. &&
-         cpn && (cpn->statistics.getValue(stats::solverTime) > 
+         cpn && (cpn->statistics.getValue(stats::solverTime) >
                  stats::solverTime*MaxStaticCPSolvePct))) {
-      ref<ConstantExpr> value; 
+      ref<ConstantExpr> value;
       bool success = solver->getValue(current, condition, value);
       assert(success && "FIXME: Unhandled solver failure");
       (void) success;
@@ -951,7 +951,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
       assert(replayPosition<replayPath->size() &&
              "ran out of branches in replay path mode");
       bool branch = (*replayPath)[replayPosition++];
-      
+
       if (res==Solver::True) {
         assert(branch && "hit invalid branch in replay path mode");
       } else if (res==Solver::False) {
@@ -968,10 +968,10 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
       }
     } else if (res==Solver::Unknown) {
       assert(!replayKTest && "in replay mode, only one branch can be true.");
-      
-      if ((MaxMemoryInhibit && atMemoryLimit) || 
+
+      if ((MaxMemoryInhibit && atMemoryLimit) ||
           current.forkDisabled ||
-          inhibitForking || 
+          inhibitForking ||
           (MaxForks!=~0u && stats::forks >= MaxForks)) {
 
 	if (MaxMemoryInhibit && atMemoryLimit)
@@ -980,13 +980,13 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
 	  klee_warning_once(0, "skipping fork (fork disabled on current path)");
 	else if (inhibitForking)
 	  klee_warning_once(0, "skipping fork (fork disabled globally)");
-	else 
+	else
 	  klee_warning_once(0, "skipping fork (max-forks reached)");
 
         TimerStatIncrementer timer(stats::forkTime);
         if (theRNG.getBool()) {
           addConstraint(current, condition);
-          res = Solver::True;        
+          res = Solver::True;
         } else {
           addConstraint(current, Expr::createIsZero(condition));
           res = Solver::False;
@@ -997,15 +997,15 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
 
   // Fix branch in only-replay-seed mode, if we don't have both true
   // and false seeds.
-  if (isSeeding && 
-      (current.forkDisabled || OnlyReplaySeeds) && 
+  if (isSeeding &&
+      (current.forkDisabled || OnlyReplaySeeds) &&
       res == Solver::Unknown) {
     bool trueSeed=false, falseSeed=false;
     // Is seed extension still ok here?
-    for (std::vector<SeedInfo>::iterator siit = it->second.begin(), 
+    for (std::vector<SeedInfo>::iterator siit = it->second.begin(),
            siie = it->second.end(); siit != siie; ++siit) {
       ref<ConstantExpr> res;
-      bool success = 
+      bool success =
         solver->getValue(current, siit->assignment.evaluate(condition), res);
       assert(success && "FIXME: Unhandled solver failure");
       (void) success;
@@ -1019,7 +1019,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
     }
     if (!(trueSeed && falseSeed)) {
       assert(trueSeed || falseSeed);
-      
+
       res = trueSeed ? Solver::True : Solver::False;
       addConstraint(current, trueSeed ? condition : Expr::createIsZero(condition));
     }
@@ -1063,10 +1063,10 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
       it->second.clear();
       std::vector<SeedInfo> &trueSeeds = seedMap[trueState];
       std::vector<SeedInfo> &falseSeeds = seedMap[falseState];
-      for (std::vector<SeedInfo>::iterator siit = seeds.begin(), 
+      for (std::vector<SeedInfo>::iterator siit = seeds.begin(),
              siie = seeds.end(); siit != siie; ++siit) {
         ref<ConstantExpr> res;
-        bool success = 
+        bool success =
           solver->getValue(current, siit->assignment.evaluate(condition), res);
         assert(success && "FIXME: Unhandled solver failure");
         (void) success;
@@ -1076,7 +1076,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
           falseSeeds.push_back(*siit);
         }
       }
-      
+
       bool swapInfo = false;
       if (trueSeeds.empty()) {
         if (&current == trueState) swapInfo = true;
@@ -1133,14 +1133,14 @@ void Executor::addConstraint(ExecutionState &state, ref<Expr> condition) {
   }
 
   // Check to see if this constraint violates seeds.
-  std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it = 
+  std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it =
     seedMap.find(&state);
   if (it != seedMap.end()) {
     bool warn = false;
-    for (std::vector<SeedInfo>::iterator siit = it->second.begin(), 
+    for (std::vector<SeedInfo>::iterator siit = it->second.begin(),
            siie = it->second.end(); siit != siie; ++siit) {
       bool res;
-      bool success = 
+      bool success =
         solver->mustBeFalse(state, siit->assignment.evaluate(condition), res);
       assert(success && "FIXME: Unhandled solver failure");
       (void) success;
@@ -1150,16 +1150,16 @@ void Executor::addConstraint(ExecutionState &state, ref<Expr> condition) {
       }
     }
     if (warn)
-      klee_warning("seeds patched for violating constraint"); 
+      klee_warning("seeds patched for violating constraint");
   }
 
   state.addConstraint(condition);
   if (ivcEnabled)
-    doImpliedValueConcretization(state, condition, 
+    doImpliedValueConcretization(state, condition,
                                  ConstantExpr::alloc(1, Expr::Bool));
 }
 
-const Cell& Executor::eval(KInstruction *ki, unsigned index, 
+const Cell& Executor::eval(KInstruction *ki, unsigned index,
                            ExecutionState &state) const {
   assert(index < ki->inst->getNumOperands());
   int vnumber = ki->operands[index];
@@ -1178,17 +1178,17 @@ const Cell& Executor::eval(KInstruction *ki, unsigned index,
   }
 }
 
-void Executor::bindLocal(KInstruction *target, ExecutionState &state, 
+void Executor::bindLocal(KInstruction *target, ExecutionState &state,
                          ref<Expr> value) {
   getDestCell(state, target).value = value;
 }
 
-void Executor::bindArgument(KFunction *kf, unsigned index, 
+void Executor::bindArgument(KFunction *kf, unsigned index,
                             ExecutionState &state, ref<Expr> value) {
   getArgumentCell(state, kf, index).value = value;
 }
 
-ref<Expr> Executor::toUnique(const ExecutionState &state, 
+ref<Expr> Executor::toUnique(const ExecutionState &state,
                              ref<Expr> &e) {
   ref<Expr> result = e;
 
@@ -1205,15 +1205,15 @@ ref<Expr> Executor::toUnique(const ExecutionState &state,
     }
     solver->setTimeout(time::Span());
   }
-  
+
   return result;
 }
 
 
-/* Concretize the given expression, and return a possible constant value. 
+/* Concretize the given expression, and return a possible constant value.
    'reason' is just a documentation string stating the reason for concretization. */
-ref<klee::ConstantExpr> 
-Executor::toConstant(ExecutionState &state, 
+ref<klee::ConstantExpr>
+Executor::toConstant(ExecutionState &state,
                      ref<Expr> e,
                      const char *reason) {
   e = state.constraints.simplifyExpr(e);
@@ -1237,7 +1237,7 @@ Executor::toConstant(ExecutionState &state,
     klee_warning_once(reason, "%s", os.str().c_str());
 
   addConstraint(state, EqExpr::create(e, value));
-    
+
   return value;
 }
 
@@ -1245,7 +1245,7 @@ void Executor::executeGetValue(ExecutionState &state,
                                ref<Expr> e,
                                KInstruction *target) {
   e = state.constraints.simplifyExpr(e);
-  std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it = 
+  std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it =
     seedMap.find(&state);
   if (it==seedMap.end() || isa<ConstantExpr>(e)) {
     ref<ConstantExpr> value;
@@ -1256,7 +1256,7 @@ void Executor::executeGetValue(ExecutionState &state,
     bindLocal(target, state, value);
   } else {
     std::set< ref<Expr> > values;
-    for (std::vector<SeedInfo>::iterator siit = it->second.begin(), 
+    for (std::vector<SeedInfo>::iterator siit = it->second.begin(),
            siie = it->second.end(); siit != siie; ++siit) {
       ref<Expr> cond = siit->assignment.evaluate(e);
       cond = optimizer.optimizeExpr(cond, true);
@@ -1266,17 +1266,17 @@ void Executor::executeGetValue(ExecutionState &state,
       (void) success;
       values.insert(value);
     }
-    
+
     std::vector< ref<Expr> > conditions;
-    for (std::set< ref<Expr> >::iterator vit = values.begin(), 
+    for (std::set< ref<Expr> >::iterator vit = values.begin(),
            vie = values.end(); vit != vie; ++vit)
       conditions.push_back(EqExpr::create(e, *vit));
 
     std::vector<ExecutionState*> branches;
     branch(state, conditions, branches);
-    
+
     std::vector<ExecutionState*>::iterator bit = branches.begin();
-    for (std::set< ref<Expr> >::iterator vit = values.begin(), 
+    for (std::set< ref<Expr> >::iterator vit = values.begin(),
            vie = values.end(); vit != vie; ++vit) {
       ExecutionState *es = *bit;
       if (es)
@@ -1356,7 +1356,7 @@ static inline const llvm::fltSemantics *fpWidthToSemantics(unsigned width) {
   }
 }
 
-void Executor::executeCall(ExecutionState &state, 
+void Executor::executeCall(ExecutionState &state,
                            KInstruction *ki,
                            Function *f,
                            std::vector< ref<Expr> > &arguments) {
@@ -1396,7 +1396,7 @@ void Executor::executeCall(ExecutionState &state,
       // size. This happens to work for x86-32 and x86-64, however.
       Expr::Width WordSize = Context::get().getPointerWidth();
       if (WordSize == Expr::Int32) {
-        executeMemoryOperation(state, true, arguments[0], 
+        executeMemoryOperation(state, true, arguments[0],
                                sf.varargs->getBaseExpr(), 0);
       } else {
         assert(WordSize == Expr::Int64 && "Unknown word size!");
@@ -1407,15 +1407,15 @@ void Executor::executeCall(ExecutionState &state,
         executeMemoryOperation(state, true, arguments[0],
                                ConstantExpr::create(48, 32), 0); // gp_offset
         executeMemoryOperation(state, true,
-                               AddExpr::create(arguments[0], 
+                               AddExpr::create(arguments[0],
                                                ConstantExpr::create(4, 64)),
                                ConstantExpr::create(304, 32), 0); // fp_offset
         executeMemoryOperation(state, true,
-                               AddExpr::create(arguments[0], 
+                               AddExpr::create(arguments[0],
                                                ConstantExpr::create(8, 64)),
                                sf.varargs->getBaseExpr(), 0); // overflow_arg_area
         executeMemoryOperation(state, true,
-                               AddExpr::create(arguments[0], 
+                               AddExpr::create(arguments[0],
                                                ConstantExpr::create(16, 64)),
                                ConstantExpr::create(0, 64), 0); // reg_save_area
       }
@@ -1427,7 +1427,7 @@ void Executor::executeCall(ExecutionState &state,
       // FIXME: We should validate that the target didn't do something bad
       // with va_end, however (like call it twice).
       break;
-        
+
     case Intrinsic::vacopy:
       // va_copy should have been lowered.
       //
@@ -1467,7 +1467,7 @@ void Executor::executeCall(ExecutionState &state,
     unsigned funcArgs = f->arg_size();
     if (!f->isVarArg()) {
       if (callingArgs > funcArgs) {
-        klee_warning_once(f, "calling %s with extra arguments.", 
+        klee_warning_once(f, "calling %s with extra arguments.",
                           f->getName().data());
       } else if (callingArgs < funcArgs) {
         terminateStateOnError(state, "calling function with too few arguments",
@@ -1561,12 +1561,12 @@ void Executor::executeCall(ExecutionState &state,
     }
 
     unsigned numFormals = f->arg_size();
-    for (unsigned i=0; i<numFormals; ++i) 
+    for (unsigned i=0; i<numFormals; ++i)
       bindArgument(kf, i, state, arguments[i]);
   }
 }
 
-void Executor::transferToBasicBlock(BasicBlock *dst, BasicBlock *src, 
+void Executor::transferToBasicBlock(BasicBlock *dst, BasicBlock *src,
                                     ExecutionState &state) {
   // Note that in general phi nodes can reuse phi values from the same
   // block but the incoming value is the eval() result *before* the
@@ -1579,7 +1579,7 @@ void Executor::transferToBasicBlock(BasicBlock *dst, BasicBlock *src,
   //
   // With that done we simply set an index in the state so that PHI
   // instructions know which argument to eval, set the pc, and continue.
-  
+
   // XXX this lookup has to go ?
   KFunction *kf = state.stack.back().kf;
   unsigned entry = kf->basicBlockEntry[dst];
@@ -1630,11 +1630,11 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     Instruction *caller = kcaller ? kcaller->inst : 0;
     bool isVoidReturn = (ri->getNumOperands() == 0);
     ref<Expr> result = ConstantExpr::alloc(0, Expr::Bool);
-    
+
     if (!isVoidReturn) {
       result = eval(ki, 0, state).value;
     }
-    
+
     if (state.stack.size() <= 1) {
       assert(!caller && "caller set on initial stack frame");
       terminateStateOnExit(state);
@@ -1657,9 +1657,9 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
           // may need to do coercion due to bitcasts
           Expr::Width from = result->getWidth();
           Expr::Width to = getWidthForLLVMType(t);
-            
+
           if (from != to) {
-            CallSite cs = (isa<InvokeInst>(caller) ? CallSite(cast<InvokeInst>(caller)) : 
+            CallSite cs = (isa<InvokeInst>(caller) ? CallSite(cast<InvokeInst>(caller)) :
                            CallSite(cast<CallInst>(caller)));
 
             // XXX need to check other param attrs ?
@@ -1685,7 +1685,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
           terminateStateOnExecError(state, "return void when caller expected a result");
         }
       }
-    }      
+    }
     break;
   }
   case Instruction::Br: {
@@ -1939,7 +1939,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
       arguments.push_back(eval(ki, j+1, state).value);
 
     if (f) {
-      const FunctionType *fType = 
+      const FunctionType *fType =
         dyn_cast<FunctionType>(cast<PointerType>(f->getType())->getElementType());
       const FunctionType *fpType =
         dyn_cast<FunctionType>(cast<PointerType>(fp->getType())->getElementType());
@@ -1956,7 +1956,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
                ai = arguments.begin(), ie = arguments.end();
              ai != ie; ++ai) {
           Expr::Width to, from = (*ai)->getWidth();
-            
+
           if (i<fType->getNumParams()) {
             to = getWidthForLLVMType(fType->getParamType(i));
 
@@ -1974,7 +1974,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
               }
             }
           }
-            
+
           i++;
         }
       }
@@ -2058,7 +2058,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     bindLocal(ki, state, SubExpr::create(left, right));
     break;
   }
- 
+
   case Instruction::Mul: {
     ref<Expr> left = eval(ki, 0, state).value;
     ref<Expr> right = eval(ki, 1, state).value;
@@ -2238,11 +2238,11 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     }
     break;
   }
- 
+
     // Memory instructions...
   case Instruction::Alloca: {
     AllocaInst *ai = cast<AllocaInst>(i);
-    unsigned elementSize = 
+    unsigned elementSize =
       kmodule->targetData->getTypeStoreSize(ai->getAllocatedType());
     ref<Expr> size = Expr::createPointer(elementSize);
     if (ai->isArrayAllocation()) {
@@ -2270,8 +2270,8 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     KGEPInstruction *kgepi = static_cast<KGEPInstruction*>(ki);
     ref<Expr> base = eval(ki, 0, state).value;
 
-    for (std::vector< std::pair<unsigned, uint64_t> >::iterator 
-           it = kgepi->indices.begin(), ie = kgepi->indices.end(); 
+    for (std::vector< std::pair<unsigned, uint64_t> >::iterator
+           it = kgepi->indices.begin(), ie = kgepi->indices.end();
          it != ie; ++it) {
       uint64_t elementSize = it->second;
       ref<Expr> index = eval(ki, it->first, state).value;
@@ -2733,7 +2733,7 @@ void Executor::updateStates(ExecutionState *current) {
   if (searcher) {
     searcher->update(current, addedStates, removedStates);
   }
-  
+
   states.insert(addedStates.begin(), addedStates.end());
   addedStates.clear();
 
@@ -2744,7 +2744,7 @@ void Executor::updateStates(ExecutionState *current) {
     std::set<ExecutionState*>::iterator it2 = states.find(es);
     assert(it2!=states.end());
     states.erase(it2);
-    std::map<ExecutionState*, std::vector<SeedInfo> >::iterator it3 = 
+    std::map<ExecutionState*, std::vector<SeedInfo> >::iterator it3 =
       seedMap.find(es);
     if (it3 != seedMap.end())
       seedMap.erase(it3);
@@ -2773,13 +2773,13 @@ void Executor::computeOffsets(KGEPInstruction *kgepi, TypeIt ib, TypeIt ie) {
       constantOffset = constantOffset->Add(ConstantExpr::alloc(addend,
                                                                Context::get().getPointerWidth()));
     } else if (const auto set = dyn_cast<SequentialType>(*ii)) {
-      uint64_t elementSize = 
+      uint64_t elementSize =
         kmodule->targetData->getTypeStoreSize(set->getElementType());
       Value *operand = ii.getOperand();
       if (Constant *c = dyn_cast<Constant>(operand)) {
-        ref<ConstantExpr> index = 
+        ref<ConstantExpr> index =
           evalConstant(c)->SExt(Context::get().getPointerWidth());
-        ref<ConstantExpr> addend = 
+        ref<ConstantExpr> addend =
           index->Mul(ConstantExpr::alloc(elementSize,
                                          Context::get().getPointerWidth()));
         constantOffset = constantOffset->Add(addend);
@@ -2891,8 +2891,8 @@ void Executor::run(ExecutionState &initialState) {
 
   if (usingSeeds) {
     std::vector<SeedInfo> &v = seedMap[&initialState];
-    
-    for (std::vector<KTest*>::const_iterator it = usingSeeds->begin(), 
+
+    for (std::vector<KTest*>::const_iterator it = usingSeeds->begin(),
            ie = usingSeeds->end(); it != ie; ++it)
       v.push_back(SeedInfo(*it));
 
@@ -2905,7 +2905,7 @@ void Executor::run(ExecutionState &initialState) {
         return;
       }
 
-      std::map<ExecutionState*, std::vector<SeedInfo> >::iterator it = 
+      std::map<ExecutionState*, std::vector<SeedInfo> >::iterator it =
         seedMap.upper_bound(lastState);
       if (it == seedMap.end())
         it = seedMap.begin();
@@ -2937,8 +2937,8 @@ void Executor::run(ExecutionState &initialState) {
         } else if (numSeeds<=lastNumSeeds-10 ||
                    time - lastTime >= time::seconds(10)) {
           lastTime = time;
-          lastNumSeeds = numSeeds;          
-          klee_message("%d seeds remaining over: %d states", 
+          lastNumSeeds = numSeeds;
+          klee_message("%d seeds remaining over: %d states",
                        numSeeds, numStates);
         }
       }
@@ -2986,7 +2986,7 @@ void Executor::run(ExecutionState &initialState) {
   doDumpStates();
 }
 
-std::string Executor::getAddressInfo(ExecutionState &state, 
+std::string Executor::getAddressInfo(ExecutionState &state,
                                      ref<Expr> address) const{
   std::string Str;
   llvm::raw_string_ostream info(Str);
@@ -3004,8 +3004,8 @@ std::string Executor::getAddressInfo(ExecutionState &state,
     std::pair< ref<Expr>, ref<Expr> > res = solver->getRange(state, address);
     info << "\trange: [" << res.first << ", " << res.second <<"]\n";
   }
-  
-  MemoryObject hack((unsigned) example);    
+
+  MemoryObject hack((unsigned) example);
   MemoryMap::iterator lower = state.addressSpace.objects.upper_bound(&hack);
   info << "\tnext: ";
   if (lower==state.addressSpace.objects.end()) {
@@ -3027,7 +3027,7 @@ std::string Executor::getAddressInfo(ExecutionState &state,
       const MemoryObject *mo = lower->first;
       std::string alloc_info;
       mo->getAllocInfo(alloc_info);
-      info << "object at " << mo->address 
+      info << "object at " << mo->address
            << " of size " << mo->size << "\n"
            << "\t\t" << alloc_info << "\n";
     }
@@ -3076,7 +3076,7 @@ void Executor::terminateState(ExecutionState &state) {
     removedStates.push_back(&state);
   } else {
     // never reached searcher, just delete immediately
-    std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it3 = 
+    std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it3 =
       seedMap.find(&state);
     if (it3 != seedMap.end())
       seedMap.erase(it3);
@@ -3086,7 +3086,7 @@ void Executor::terminateState(ExecutionState &state) {
   }
 }
 
-void Executor::terminateStateEarly(ExecutionState &state, 
+void Executor::terminateStateEarly(ExecutionState &state,
                                    const Twine &message) {
   if (!OnlyOutputStatesCoveringNew || state.coveredNew ||
       (AlwaysOutputSeeds && seedMap.count(&state)))
@@ -3096,7 +3096,7 @@ void Executor::terminateStateEarly(ExecutionState &state,
 }
 
 void Executor::terminateStateOnExit(ExecutionState &state) {
-  if (!OnlyOutputStatesCoveringNew || state.coveredNew || 
+  if (!OnlyOutputStatesCoveringNew || state.coveredNew ||
       (AlwaysOutputSeeds && seedMap.count(&state)))
     interpreterHandler->processTestCase(state, 0, 0);
   terminateState(state);
@@ -3165,7 +3165,7 @@ void Executor::terminateStateOnError(ExecutionState &state,
   static std::set< std::pair<Instruction*, std::string> > emittedErrors;
   Instruction * lastInst;
   const InstructionInfo &ii = getLastNonKleeInternalInstruction(state, &lastInst);
-  
+
   if (EmitAllErrors ||
       emittedErrors.insert(std::make_pair(lastInst, message)).second) {
     if (ii.file != "") {
@@ -3200,7 +3200,7 @@ void Executor::terminateStateOnError(ExecutionState &state,
 
     interpreterHandler->processTestCase(state, msg.str().c_str(), suffix);
   }
-    
+
   terminateState(state);
 
   if (shouldExitOn(termReason))
@@ -3208,12 +3208,12 @@ void Executor::terminateStateOnError(ExecutionState &state,
 }
 
 // XXX shoot me
-static const char *okExternalsList[] = { "printf", 
-                                         "fprintf", 
+static const char *okExternalsList[] = { "printf",
+                                         "fprintf",
                                          "puts",
                                          "getpid" };
 static std::set<std::string> okExternals(okExternalsList,
-                                         okExternalsList + 
+                                         okExternalsList +
                                          (sizeof(okExternalsList)/sizeof(okExternalsList[0])));
 
 void Executor::callExternalFunction(ExecutionState &state,
@@ -3223,7 +3223,7 @@ void Executor::callExternalFunction(ExecutionState &state,
   // check if specialFunctionHandler wants it
   if (specialFunctionHandler->handle(state, function, target, arguments))
     return;
-  
+
   if (ExternalCalls == ExternalCallPolicy::None
       && !okExternals.count(function->getName())) {
     klee_warning("Disallowed call to external function: %s\n",
@@ -3239,7 +3239,7 @@ void Executor::callExternalFunction(ExecutionState &state,
   uint64_t *args = (uint64_t*) alloca(2*sizeof(*args) * (arguments.size() + 1));
   memset(args, 0, 2 * sizeof(*args) * (arguments.size() + 1));
   unsigned wordIndex = 2;
-  for (std::vector<ref<Expr> >::iterator ai = arguments.begin(), 
+  for (std::vector<ref<Expr> >::iterator ai = arguments.begin(),
        ae = arguments.end(); ai!=ae; ++ai) {
     if (ExternalCalls == ExternalCallPolicy::All) { // don't bother checking uniqueness
       *ai = optimizer.optimizeExpr(*ai, true);
@@ -3262,8 +3262,8 @@ void Executor::callExternalFunction(ExecutionState &state,
         ce->toMemory(&args[wordIndex]);
         wordIndex += (ce->getWidth()+63)/64;
       } else {
-        terminateStateOnExecError(state, 
-                                  "external call with symbolic argument: " + 
+        terminateStateOnExecError(state,
+                                  "external call with symbolic argument: " +
                                   function->getName());
         return;
       }
@@ -3304,7 +3304,7 @@ void Executor::callExternalFunction(ExecutionState &state,
         os << ", ";
     }
     os << ") at " << state.pc->getSourceLocation();
-    
+
     if (AllExternalWarnings)
       klee_warning("%s", os.str().c_str());
     else
@@ -3333,7 +3333,7 @@ void Executor::callExternalFunction(ExecutionState &state,
 
   Type *resultType = target->inst->getType();
   if (resultType != Type::getVoidTy(function->getContext())) {
-    ref<Expr> e = ConstantExpr::fromMemory((void*) args, 
+    ref<Expr> e = ConstantExpr::fromMemory((void*) args,
                                            getWidthForLLVMType(resultType));
     bindLocal(target, state, e);
   }
@@ -3341,7 +3341,7 @@ void Executor::callExternalFunction(ExecutionState &state,
 
 /***/
 
-ref<Expr> Executor::replaceReadWithSymbolic(ExecutionState &state, 
+ref<Expr> Executor::replaceReadWithSymbolic(ExecutionState &state,
                                             ref<Expr> e) {
   unsigned n = interpreterOpts.MakeConcreteSymbolic;
   if (!n || replayKTest || replayPath)
@@ -3356,7 +3356,7 @@ ref<Expr> Executor::replaceReadWithSymbolic(ExecutionState &state,
 
   // create a new fresh location, assert it is equal to concrete value in e
   // and return it.
-  
+
   static unsigned id;
   const Array *array =
       arrayCache.CreateArray("rrws_arr" + llvm::utostr(++id),
@@ -3368,7 +3368,7 @@ ref<Expr> Executor::replaceReadWithSymbolic(ExecutionState &state,
   return res;
 }
 
-ObjectState *Executor::bindObjectInState(ExecutionState &state, 
+ObjectState *Executor::bindObjectInState(ExecutionState &state,
                                          const MemoryObject *mo,
                                          bool isLocal,
                                          const Array *array) {
@@ -3402,7 +3402,7 @@ void Executor::executeAlloc(ExecutionState &state,
         memory->allocate(CE->getZExtValue(), isLocal, /*isGlobal=*/false,
                          allocSite, allocationAlignment);
     if (!mo) {
-      bindLocal(target, state, 
+      bindLocal(target, state,
                 ConstantExpr::alloc(0, Context::get().getPointerWidth()));
     } else {
       ObjectState *os = bindObjectInState(state, mo, isLocal);
@@ -3412,7 +3412,7 @@ void Executor::executeAlloc(ExecutionState &state,
         os->initializeToRandom();
       }
       bindLocal(target, state, mo->getBaseExpr());
-      
+
       if (reallocFrom) {
         unsigned count = std::min(reallocFrom->size, os->size);
         for (unsigned i=0; i<count; i++)
@@ -3426,7 +3426,7 @@ void Executor::executeAlloc(ExecutionState &state,
     // "smartly" pick a value, for example we could fork and pick the
     // min and max values and perhaps some intermediate (reasonable
     // value).
-    // 
+    //
     // It would also be nice to recognize the case when size has
     // exactly two values and just fork (but we need to get rid of
     // return argument first). This shows up in pcre when llvm
@@ -3438,14 +3438,14 @@ void Executor::executeAlloc(ExecutionState &state,
     bool success = solver->getValue(state, size, example);
     assert(success && "FIXME: Unhandled solver failure");
     (void) success;
-    
+
     // Try and start with a small example.
     Expr::Width W = example->getWidth();
     while (example->Ugt(ConstantExpr::alloc(128, W))->isTrue()) {
       ref<ConstantExpr> tmp = example->LShr(ConstantExpr::alloc(1, W));
       bool res;
       bool success = solver->mayBeTrue(state, EqExpr::create(tmp, size), res);
-      assert(success && "FIXME: Unhandled solver failure");      
+      assert(success && "FIXME: Unhandled solver failure");
       (void) success;
       if (!res)
         break;
@@ -3453,18 +3453,18 @@ void Executor::executeAlloc(ExecutionState &state,
     }
 
     StatePair fixedSize = fork(state, EqExpr::create(example, size), true);
-    
-    if (fixedSize.second) { 
+
+    if (fixedSize.second) {
       // Check for exactly two values
       ref<ConstantExpr> tmp;
       bool success = solver->getValue(*fixedSize.second, size, tmp);
-      assert(success && "FIXME: Unhandled solver failure");      
+      assert(success && "FIXME: Unhandled solver failure");
       (void) success;
       bool res;
-      success = solver->mustBeTrue(*fixedSize.second, 
+      success = solver->mustBeTrue(*fixedSize.second,
                                    EqExpr::create(tmp, size),
                                    res);
-      assert(success && "FIXME: Unhandled solver failure");      
+      assert(success && "FIXME: Unhandled solver failure");
       (void) success;
       if (res) {
         executeAlloc(*fixedSize.second, tmp, isLocal,
@@ -3472,16 +3472,16 @@ void Executor::executeAlloc(ExecutionState &state,
       } else {
         // See if a *really* big value is possible. If so assume
         // malloc will fail for it, so lets fork and return 0.
-        StatePair hugeSize = 
-          fork(*fixedSize.second, 
+        StatePair hugeSize =
+          fork(*fixedSize.second,
                UltExpr::create(ConstantExpr::alloc(1U<<31, W), size),
                true);
         if (hugeSize.first) {
           klee_message("NOTE: found huge malloc, returning 0");
-          bindLocal(target, *hugeSize.first, 
+          bindLocal(target, *hugeSize.first,
                     ConstantExpr::alloc(0, Context::get().getPointerWidth()));
         }
-        
+
         if (hugeSize.second) {
 
           std::string Str;
@@ -3496,7 +3496,7 @@ void Executor::executeAlloc(ExecutionState &state,
     }
 
     if (fixedSize.first) // can be zero when fork fails
-      executeAlloc(*fixedSize.first, example, isLocal, 
+      executeAlloc(*fixedSize.first, example, isLocal,
                    target, zeroMemory, reallocFrom);
   }
 }
@@ -3513,8 +3513,8 @@ void Executor::executeFree(ExecutionState &state,
   if (zeroPointer.second) { // address != 0
     ExactResolutionList rl;
     resolveExact(*zeroPointer.second, address, rl, "free");
-    
-    for (Executor::ExactResolutionList::iterator it = rl.begin(), 
+
+    for (Executor::ExactResolutionList::iterator it = rl.begin(),
            ie = rl.end(); it != ie; ++it) {
       const MemoryObject *mo = it->first.first;
       if (mo->isLocal) {
@@ -3534,20 +3534,20 @@ void Executor::executeFree(ExecutionState &state,
 
 void Executor::resolveExact(ExecutionState &state,
                             ref<Expr> p,
-                            ExactResolutionList &results, 
+                            ExactResolutionList &results,
                             const std::string &name) {
   p = optimizer.optimizeExpr(p, true);
   // XXX we may want to be capping this?
   ResolutionList rl;
   state.addressSpace.resolve(state, solver, p, rl);
-  
+
   ExecutionState *unbound = &state;
-  for (ResolutionList::iterator it = rl.begin(), ie = rl.end(); 
+  for (ResolutionList::iterator it = rl.begin(), ie = rl.end();
        it != ie; ++it) {
     ref<Expr> inBounds = EqExpr::create(p, it->first->getBaseExpr());
-    
+
     StatePair branches = fork(*unbound, inBounds, true);
-    
+
     if (branches.first)
       results.push_back(std::make_pair(*it, branches.first));
 
@@ -3567,7 +3567,7 @@ void Executor::executeMemoryOperation(ExecutionState &state,
                                       ref<Expr> address,
                                       ref<Expr> value /* undef if read */,
                                       KInstruction *target /* undef if write */) {
-  Expr::Width type = (isWrite ? value->getWidth() : 
+  Expr::Width type = (isWrite ? value->getWidth() :
                      getWidthForLLVMType(target->inst->getType()));
   unsigned bytes = Expr::getMinBytesForWidth(type);
 
@@ -3596,7 +3596,7 @@ void Executor::executeMemoryOperation(ExecutionState &state,
     if (MaxSymArraySize && mo->size >= MaxSymArraySize) {
       address = toConstant(state, address, "max-sym-array-size");
     }
-    
+
     ref<Expr> offset = mo->getOffsetExpr(address);
     ref<Expr> check = mo->getBoundsCheckOffset(offset, bytes);
     check = optimizer.optimizeExpr(check, true);
@@ -3620,42 +3620,42 @@ void Executor::executeMemoryOperation(ExecutionState &state,
         } else {
           ObjectState *wos = state.addressSpace.getWriteable(mo, os);
           wos->write(offset, value);
-        }          
+        }
       } else {
         ref<Expr> result = os->read(offset, type);
-        
+
         if (interpreterOpts.MakeConcreteSymbolic)
           result = replaceReadWithSymbolic(state, result);
-        
+
         bindLocal(target, state, result);
       }
 
       return;
     }
-  } 
+  }
 
   // we are on an error path (no resolution, multiple resolution, one
   // resolution with out of bounds)
 
   address = optimizer.optimizeExpr(address, true);
-  ResolutionList rl;  
+  ResolutionList rl;
   solver->setTimeout(coreSolverTimeout);
   bool incomplete = state.addressSpace.resolve(state, solver, address, rl,
                                                0, coreSolverTimeout);
   solver->setTimeout(time::Span());
-  
+
   // XXX there is some query wasteage here. who cares?
   ExecutionState *unbound = &state;
-  
+
   for (ResolutionList::iterator i = rl.begin(), ie = rl.end(); i != ie; ++i) {
     const MemoryObject *mo = i->first;
     const ObjectState *os = i->second;
     ref<Expr> inBounds = mo->getBoundsCheckPointer(address, bytes);
-    
+
     StatePair branches = fork(*unbound, inBounds, true);
     ExecutionState *bound = branches.first;
 
-    // bound can be 0 on failure or overlapped 
+    // bound can be 0 on failure or overlapped
     if (bound) {
       if (isWrite) {
         if (os->readOnly) {
@@ -3675,7 +3675,7 @@ void Executor::executeMemoryOperation(ExecutionState &state,
     if (!unbound)
       break;
   }
-  
+
   // XXX should we distinguish out of bounds and overlapped cases?
   if (unbound) {
     if (incomplete) {
@@ -3687,7 +3687,7 @@ void Executor::executeMemoryOperation(ExecutionState &state,
   }
 }
 
-void Executor::executeMakeSymbolic(ExecutionState &state, 
+void Executor::executeMakeSymbolic(ExecutionState &state,
                                    const MemoryObject *mo,
                                    const std::string &name) {
   // Create a new object state for the memory object (instead of a copy).
@@ -3702,12 +3702,12 @@ void Executor::executeMakeSymbolic(ExecutionState &state,
     const Array *array = arrayCache.CreateArray(uniqueName, mo->size);
     bindObjectInState(state, mo, false, array);
     state.addSymbolic(mo, array);
-    
-    std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it = 
+
+    std::map< ExecutionState*, std::vector<SeedInfo> >::iterator it =
       seedMap.find(&state);
     if (it!=seedMap.end()) { // In seed mode we need to add this as a
                              // binding.
-      for (std::vector<SeedInfo>::iterator siit = it->second.begin(), 
+      for (std::vector<SeedInfo>::iterator siit = it->second.begin(),
              siie = it->second.end(); siit != siie; ++siit) {
         SeedInfo &si = *siit;
         KTestObject *obj = si.getNextInput(mo, NamedSeedMatching);
@@ -3736,7 +3736,7 @@ void Executor::executeMakeSymbolic(ExecutionState &state,
             break;
           } else {
             std::vector<unsigned char> &values = si.assignment.bindings[array];
-            values.insert(values.begin(), obj->bytes, 
+            values.insert(values.begin(), obj->bytes,
                           obj->bytes + std::min(obj->numBytes, mo->size));
             if (ZeroSeedExtension) {
               for (unsigned i=obj->numBytes; i<mo->size; ++i)
@@ -3773,7 +3773,7 @@ void Executor::runFunctionAsMain(Function *f,
   // force deterministic initialization of memory objects
   srand(1);
   srandom(1);
-  
+
   MemoryObject *argvMO = 0;
 
   // In order to make uclibc happy and be closer to what the system is
@@ -3813,10 +3813,10 @@ void Executor::runFunctionAsMain(Function *f,
   }
 
   ExecutionState *state = new ExecutionState(kmodule->functionMap[f]);
-  
-  if (pathWriter) 
+
+  if (pathWriter)
     state->pathOS = pathWriter->open();
-  if (symPathWriter) 
+  if (symPathWriter)
     state->symPathOS = symPathWriter->open();
 
 
@@ -3852,7 +3852,7 @@ void Executor::runFunctionAsMain(Function *f,
       }
     }
   }
-  
+
   initializeGlobals(*state);
 
   processTree = std::make_unique<PTree>(state);
@@ -3915,7 +3915,7 @@ void Executor::getConstraintLog(const ExecutionState &state, std::string &res,
 }
 
 bool Executor::getSymbolicSolution(const ExecutionState &state,
-                                   std::vector< 
+                                   std::vector<
                                    std::pair<std::string,
                                    std::vector<unsigned char> > >
                                    &res) {
@@ -3932,12 +3932,12 @@ bool Executor::getSymbolicSolution(const ExecutionState &state,
   // also make understanding individual test cases much easier.
   for (unsigned i = 0; i != state.symbolics.size(); ++i) {
     const MemoryObject *mo = state.symbolics[i].first;
-    std::vector< ref<Expr> >::const_iterator pi = 
+    std::vector< ref<Expr> >::const_iterator pi =
       mo->cexPreferences.begin(), pie = mo->cexPreferences.end();
     for (; pi != pie; ++pi) {
       bool mustBeTrue;
       // Attempt to bound byte to constraints held in cexPreferences
-      bool success = solver->mustBeTrue(tmp, Expr::createIsZero(*pi), 
+      bool success = solver->mustBeTrue(tmp, Expr::createIsZero(*pi),
 					mustBeTrue);
       // If it isn't possible to constrain this particular byte in the desired
       // way (normally this would mean that the byte can't be constrained to
@@ -3963,7 +3963,7 @@ bool Executor::getSymbolicSolution(const ExecutionState &state,
                              ConstantExpr::alloc(0, Expr::Bool));
     return false;
   }
-  
+
   for (unsigned i = 0; i != state.symbolics.size(); ++i)
     res.push_back(std::make_pair(state.symbolics[i].first->name, values[i]));
   return true;
@@ -3987,7 +3987,7 @@ void Executor::doImpliedValueConcretization(ExecutionState &state,
   for (ImpliedValueList::iterator it = results.begin(), ie = results.end();
        it != ie; ++it) {
     ReadExpr *re = it->first.get();
-    
+
     if (ConstantExpr *CE = dyn_cast<ConstantExpr>(re->index)) {
       // FIXME: This is the sole remaining usage of the Array object
       // variable. Kill me.
@@ -3999,7 +3999,7 @@ void Executor::doImpliedValueConcretization(ExecutionState &state,
         // in other cases we would like to concretize the outstanding
         // reads, but we have no facility for that yet)
       } else {
-        assert(!os->readOnly && 
+        assert(!os->readOnly &&
                "not possible? read only object with static read?");
         ObjectState *wos = state.addressSpace.getWriteable(mo, os);
         wos->write(CE, it->second);

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -51,7 +51,7 @@ namespace llvm {
   class Value;
 }
 
-namespace klee {  
+namespace klee {
   class Array;
   struct Cell;
   class ExecutionState;
@@ -138,13 +138,13 @@ private:
   std::set<ExecutionState *> inCloseMerge;
 
   /// Used to track states that have been added during the current
-  /// instructions step. 
-  /// \invariant \ref addedStates is a subset of \ref states. 
+  /// instructions step.
+  /// \invariant \ref addedStates is a subset of \ref states.
   /// \invariant \ref addedStates and \ref removedStates are disjoint.
   std::vector<ExecutionState *> addedStates;
   /// Used to track states that have been removed during the current
-  /// instructions step. 
-  /// \invariant \ref removedStates is a subset of \ref states. 
+  /// instructions step.
+  /// \invariant \ref removedStates is a subset of \ref states.
   /// \invariant \ref addedStates and \ref removedStates are disjoint.
   std::vector<ExecutionState *> removedStates;
 
@@ -163,7 +163,7 @@ private:
   /// happens with other states (that don't satisfy the seeds) depends
   /// on as-yet-to-be-determined flags.
   std::map<ExecutionState*, std::vector<SeedInfo> > seedMap;
-  
+
   /// Map of globals to their representative memory object.
   std::map<const llvm::GlobalValue*, MemoryObject*> globalObjects;
 
@@ -188,7 +188,7 @@ private:
 
   /// When non-null a list of "seed" inputs which will be used to
   /// drive execution.
-  const std::vector<struct KTest *> *usingSeeds;  
+  const std::vector<struct KTest *> *usingSeeds;
 
   /// Disables forking, instead a random path is chosen. Enabled as
   /// needed to control memory usage. \see fork()
@@ -199,7 +199,7 @@ private:
 
   /// Signals the executor to halt execution at the next instruction
   /// step.
-  bool haltExecution;  
+  bool haltExecution;
 
   /// Whether implied-value concretization is enabled. Currently
   /// false, it is buggy (it needs to validate its writes).
@@ -229,24 +229,24 @@ private:
 
   llvm::Function* getTargetFunction(llvm::Value *calledVal,
                                     ExecutionState &state);
-  
+
   void executeInstruction(ExecutionState &state, KInstruction *ki);
 
   void run(ExecutionState &initialState);
 
-  // Given a concrete object in our [klee's] address space, add it to 
+  // Given a concrete object in our [klee's] address space, add it to
   // objects checked code can reference.
-  MemoryObject *addExternalObject(ExecutionState &state, void *addr, 
+  MemoryObject *addExternalObject(ExecutionState &state, void *addr,
                                   unsigned size, bool isReadOnly);
 
-  void initializeGlobalObject(ExecutionState &state, ObjectState *os, 
+  void initializeGlobalObject(ExecutionState &state, ObjectState *os,
 			      const llvm::Constant *c,
 			      unsigned offset);
   void initializeGlobals(ExecutionState &state);
 
   void stepInstruction(ExecutionState &state);
   void updateStates(ExecutionState *current);
-  void transferToBasicBlock(llvm::BasicBlock *dst, 
+  void transferToBasicBlock(llvm::BasicBlock *dst,
 			    llvm::BasicBlock *src,
 			    ExecutionState &state);
 
@@ -266,7 +266,7 @@ private:
   /// \param results[out] A list of ((MemoryObject,ObjectState),
   /// state) pairs for each object the given address can point to the
   /// beginning of.
-  typedef std::vector< std::pair<std::pair<const MemoryObject*, const ObjectState*>, 
+  typedef std::vector< std::pair<std::pair<const MemoryObject*, const ObjectState*>,
                                  ExecutionState*> > ExactResolutionList;
   void resolveExact(ExecutionState &state,
                     ref<Expr> p,
@@ -308,12 +308,12 @@ private:
   void executeFree(ExecutionState &state,
                    ref<Expr> address,
                    KInstruction *target = 0);
-  
-  void executeCall(ExecutionState &state, 
+
+  void executeCall(ExecutionState &state,
                    KInstruction *ki,
                    llvm::Function *f,
                    std::vector< ref<Expr> > &arguments);
-                   
+
   // do address resolution / object binding / out of bounds checking
   // and perform the operation
   void executeMemoryOperation(ExecutionState &state,
@@ -329,7 +329,7 @@ private:
   /// a constraint and return the results. The input state is included
   /// as one of the results. Note that the output vector may included
   /// NULL pointers for states which were unable to be created.
-  void branch(ExecutionState &state, 
+  void branch(ExecutionState &state,
               const std::vector< ref<Expr> > &conditions,
               std::vector<ExecutionState*> &result);
 
@@ -348,7 +348,7 @@ private:
   // Used for testing.
   ref<Expr> replaceReadWithSymbolic(ExecutionState &state, ref<Expr> e);
 
-  const Cell& eval(KInstruction *ki, unsigned index, 
+  const Cell& eval(KInstruction *ki, unsigned index,
                    ExecutionState &state) const;
 
   Cell& getArgumentCell(ExecutionState &state,
@@ -362,10 +362,10 @@ private:
     return state.stack.back().locals[target->dest];
   }
 
-  void bindLocal(KInstruction *target, 
-                 ExecutionState &state, 
+  void bindLocal(KInstruction *target,
+                 ExecutionState &state,
                  ref<Expr> value);
-  void bindArgument(KFunction *kf, 
+  void bindArgument(KFunction *kf,
                     unsigned index,
                     ExecutionState &state,
                     ref<Expr> value);
@@ -393,7 +393,7 @@ private:
   /// should generally be avoided.
   ///
   /// \param purpose An identify string to printed in case of concretization.
-  ref<klee::ConstantExpr> toConstant(ExecutionState &state, ref<Expr> e, 
+  ref<klee::ConstantExpr> toConstant(ExecutionState &state, ref<Expr> e,
                                      const char *purpose);
 
   /// Bind a constant value for e to the given target. NOTE: This
@@ -429,7 +429,7 @@ private:
   // call error handler and terminate state, for execution errors
   // (things that should not be possible, like illegal instruction or
   // unlowered instrinsic, or are unsupported, like inline assembly)
-  void terminateStateOnExecError(ExecutionState &state, 
+  void terminateStateOnExecError(ExecutionState &state,
                                  const llvm::Twine &message,
                                  const llvm::Twine &info="") {
     terminateStateOnError(state, message, Exec, NULL, info);
@@ -527,7 +527,7 @@ public:
   /// Returns the errno location in memory of the state
   int *getErrnoLocation(const ExecutionState &state) const;
 };
-  
+
 } // End klee namespace
 
 #endif /* KLEE_EXECUTOR_H */

--- a/lib/Core/ExecutorUtil.cpp
+++ b/lib/Core/ExecutorUtil.cpp
@@ -178,7 +178,7 @@ namespace klee {
          << (ki ? ki->getSourceLocation() : "[unknown]");
       klee_error("%s", os.str().c_str());
 
-    case Instruction::Trunc: 
+    case Instruction::Trunc:
       return op1->Extract(0, getWidthForLLVMType(type));
     case Instruction::ZExt:  return op1->ZExt(getWidthForLLVMType(type));
     case Instruction::SExt:  return op1->SExt(getWidthForLLVMType(type));
@@ -236,7 +236,7 @@ namespace klee {
       }
       return base;
     }
-      
+
     case Instruction::ICmp: {
       switch(ce->getPredicate()) {
       default: assert(0 && "unhandled ICmp predicate");

--- a/lib/Core/ImpliedValue.cpp
+++ b/lib/Core/ImpliedValue.cpp
@@ -29,7 +29,7 @@ void ImpliedValue::getImpliedValues(ref<Expr> e,
                                     ImpliedValueList &results) {
   switch (e->getKind()) {
   case Expr::Constant: {
-    assert(value == cast<ConstantExpr>(e) && 
+    assert(value == cast<ConstantExpr>(e) &&
            "error in implied value calculation");
     break;
   }
@@ -47,21 +47,21 @@ void ImpliedValue::getImpliedValues(ref<Expr> e,
     results.push_back(std::make_pair(re, value));
     break;
   }
-    
+
   case Expr::Select: {
     // not much to do, could improve with range analysis
     SelectExpr *se = cast<SelectExpr>(e);
-    
+
     if (ConstantExpr *TrueCE = dyn_cast<ConstantExpr>(se->trueExpr)) {
       if (ConstantExpr *FalseCE = dyn_cast<ConstantExpr>(se->falseExpr)) {
         if (TrueCE != FalseCE) {
           if (value == TrueCE) {
-            getImpliedValues(se->cond, ConstantExpr::alloc(1, Expr::Bool), 
+            getImpliedValues(se->cond, ConstantExpr::alloc(1, Expr::Bool),
                              results);
           } else {
             assert(value == FalseCE &&
                    "err in implied value calculation");
-            getImpliedValues(se->cond, ConstantExpr::alloc(0, Expr::Bool), 
+            getImpliedValues(se->cond, ConstantExpr::alloc(0, Expr::Bool),
                              results);
           }
         }
@@ -80,7 +80,7 @@ void ImpliedValue::getImpliedValues(ref<Expr> e,
                      results);
     break;
   }
-    
+
   case Expr::Extract: {
     // XXX, could do more here with "some bits" mask
     break;
@@ -88,7 +88,7 @@ void ImpliedValue::getImpliedValues(ref<Expr> e,
 
     // Casting
 
-  case Expr::ZExt: 
+  case Expr::ZExt:
   case Expr::SExt: {
     CastExpr *ce = cast<CastExpr>(e);
     getImpliedValues(ce->src, value->Extract(0, ce->src->getWidth()),
@@ -157,7 +157,7 @@ void ImpliedValue::getImpliedValues(ref<Expr> e,
   }
 
     // Comparison
-  case Expr::Ne: 
+  case Expr::Ne:
     value = value->Not();
     /* fallthru */
   case Expr::Eq: {
@@ -172,20 +172,20 @@ void ImpliedValue::getImpliedValues(ref<Expr> e,
       // this trick. The only obvious case where this occurs, aside from
       // booleans, is as the result of a select expression where the true and
       // false branches are single valued and distinct.
-      
+
       if (ConstantExpr *CE = dyn_cast<ConstantExpr>(ee->left))
         if (CE->getWidth() == Expr::Bool)
           getImpliedValues(ee->right, CE->Not(), results);
     }
     break;
   }
-    
+
   default:
     break;
   }
 }
-    
-void ImpliedValue::checkForImpliedValues(Solver *S, ref<Expr> e, 
+
+void ImpliedValue::checkForImpliedValues(Solver *S, ref<Expr> e,
                                          ref<ConstantExpr> value) {
   std::vector<ref<ReadExpr> > reads;
   std::map<ref<ReadExpr>, ref<ConstantExpr> > found;
@@ -195,7 +195,7 @@ void ImpliedValue::checkForImpliedValues(Solver *S, ref<Expr> e,
 
   for (ImpliedValueList::iterator i = results.begin(), ie = results.end();
        i != ie; ++i) {
-    std::map<ref<ReadExpr>, ref<ConstantExpr> >::iterator it = 
+    std::map<ref<ReadExpr>, ref<ConstantExpr> >::iterator it =
       found.find(i->first);
     if (it != found.end()) {
       assert(it->second == i->second && "Invalid ImpliedValue!");
@@ -217,25 +217,25 @@ void ImpliedValue::checkForImpliedValues(Solver *S, ref<Expr> e,
   // bounds indices which will not get picked up. this is of utmost
   // importance if we are being backed by the CexCachingSolver.
 
-  for (std::vector< ref<ReadExpr> >::iterator i = reads.begin(), 
+  for (std::vector< ref<ReadExpr> >::iterator i = reads.begin(),
          ie = reads.end(); i != ie; ++i) {
     ReadExpr *re = i->get();
-    assumption.push_back(UltExpr::create(re->index, 
-                                         ConstantExpr::alloc(re->updates.root->size, 
+    assumption.push_back(UltExpr::create(re->index,
+                                         ConstantExpr::alloc(re->updates.root->size,
                                                              Context::get().getPointerWidth())));
   }
 
   ConstraintManager assume(assumption);
-  for (std::vector< ref<ReadExpr> >::iterator i = reads.begin(), 
+  for (std::vector< ref<ReadExpr> >::iterator i = reads.begin(),
          ie = reads.end(); i != ie; ++i) {
     ref<ReadExpr> var = *i;
     ref<ConstantExpr> possible;
     bool success = S->getValue(Query(assume, var), possible); (void) success;
-    assert(success && "FIXME: Unhandled solver failure");    
+    assert(success && "FIXME: Unhandled solver failure");
     std::map<ref<ReadExpr>, ref<ConstantExpr> >::iterator it = found.find(var);
     bool res;
     success = S->mustBeTrue(Query(assume, EqExpr::create(var, possible)), res);
-    assert(success && "FIXME: Unhandled solver failure");    
+    assert(success && "FIXME: Unhandled solver failure");
     if (res) {
       if (it != found.end()) {
         assert(possible == it->second && "Invalid ImpliedValue!");

--- a/lib/Core/ImpliedValue.h
+++ b/lib/Core/ImpliedValue.h
@@ -26,14 +26,14 @@ namespace klee {
   class ReadExpr;
   class Solver;
 
-  typedef std::vector< std::pair<ref<ReadExpr>, 
+  typedef std::vector< std::pair<ref<ReadExpr>,
                                  ref<ConstantExpr> > > ImpliedValueList;
-  
-  namespace ImpliedValue {        
-    void getImpliedValues(ref<Expr> e, ref<ConstantExpr> cvalue, 
+
+  namespace ImpliedValue {
+    void getImpliedValues(ref<Expr> e, ref<ConstantExpr> cvalue,
                           ImpliedValueList &result);
-    void checkForImpliedValues(Solver *S, ref<Expr> e, 
-                               ref<ConstantExpr> cvalue);    
+    void checkForImpliedValues(Solver *S, ref<Expr> e,
+                               ref<ConstantExpr> cvalue);
   }
 
 }

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -60,7 +60,7 @@ public:
   /// should be either the allocating instruction or the global object
   /// it was allocated for (or whatever else makes sense).
   const llvm::Value *allocSite;
-  
+
   /// A list of boolean expressions the user has requested be true of
   /// a counterexample. Mutable since we play a little fast and loose
   /// with allowing it to be added to during execution (although
@@ -74,9 +74,9 @@ public:
 public:
   // XXX this is just a temp hack, should be removed
   explicit
-  MemoryObject(uint64_t _address) 
+  MemoryObject(uint64_t _address)
     : refCount(0),
-      id(counter++), 
+      id(counter++),
       address(_address),
       size(0),
       isFixed(true),
@@ -84,11 +84,11 @@ public:
       allocSite(0) {
   }
 
-  MemoryObject(uint64_t _address, unsigned _size, 
+  MemoryObject(uint64_t _address, unsigned _size,
                bool _isLocal, bool _isGlobal, bool _isFixed,
                const llvm::Value *_allocSite,
                MemoryManager *_parent)
-    : refCount(0), 
+    : refCount(0),
       id(counter++),
       address(_address),
       size(_size),
@@ -97,7 +97,7 @@ public:
       isGlobal(_isGlobal),
       isFixed(_isFixed),
       isUserSpecified(false),
-      parent(_parent), 
+      parent(_parent),
       allocSite(_allocSite) {
   }
 
@@ -110,10 +110,10 @@ public:
     this->name = name;
   }
 
-  ref<ConstantExpr> getBaseExpr() const { 
+  ref<ConstantExpr> getBaseExpr() const {
     return ConstantExpr::create(address, Context::get().getPointerWidth());
   }
-  ref<ConstantExpr> getSizeExpr() const { 
+  ref<ConstantExpr> getSizeExpr() const {
     return ConstantExpr::create(size, Context::get().getPointerWidth());
   }
   ref<Expr> getOffsetExpr(ref<Expr> pointer) const {
@@ -128,7 +128,7 @@ public:
 
   ref<Expr> getBoundsCheckOffset(ref<Expr> offset) const {
     if (size==0) {
-      return EqExpr::create(offset, 
+      return EqExpr::create(offset,
                             ConstantExpr::alloc(0, Context::get().getPointerWidth()));
     } else {
       return UltExpr::create(offset, getSizeExpr());
@@ -136,8 +136,8 @@ public:
   }
   ref<Expr> getBoundsCheckOffset(ref<Expr> offset, unsigned bytes) const {
     if (bytes<=size) {
-      return UltExpr::create(offset, 
-                             ConstantExpr::alloc(size - bytes + 1, 
+      return UltExpr::create(offset,
+                             ConstantExpr::alloc(size - bytes + 1,
                                                  Context::get().getPointerWidth()));
     } else {
       return ConstantExpr::alloc(0, Expr::Bool);
@@ -227,7 +227,7 @@ private:
   void write8(unsigned offset, ref<Expr> value);
   void write8(ref<Expr> offset, ref<Expr> value);
 
-  void fastRangeCheckOffset(ref<Expr> offset, unsigned *base_r, 
+  void fastRangeCheckOffset(ref<Expr> offset, unsigned *base_r,
                             unsigned *size_r) const;
   void flushRangeForRead(unsigned rangeBase, unsigned rangeSize) const;
   void flushRangeForWrite(unsigned rangeBase, unsigned rangeSize);
@@ -244,7 +244,7 @@ private:
 
   ArrayCache *getArrayCache() const;
 };
-  
+
 } // End klee namespace
 
 #endif /* KLEE_MEMORY_H */

--- a/lib/Core/ObjectHolder.h
+++ b/lib/Core/ObjectHolder.h
@@ -15,13 +15,13 @@ namespace klee {
 
   class ObjectHolder {
     ObjectState *os;
-    
+
   public:
     ObjectHolder() : os(0) {}
     ObjectHolder(ObjectState *_os);
     ObjectHolder(const ObjectHolder &b);
-    ~ObjectHolder(); 
-    
+    ~ObjectHolder();
+
     ObjectHolder &operator=(const ObjectHolder &b);
 
     operator class ObjectState *() { return os; }

--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -157,7 +157,7 @@ RandomSearcher::update(ExecutionState *current,
         break;
       }
     }
-    
+
     assert(ok && "invalid state removed");
   }
 }
@@ -168,7 +168,7 @@ WeightedRandomSearcher::WeightedRandomSearcher(WeightType _type)
   : states(new DiscretePDF<ExecutionState*>()),
     type(_type) {
   switch(type) {
-  case Depth: 
+  case Depth:
     updateWeights = false;
     break;
   case InstCount:
@@ -194,7 +194,7 @@ ExecutionState &WeightedRandomSearcher::selectState() {
 double WeightedRandomSearcher::getWeight(ExecutionState *es) {
   switch(type) {
   default:
-  case Depth: 
+  case Depth:
     return es->weight;
   case InstCount: {
     uint64_t count = theStatisticManager->getIndexedValue(stats::instructions,
@@ -250,8 +250,8 @@ void WeightedRandomSearcher::update(
   }
 }
 
-bool WeightedRandomSearcher::empty() { 
-  return states->empty(); 
+bool WeightedRandomSearcher::empty() {
+  return states->empty();
 }
 
 ///
@@ -289,8 +289,8 @@ RandomPathSearcher::update(ExecutionState *current,
                            const std::vector<ExecutionState *> &removedStates) {
 }
 
-bool RandomPathSearcher::empty() { 
-  return executor.states.empty(); 
+bool RandomPathSearcher::empty() {
+  return executor.states.empty();
 }
 
 ///
@@ -333,12 +333,12 @@ ExecutionState& MergingSearcher::selectState() {
 
 BatchingSearcher::BatchingSearcher(Searcher *_baseSearcher,
                                    time::Span _timeBudget,
-                                   unsigned _instructionBudget) 
+                                   unsigned _instructionBudget)
   : baseSearcher(_baseSearcher),
     timeBudget(_timeBudget),
     instructionBudget(_instructionBudget),
     lastState(0) {
-  
+
 }
 
 BatchingSearcher::~BatchingSearcher() {
@@ -414,7 +414,7 @@ void IterativeDeepeningTimeSearcher::update(
         pausedStates.erase(it2);
         alt.erase(std::remove(alt.begin(), alt.end(), es), alt.end());
       }
-    }    
+    }
     baseSearcher->update(current, addedStates, alt);
   } else {
     baseSearcher->update(current, addedStates, removedStates);

--- a/lib/Core/Searcher.h
+++ b/lib/Core/Searcher.h
@@ -140,7 +140,7 @@ namespace klee {
     DiscretePDF<ExecutionState*> *states;
     WeightType type;
     bool updateWeights;
-    
+
     double getWeight(ExecutionState*);
 
   public:
@@ -219,7 +219,7 @@ namespace klee {
     unsigned lastStartInstructions;
 
   public:
-    BatchingSearcher(Searcher *baseSearcher, 
+    BatchingSearcher(Searcher *baseSearcher,
                      time::Span _timeBudget,
                      unsigned _instructionBudget);
     ~BatchingSearcher();

--- a/lib/Core/SeedInfo.cpp
+++ b/lib/Core/SeedInfo.cpp
@@ -23,14 +23,14 @@ KTestObject *SeedInfo::getNextInput(const MemoryObject *mo,
                                    bool byName) {
   if (byName) {
     unsigned i;
-    
+
     for (i=0; i<input->numObjects; ++i) {
       KTestObject *obj = &input->objects[i];
       if (std::string(obj->name) == mo->name)
         if (used.insert(obj).second)
           return obj;
     }
-    
+
     // If first unused input matches in size then accept that as
     // well.
     for (i=0; i<input->numObjects; ++i)
@@ -45,19 +45,19 @@ KTestObject *SeedInfo::getNextInput(const MemoryObject *mo,
         return obj;
       }
     }
-    
+
     klee_warning_once(mo, "no seed input for: %s", mo->name.c_str());
     return 0;
   } else {
     if (inputPosition >= input->numObjects) {
-      return 0; 
+      return 0;
     } else {
       return &input->objects[inputPosition++];
     }
   }
 }
 
-void SeedInfo::patchSeed(const ExecutionState &state, 
+void SeedInfo::patchSeed(const ExecutionState &state,
                          ref<Expr> condition,
                          TimingSolver *solver) {
   std::vector< ref<Expr> > required(state.constraints.begin(),
@@ -73,27 +73,27 @@ void SeedInfo::patchSeed(const ExecutionState &state,
   std::set< std::pair<const Array*, unsigned> > directReads;
   std::vector< ref<ReadExpr> > reads;
   findReads(condition, false, reads);
-  for (std::vector< ref<ReadExpr> >::iterator it = reads.begin(), 
+  for (std::vector< ref<ReadExpr> >::iterator it = reads.begin(),
          ie = reads.end(); it != ie; ++it) {
     ReadExpr *re = it->get();
     if (ConstantExpr *CE = dyn_cast<ConstantExpr>(re->index)) {
-      directReads.insert(std::make_pair(re->updates.root, 
+      directReads.insert(std::make_pair(re->updates.root,
                                         (unsigned) CE->getZExtValue(32)));
     }
   }
-  
+
   for (std::set< std::pair<const Array*, unsigned> >::iterator
          it = directReads.begin(), ie = directReads.end(); it != ie; ++it) {
     const Array *array = it->first;
     unsigned i = it->second;
     ref<Expr> read = ReadExpr::create(UpdateList(array, 0),
                                       ConstantExpr::alloc(i, Expr::Int32));
-    
+
     // If not in bindings then this can't be a violation?
     Assignment::bindings_ty::iterator it2 = assignment.bindings.find(array);
     if (it2 != assignment.bindings.end()) {
-      ref<Expr> isSeed = EqExpr::create(read, 
-                                        ConstantExpr::alloc(it2->second[i], 
+      ref<Expr> isSeed = EqExpr::create(read,
+                                        ConstantExpr::alloc(it2->second[i],
                                                             Expr::Int8));
       bool res;
       bool success = solver->mustBeFalse(tmp, isSeed, res);
@@ -102,11 +102,11 @@ void SeedInfo::patchSeed(const ExecutionState &state,
       if (res) {
         ref<ConstantExpr> value;
         bool success = solver->getValue(tmp, read, value);
-        assert(success && "FIXME: Unhandled solver failure");            
+        assert(success && "FIXME: Unhandled solver failure");
         (void) success;
         it2->second[i] = value->getZExtValue(8);
-        tmp.addConstraint(EqExpr::create(read, 
-                                         ConstantExpr::alloc(it2->second[i], 
+        tmp.addConstraint(EqExpr::create(read,
+                                         ConstantExpr::alloc(it2->second[i],
                                                              Expr::Int8)));
       } else {
         tmp.addConstraint(isSeed);
@@ -120,17 +120,17 @@ void SeedInfo::patchSeed(const ExecutionState &state,
   (void) success;
   if (res)
     return;
-  
+
   // We could still do a lot better than this, for example by looking at
   // independence. But really, this shouldn't be happening often.
-  for (Assignment::bindings_ty::iterator it = assignment.bindings.begin(), 
+  for (Assignment::bindings_ty::iterator it = assignment.bindings.begin(),
          ie = assignment.bindings.end(); it != ie; ++it) {
     const Array *array = it->first;
     for (unsigned i=0; i<array->size; ++i) {
       ref<Expr> read = ReadExpr::create(UpdateList(array, 0),
                                         ConstantExpr::alloc(i, Expr::Int32));
-      ref<Expr> isSeed = EqExpr::create(read, 
-                                        ConstantExpr::alloc(it->second[i], 
+      ref<Expr> isSeed = EqExpr::create(read,
+                                        ConstantExpr::alloc(it->second[i],
                                                             Expr::Int8));
       bool res;
       bool success = solver->mustBeFalse(tmp, isSeed, res);
@@ -139,11 +139,11 @@ void SeedInfo::patchSeed(const ExecutionState &state,
       if (res) {
         ref<ConstantExpr> value;
         bool success = solver->getValue(tmp, read, value);
-        assert(success && "FIXME: Unhandled solver failure");            
+        assert(success && "FIXME: Unhandled solver failure");
         (void) success;
         it->second[i] = value->getZExtValue(8);
-        tmp.addConstraint(EqExpr::create(read, 
-                                         ConstantExpr::alloc(it->second[i], 
+        tmp.addConstraint(EqExpr::create(read,
+                                         ConstantExpr::alloc(it->second[i],
                                                              Expr::Int8)));
       } else {
         tmp.addConstraint(isSeed);
@@ -154,9 +154,9 @@ void SeedInfo::patchSeed(const ExecutionState &state,
 #ifndef NDEBUG
   {
     bool res;
-    bool success = 
+    bool success =
       solver->mayBeTrue(state, assignment.evaluate(condition), res);
-    assert(success && "FIXME: Unhandled solver failure");            
+    assert(success && "FIXME: Unhandled solver failure");
     (void) success;
     assert(res && "seed patching failed");
   }

--- a/lib/Core/SeedInfo.h
+++ b/lib/Core/SeedInfo.h
@@ -28,19 +28,19 @@ namespace klee {
     KTest *input;
     unsigned inputPosition;
     std::set<struct KTestObject*> used;
-    
+
   public:
     explicit
     SeedInfo(KTest *_input) : assignment(true),
                              input(_input),
                              inputPosition(0) {}
-    
+
     KTestObject *getNextInput(const MemoryObject *mo,
                              bool byName);
-    
+
     /// Patch the seed so that condition is satisfied while retaining as
     /// many of the seed values as possible.
-    void patchSeed(const ExecutionState &state, 
+    void patchSeed(const ExecutionState &state,
                    ref<Expr> condition,
                    TimingSolver *solver);
   };

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -165,7 +165,7 @@ int SpecialFunctionHandler::size() {
 	return sizeof(handlerInfo)/sizeof(handlerInfo[0]);
 }
 
-SpecialFunctionHandler::SpecialFunctionHandler(Executor &_executor) 
+SpecialFunctionHandler::SpecialFunctionHandler(Executor &_executor)
   : executor(_executor) {}
 
 void SpecialFunctionHandler::prepare(
@@ -199,24 +199,24 @@ void SpecialFunctionHandler::bind() {
   for (unsigned i=0; i<N; ++i) {
     HandlerInfo &hi = handlerInfo[i];
     Function *f = executor.kmodule->module->getFunction(hi.name);
-    
+
     if (f && (!hi.doNotOverride || f->isDeclaration()))
       handlers[f] = std::make_pair(hi.handler, hi.hasReturnValue);
   }
 }
 
 
-bool SpecialFunctionHandler::handle(ExecutionState &state, 
+bool SpecialFunctionHandler::handle(ExecutionState &state,
                                     Function *f,
                                     KInstruction *target,
                                     std::vector< ref<Expr> > &arguments) {
   handlers_ty::iterator it = handlers.find(f);
-  if (it != handlers.end()) {    
+  if (it != handlers.end()) {
     Handler h = it->second.first;
     bool hasReturnValue = it->second.second;
      // FIXME: Check this... add test?
     if (!hasReturnValue && !target->inst->use_empty()) {
-      executor.terminateStateOnExecError(state, 
+      executor.terminateStateOnExecError(state,
                                          "expected return value from void special function");
     } else {
       (this->*h)(state, target, arguments);
@@ -230,8 +230,8 @@ bool SpecialFunctionHandler::handle(ExecutionState &state,
 /****/
 
 // reads a concrete string from memory
-std::string 
-SpecialFunctionHandler::readStringAtAddress(ExecutionState &state, 
+std::string
+SpecialFunctionHandler::readStringAtAddress(ExecutionState &state,
                                             ref<Expr> addressExpr) {
   ObjectPair op;
   addressExpr = executor.toUnique(state, addressExpr);
@@ -249,8 +249,8 @@ SpecialFunctionHandler::readStringAtAddress(ExecutionState &state,
     return "";
   }
   bool res __attribute__ ((unused));
-  assert(executor.solver->mustBeTrue(state, 
-                                     EqExpr::create(address, 
+  assert(executor.solver->mustBeTrue(state,
+                                     EqExpr::create(address,
                                                     op.first->getBaseExpr()),
                                      res) &&
          res &&
@@ -264,12 +264,12 @@ SpecialFunctionHandler::readStringAtAddress(ExecutionState &state,
   for (i = 0; i < mo->size - 1; i++) {
     ref<Expr> cur = os->read8(i);
     cur = executor.toUnique(state, cur);
-    assert(isa<ConstantExpr>(cur) && 
+    assert(isa<ConstantExpr>(cur) &&
            "hit symbolic char while reading concrete string");
     buf[i] = cast<ConstantExpr>(cur)->getZExtValue(8);
   }
   buf[i] = 0;
-  
+
   std::string result(buf);
   delete[] buf;
   return result;
@@ -301,7 +301,7 @@ void SpecialFunctionHandler::handleSilentExit(ExecutionState &state,
 void SpecialFunctionHandler::handleAssert(ExecutionState &state,
                                           KInstruction *target,
                                           std::vector<ref<Expr> > &arguments) {
-  assert(arguments.size()==3 && "invalid number of arguments to _assert");  
+  assert(arguments.size()==3 && "invalid number of arguments to _assert");
   executor.terminateStateOnError(state,
 				 "ASSERTION FAIL: " + readStringAtAddress(state, arguments[0]),
 				 Executor::Assert);
@@ -320,7 +320,7 @@ void SpecialFunctionHandler::handleReportError(ExecutionState &state,
                                                KInstruction *target,
                                                std::vector<ref<Expr> > &arguments) {
   assert(arguments.size()==4 && "invalid number of arguments to klee_report_error");
-  
+
   // arguments[0], arguments[1] are file, line
   executor.terminateStateOnError(state,
 				 readStringAtAddress(state, arguments[2]),
@@ -450,12 +450,12 @@ void SpecialFunctionHandler::handleAssume(ExecutionState &state,
                             KInstruction *target,
                             std::vector<ref<Expr> > &arguments) {
   assert(arguments.size()==1 && "invalid number of arguments to klee_assume");
-  
+
   ref<Expr> e = arguments[0];
-  
+
   if (e->getWidth() != Expr::Bool)
     e = NeExpr::create(e, ConstantExpr::create(0, e->getWidth()));
-  
+
   bool res;
   bool success __attribute__ ((unused)) = executor.solver->mustBeFalse(state, e, res);
   assert(success && "FIXME: Unhandled solver failure");
@@ -477,7 +477,7 @@ void SpecialFunctionHandler::handleIsSymbolic(ExecutionState &state,
                                 std::vector<ref<Expr> > &arguments) {
   assert(arguments.size()==1 && "invalid number of arguments to klee_is_symbolic");
 
-  executor.bindLocal(target, state, 
+  executor.bindLocal(target, state,
                      ConstantExpr::create(!isa<ConstantExpr>(arguments[0]),
                                           Expr::Int32));
 }
@@ -494,7 +494,7 @@ void SpecialFunctionHandler::handlePreferCex(ExecutionState &state,
 
   Executor::ExactResolutionList rl;
   executor.resolveExact(state, arguments[0], rl, "prefex_cex");
-  
+
   assert(rl.size() == 1 &&
          "prefer_cex target must resolve to precisely one object");
 
@@ -524,11 +524,11 @@ void SpecialFunctionHandler::handleSetForking(ExecutionState &state,
   assert(arguments.size()==1 &&
          "invalid number of arguments to klee_set_forking");
   ref<Expr> value = executor.toUnique(state, arguments[0]);
-  
+
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(value)) {
     state.forkDisabled = CE->isZero();
   } else {
-    executor.terminateStateOnError(state, 
+    executor.terminateStateOnError(state,
                                    "klee_set_forking requires a constant arg",
                                    Executor::User);
   }
@@ -546,7 +546,7 @@ void SpecialFunctionHandler::handleWarning(ExecutionState &state,
   assert(arguments.size()==1 && "invalid number of arguments to klee_warning");
 
   std::string msg_str = readStringAtAddress(state, arguments[0]);
-  klee_warning("%s: %s", state.stack.back().kf->function->getName().data(), 
+  klee_warning("%s: %s", state.stack.back().kf->function->getName().data(),
                msg_str.c_str());
 }
 
@@ -575,13 +575,13 @@ void SpecialFunctionHandler::handlePrintRange(ExecutionState &state,
     bool success __attribute__ ((unused)) = executor.solver->getValue(state, arguments[1], value);
     assert(success && "FIXME: Unhandled solver failure");
     bool res;
-    success = executor.solver->mustBeTrue(state, 
-                                          EqExpr::create(arguments[1], value), 
+    success = executor.solver->mustBeTrue(state,
+                                          EqExpr::create(arguments[1], value),
                                           res);
     assert(success && "FIXME: Unhandled solver failure");
     if (res) {
       llvm::errs() << " == " << value;
-    } else { 
+    } else {
       llvm::errs() << " ~= " << value;
       std::pair< ref<Expr>, ref<Expr> > res =
         executor.solver->getRange(state, arguments[1]);
@@ -599,7 +599,7 @@ void SpecialFunctionHandler::handleGetObjSize(ExecutionState &state,
          "invalid number of arguments to klee_get_obj_size");
   Executor::ExactResolutionList rl;
   executor.resolveExact(state, arguments[0], rl, "klee_get_obj_size");
-  for (Executor::ExactResolutionList::iterator it = rl.begin(), 
+  for (Executor::ExactResolutionList::iterator it = rl.begin(),
          ie = rl.end(); it != ie; ++it) {
     executor.bindLocal(
         target, *it->second,
@@ -671,28 +671,28 @@ void SpecialFunctionHandler::handleRealloc(ExecutionState &state,
   ref<Expr> address = arguments[0];
   ref<Expr> size = arguments[1];
 
-  Executor::StatePair zeroSize = executor.fork(state, 
-                                               Expr::createIsZero(size), 
+  Executor::StatePair zeroSize = executor.fork(state,
+                                               Expr::createIsZero(size),
                                                true);
-  
+
   if (zeroSize.first) { // size == 0
-    executor.executeFree(*zeroSize.first, address, target);   
+    executor.executeFree(*zeroSize.first, address, target);
   }
   if (zeroSize.second) { // size != 0
-    Executor::StatePair zeroPointer = executor.fork(*zeroSize.second, 
-                                                    Expr::createIsZero(address), 
+    Executor::StatePair zeroPointer = executor.fork(*zeroSize.second,
+                                                    Expr::createIsZero(address),
                                                     true);
-    
+
     if (zeroPointer.first) { // address == 0
       executor.executeAlloc(*zeroPointer.first, size, false, target);
-    } 
+    }
     if (zeroPointer.second) { // address != 0
       Executor::ExactResolutionList rl;
       executor.resolveExact(*zeroPointer.second, address, rl, "realloc");
-      
-      for (Executor::ExactResolutionList::iterator it = rl.begin(), 
+
+      for (Executor::ExactResolutionList::iterator it = rl.begin(),
              ie = rl.end(); it != ie; ++it) {
-        executor.executeAlloc(*it->second, size, false, target, false, 
+        executor.executeAlloc(*it->second, size, false, target, false,
                               it->first.second);
       }
     }
@@ -710,7 +710,7 @@ void SpecialFunctionHandler::handleFree(ExecutionState &state,
 
 void SpecialFunctionHandler::handleCheckMemoryAccess(ExecutionState &state,
                                                      KInstruction *target,
-                                                     std::vector<ref<Expr> > 
+                                                     std::vector<ref<Expr> >
                                                        &arguments) {
   assert(arguments.size()==2 &&
          "invalid number of arguments to klee_check_memory_access");
@@ -718,7 +718,7 @@ void SpecialFunctionHandler::handleCheckMemoryAccess(ExecutionState &state,
   ref<Expr> address = executor.toUnique(state, arguments[0]);
   ref<Expr> size = executor.toUnique(state, arguments[1]);
   if (!isa<ConstantExpr>(address) || !isa<ConstantExpr>(size)) {
-    executor.terminateStateOnError(state, 
+    executor.terminateStateOnError(state,
                                    "check_memory_access requires constant args",
 				   Executor::User);
   } else {
@@ -730,8 +730,8 @@ void SpecialFunctionHandler::handleCheckMemoryAccess(ExecutionState &state,
 				     Executor::Ptr, NULL,
                                      executor.getAddressInfo(state, address));
     } else {
-      ref<Expr> chk = 
-        op.first->getBoundsCheckPointer(address, 
+      ref<Expr> chk =
+        op.first->getBoundsCheckPointer(address,
                                         cast<ConstantExpr>(size)->getZExtValue());
       if (!chk->isTrue()) {
         executor.terminateStateOnError(state,
@@ -761,7 +761,7 @@ void SpecialFunctionHandler::handleDefineFixedObject(ExecutionState &state,
          "expect constant address argument to klee_define_fixed_object");
   assert(isa<ConstantExpr>(arguments[1]) &&
          "expect constant size argument to klee_define_fixed_object");
-  
+
   uint64_t address = cast<ConstantExpr>(arguments[0])->getZExtValue();
   uint64_t size = cast<ConstantExpr>(arguments[1])->getZExtValue();
   MemoryObject *mo = executor.memory->allocateFixed(address, size, state.prevPC->inst);
@@ -788,36 +788,36 @@ void SpecialFunctionHandler::handleMakeSymbolic(ExecutionState &state,
 
   Executor::ExactResolutionList rl;
   executor.resolveExact(state, arguments[0], rl, "make_symbolic");
-  
-  for (Executor::ExactResolutionList::iterator it = rl.begin(), 
+
+  for (Executor::ExactResolutionList::iterator it = rl.begin(),
          ie = rl.end(); it != ie; ++it) {
     const MemoryObject *mo = it->first.first;
     mo->setName(name);
-    
+
     const ObjectState *old = it->first.second;
     ExecutionState *s = it->second;
-    
+
     if (old->readOnly) {
       executor.terminateStateOnError(*s, "cannot make readonly object symbolic",
                                      Executor::User);
       return;
-    } 
+    }
 
     // FIXME: Type coercion should be done consistently somewhere.
     bool res;
     bool success __attribute__ ((unused)) =
-      executor.solver->mustBeTrue(*s, 
+      executor.solver->mustBeTrue(*s,
                                   EqExpr::create(ZExtExpr::create(arguments[1],
                                                                   Context::get().getPointerWidth()),
                                                  mo->getSizeExpr()),
                                   res);
     assert(success && "FIXME: Unhandled solver failure");
-    
+
     if (res) {
       executor.executeMakeSymbolic(*s, mo, name);
-    } else {      
-      executor.terminateStateOnError(*s, 
-                                     "wrong size given to klee_make_symbolic[_name]", 
+    } else {
+      executor.terminateStateOnError(*s,
+                                     "wrong size given to klee_make_symbolic[_name]",
                                      Executor::User);
     }
   }
@@ -827,12 +827,12 @@ void SpecialFunctionHandler::handleMarkGlobal(ExecutionState &state,
                                               KInstruction *target,
                                               std::vector<ref<Expr> > &arguments) {
   assert(arguments.size()==1 &&
-         "invalid number of arguments to klee_mark_global");  
+         "invalid number of arguments to klee_mark_global");
 
   Executor::ExactResolutionList rl;
   executor.resolveExact(state, arguments[0], rl, "mark_global");
-  
-  for (Executor::ExactResolutionList::iterator it = rl.begin(), 
+
+  for (Executor::ExactResolutionList::iterator it = rl.begin(),
          ie = rl.end(); it != ie; ++it) {
     const MemoryObject *mo = it->first.first;
     assert(!mo->isLocal);

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -25,14 +25,14 @@ namespace klee {
   class ExecutionState;
   struct KInstruction;
   template<typename T> class ref;
-  
+
   class SpecialFunctionHandler {
   public:
     typedef void (SpecialFunctionHandler::*Handler)(ExecutionState &state,
-                                                    KInstruction *target, 
-                                                    std::vector<ref<Expr> > 
+                                                    KInstruction *target,
+                                                    std::vector<ref<Expr> >
                                                       &arguments);
-    typedef std::map<const llvm::Function*, 
+    typedef std::map<const llvm::Function*,
                      std::pair<Handler,bool> > handlers_ty;
 
     handlers_ty handlers;
@@ -86,7 +86,7 @@ namespace klee {
     /// prepared for execution.
     void bind();
 
-    bool handle(ExecutionState &state, 
+    bool handle(ExecutionState &state,
                 llvm::Function *f,
                 KInstruction *target,
                 std::vector< ref<Expr> > &arguments);
@@ -94,7 +94,7 @@ namespace klee {
     /* Convenience routines */
 
     std::string readStringAtAddress(ExecutionState &state, ref<Expr> address);
-    
+
     /* Handlers */
 
 #define HANDLER(name) void name(ExecutionState &state, \
@@ -107,7 +107,7 @@ namespace klee {
     HANDLER(handleCalloc);
     HANDLER(handleCheckMemoryAccess);
     HANDLER(handleDefineFixedObject);
-    HANDLER(handleDelete);    
+    HANDLER(handleDelete);
     HANDLER(handleDeleteArray);
     HANDLER(handleExit);
     HANDLER(handleErrnoLocation);

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -209,7 +209,7 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
         if (kf->trackCoverage && instructionIsCoverable(ki->inst))
           ++stats::uncoveredInstructions;
       }
-      
+
       if (kf->trackCoverage) {
         if (BranchInst *bi = dyn_cast<BranchInst>(ki->inst))
           if (!bi->isUnconditional())
@@ -289,7 +289,7 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
   }
 }
 
-StatsTracker::~StatsTracker() {  
+StatsTracker::~StatsTracker() {
   if (statsFile) {
     auto rc = sqlite3_step(transactionEndStmt);
     if (rc != SQLITE_DONE) {
@@ -379,8 +379,8 @@ void StatsTracker::framePushed(ExecutionState &es, StackFrame *parentFrame) {
 
     if (UseCallPaths) {
       CallPathNode *parent = parentFrame ? parentFrame->callPathNode : 0;
-      CallPathNode *cp = callPathManager.getCallPath(parent, 
-                                                     sf.caller ? sf.caller->inst : 0, 
+      CallPathNode *cp = callPathManager.getCallPath(parent,
+                                                     sf.caller ? sf.caller->inst : 0,
                                                      sf.kf->function);
       sf.callPathNode = cp;
       cp->count++;
@@ -581,7 +581,7 @@ void StatsTracker::writeIStats() {
   const auto m = executor.kmodule->module.get();
   uint64_t istatsMask = 0;
   llvm::raw_fd_ostream &of = *istatsFile;
-  
+
   // We assume that we didn't move the file pointer
   unsigned istatsSize = of.tell();
 
@@ -616,7 +616,7 @@ void StatsTracker::writeIStats() {
   for (unsigned i=0; i<nStats; i++) {
     if (istatsMask & (1<<i)) {
       Statistic &s = sm.getStatistic(i);
-      of << "event: " << s.getShortName() << " : " 
+      of << "event: " << s.getShortName() << " : "
          << s.getName() << "\n";
     }
   }
@@ -627,7 +627,7 @@ void StatsTracker::writeIStats() {
       of << sm.getStatistic(i).getShortName() << " ";
   }
   of << "\n";
-  
+
   // set state counts, decremented after we process so that we don't
   // have to zero all records each time.
   if (istatsMask & (1<<stats::states.getID()))
@@ -641,7 +641,7 @@ void StatsTracker::writeIStats() {
 
   of << "ob=" << objectFilename << "\n";
 
-  for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
+  for (Module::iterator fnIt = m->begin(), fn_ie = m->end();
        fnIt != fn_ie; ++fnIt) {
     if (!fnIt->isDeclaration()) {
       // Always try to write the filename before the function name, as otherwise
@@ -653,11 +653,11 @@ void StatsTracker::writeIStats() {
         of << "fl=" << ii.file << "\n";
         sourceFile = ii.file;
       }
-      
+
       of << "fn=" << fnIt->getName().str() << "\n";
-      for (Function::iterator bbIt = fnIt->begin(), bb_ie = fnIt->end(); 
+      for (Function::iterator bbIt = fnIt->begin(), bb_ie = fnIt->end();
            bbIt != bb_ie; ++bbIt) {
-        for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
+        for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end();
              it != ie; ++it) {
           Instruction *instr = &*it;
           const InstructionInfo &ii = executor.kmodule->infos->getInfo(*instr);
@@ -673,7 +673,7 @@ void StatsTracker::writeIStats() {
               of << sm.getIndexedValue(sm.getStatistic(i), index) << " ";
           of << "\n";
 
-          if (UseCallPaths && 
+          if (UseCallPaths &&
               (isa<CallInst>(instr) || isa<InvokeInst>(instr))) {
             CallSiteSummaryTable::iterator it = callSiteStats.find(instr);
             if (it!=callSiteStats.end()) {
@@ -720,12 +720,12 @@ void StatsTracker::writeIStats() {
 
   if (istatsMask & (1<<stats::states.getID()))
     updateStateStatistics((uint64_t)-1);
-  
+
   // Clear then end of the file if necessary (no truncate op?).
   unsigned pos = of.tell();
   for (unsigned i=pos; i<istatsSize; ++i)
     of << '\n';
-  
+
   of.flush();
 }
 
@@ -779,18 +779,18 @@ void StatsTracker::computeReachableUncovered() {
   static bool init = true;
   const InstructionInfoTable &infos = *km->infos;
   StatisticManager &sm = *theStatisticManager;
-  
+
   if (init) {
     init = false;
 
     // Compute call targets. It would be nice to use alias information
     // instead of assuming all indirect calls hit all escaping
     // functions, eh?
-    for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
+    for (Module::iterator fnIt = m->begin(), fn_ie = m->end();
          fnIt != fn_ie; ++fnIt) {
-      for (Function::iterator bbIt = fnIt->begin(), bb_ie = fnIt->end(); 
+      for (Function::iterator bbIt = fnIt->begin(), bb_ie = fnIt->end();
            bbIt != bb_ie; ++bbIt) {
-        for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
+        for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end();
              it != ie; ++it) {
           Instruction *inst = &*it;
           if (isa<CallInst>(inst) || isa<InvokeInst>(inst)) {
@@ -814,16 +814,16 @@ void StatsTracker::computeReachableUncovered() {
     }
 
     // Compute function callers as reflexion of callTargets.
-    for (calltargets_ty::iterator it = callTargets.begin(), 
+    for (calltargets_ty::iterator it = callTargets.begin(),
            ie = callTargets.end(); it != ie; ++it)
-      for (std::vector<Function*>::iterator fit = it->second.begin(), 
-             fie = it->second.end(); fit != fie; ++fit) 
+      for (std::vector<Function*>::iterator fit = it->second.begin(),
+             fie = it->second.end(); fit != fie; ++fit)
         functionCallers[*fit].push_back(it->first);
 
     // Initialize minDistToReturn to shortest paths through
     // functions. 0 is unreachable.
     std::vector<Instruction *> instructions;
-    for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
+    for (Module::iterator fnIt = m->begin(), fn_ie = m->end();
          fnIt != fn_ie; ++fnIt) {
       Function *fn = &*fnIt;
       if (fnIt->isDeclaration()) {
@@ -837,23 +837,23 @@ void StatsTracker::computeReachableUncovered() {
       }
 
       // Not sure if I should bother to preorder here. XXX I should.
-      for (Function::iterator bbIt = fnIt->begin(), bb_ie = fnIt->end(); 
+      for (Function::iterator bbIt = fnIt->begin(), bb_ie = fnIt->end();
            bbIt != bb_ie; ++bbIt) {
-        for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
+        for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end();
              it != ie; ++it) {
           Instruction *inst = &*it;
           instructions.push_back(inst);
           unsigned id = infos.getInfo(*inst).id;
-          sm.setIndexedValue(stats::minDistToReturn, 
-                             id, 
+          sm.setIndexedValue(stats::minDistToReturn,
+                             id,
                              isa<ReturnInst>(inst)
                              );
         }
       }
     }
-  
+
     std::reverse(instructions.begin(), instructions.end());
-    
+
     // I'm so lazy it's not even worklisted.
     bool changed;
     do {
@@ -877,7 +877,7 @@ void StatsTracker::computeReachableUncovered() {
         } else {
           bestThrough = 1;
         }
-       
+
         if (bestThrough) {
           unsigned id = infos.getInfo(*(*it)).id;
           uint64_t best, cur = best = sm.getIndexedValue(stats::minDistToReturn, id);
@@ -913,25 +913,25 @@ void StatsTracker::computeReachableUncovered() {
 
   // compute minDistToUncovered, 0 is unreachable
   std::vector<Instruction *> instructions;
-  for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
+  for (Module::iterator fnIt = m->begin(), fn_ie = m->end();
        fnIt != fn_ie; ++fnIt) {
     // Not sure if I should bother to preorder here.
-    for (Function::iterator bbIt = fnIt->begin(), bb_ie = fnIt->end(); 
+    for (Function::iterator bbIt = fnIt->begin(), bb_ie = fnIt->end();
          bbIt != bb_ie; ++bbIt) {
-      for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end(); 
+      for (BasicBlock::iterator it = bbIt->begin(), ie = bbIt->end();
            it != ie; ++it) {
         Instruction *inst = &*it;
         unsigned id = infos.getInfo(*inst).id;
         instructions.push_back(inst);
-        sm.setIndexedValue(stats::minDistToUncovered, 
-                           id, 
+        sm.setIndexedValue(stats::minDistToUncovered,
+                           id,
                            sm.getIndexedValue(stats::uncoveredInstructions, id));
       }
     }
   }
-  
+
   std::reverse(instructions.begin(), instructions.end());
-  
+
   // I'm so lazy it's not even worklisted.
   bool changed;
   do {
@@ -942,7 +942,7 @@ void StatsTracker::computeReachableUncovered() {
       uint64_t best, cur = best = sm.getIndexedValue(stats::minDistToUncovered,
                                                      infos.getInfo(*inst).id);
       unsigned bestThrough = 0;
-      
+
       if (isa<CallInst>(inst) || isa<InvokeInst>(inst)) {
         std::vector<Function*> &targets = callTargets[inst];
         for (std::vector<Function*>::iterator fnIt = targets.begin(),
@@ -967,7 +967,7 @@ void StatsTracker::computeReachableUncovered() {
       } else {
         bestThrough = 1;
       }
-      
+
       if (bestThrough) {
         std::vector<Instruction*> succs = getSuccs(inst);
         for (std::vector<Instruction*>::iterator it2 = succs.begin(),
@@ -1005,9 +1005,9 @@ void StatsTracker::computeReachableUncovered() {
         kii = next->caller;
         ++kii;
       }
-      
+
       sfIt->minDistToUncoveredOnReturn = currentFrameMinDist;
-      
+
       currentFrameMinDist = computeMinDistToUncovered(kii, currentFrameMinDist);
     }
   }

--- a/lib/Core/TimingSolver.cpp
+++ b/lib/Core/TimingSolver.cpp
@@ -42,7 +42,7 @@ bool TimingSolver::evaluate(const ExecutionState& state, ref<Expr> expr,
   return success;
 }
 
-bool TimingSolver::mustBeTrue(const ExecutionState& state, ref<Expr> expr, 
+bool TimingSolver::mustBeTrue(const ExecutionState& state, ref<Expr> expr,
                               bool &result) {
   // Fast path, to avoid timer and OS overhead.
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(expr)) {
@@ -67,7 +67,7 @@ bool TimingSolver::mustBeFalse(const ExecutionState& state, ref<Expr> expr,
   return mustBeTrue(state, Expr::createIsZero(expr), result);
 }
 
-bool TimingSolver::mayBeTrue(const ExecutionState& state, ref<Expr> expr, 
+bool TimingSolver::mayBeTrue(const ExecutionState& state, ref<Expr> expr,
                              bool &result) {
   bool res;
   if (!mustBeFalse(state, expr, res))
@@ -76,7 +76,7 @@ bool TimingSolver::mayBeTrue(const ExecutionState& state, ref<Expr> expr,
   return true;
 }
 
-bool TimingSolver::mayBeFalse(const ExecutionState& state, ref<Expr> expr, 
+bool TimingSolver::mayBeFalse(const ExecutionState& state, ref<Expr> expr,
                               bool &result) {
   bool res;
   if (!mustBeTrue(state, expr, res))
@@ -85,14 +85,14 @@ bool TimingSolver::mayBeFalse(const ExecutionState& state, ref<Expr> expr,
   return true;
 }
 
-bool TimingSolver::getValue(const ExecutionState& state, ref<Expr> expr, 
+bool TimingSolver::getValue(const ExecutionState& state, ref<Expr> expr,
                             ref<ConstantExpr> &result) {
   // Fast path, to avoid timer and OS overhead.
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(expr)) {
     result = CE;
     return true;
   }
-  
+
   TimerStatIncrementer timer(stats::solverTime);
 
   if (simplifyExprs)
@@ -105,8 +105,8 @@ bool TimingSolver::getValue(const ExecutionState& state, ref<Expr> expr,
   return success;
 }
 
-bool 
-TimingSolver::getInitialValues(const ExecutionState& state, 
+bool
+TimingSolver::getInitialValues(const ExecutionState& state,
                                const std::vector<const Array*>
                                  &objects,
                                std::vector< std::vector<unsigned char> >
@@ -117,11 +117,11 @@ TimingSolver::getInitialValues(const ExecutionState& state,
   TimerStatIncrementer timer(stats::solverTime);
 
   bool success = solver->getInitialValues(Query(state.constraints,
-                                                ConstantExpr::alloc(0, Expr::Bool)), 
+                                                ConstantExpr::alloc(0, Expr::Bool)),
                                           objects, result);
-  
+
   state.queryCost += timer.delta();
-  
+
   return success;
 }
 

--- a/lib/Core/TimingSolver.h
+++ b/lib/Core/TimingSolver.h
@@ -18,7 +18,7 @@
 
 namespace klee {
   class ExecutionState;
-  class Solver;  
+  class Solver;
 
   /// TimingSolver - A simple class which wraps a solver and handles
   /// tracking the statistics that we care about.
@@ -33,7 +33,7 @@ namespace klee {
     /// \param _simplifyExprs - Whether expressions should be
     /// simplified (via the constraint manager interface) prior to
     /// querying.
-    TimingSolver(Solver *_solver, bool _simplifyExprs = true) 
+    TimingSolver(Solver *_solver, bool _simplifyExprs = true)
       : solver(_solver), simplifyExprs(_simplifyExprs) {}
     ~TimingSolver() {
       delete solver;
@@ -42,7 +42,7 @@ namespace klee {
     void setTimeout(time::Span t) {
       solver->setCoreSolverTimeout(t);
     }
-    
+
     char *getConstraintLog(const Query& query) {
       return solver->getConstraintLog(query);
     }
@@ -57,10 +57,10 @@ namespace klee {
 
     bool mayBeFalse(const ExecutionState&, ref<Expr>, bool &result);
 
-    bool getValue(const ExecutionState &, ref<Expr> expr, 
+    bool getValue(const ExecutionState &, ref<Expr> expr,
                   ref<ConstantExpr> &result);
 
-    bool getInitialValues(const ExecutionState&, 
+    bool getInitialValues(const ExecutionState&,
                           const std::vector<const Array*> &objects,
                           std::vector< std::vector<unsigned char> > &result);
 

--- a/lib/Core/UserSearcher.cpp
+++ b/lib/Core/UserSearcher.cpp
@@ -125,14 +125,14 @@ Searcher *getNewSearcher(Searcher::CoreSearchType type, Executor &executor) {
 Searcher *klee::constructUserSearcher(Executor &executor) {
 
   Searcher *searcher = getNewSearcher(CoreSearch[0], executor);
-  
+
   if (CoreSearch.size() > 1) {
     std::vector<Searcher *> s;
     s.push_back(searcher);
 
     for (unsigned i=1; i<CoreSearch.size(); i++)
       s.push_back(getNewSearcher(CoreSearch[i], executor));
-    
+
     searcher = new InterleavedSearcher(s);
   }
 

--- a/lib/Expr/Constraints.cpp
+++ b/lib/Expr/Constraints.cpp
@@ -59,7 +59,7 @@ private:
   const std::map< ref<Expr>, ref<Expr> > &replacements;
 
 public:
-  ExprReplaceVisitor2(const std::map< ref<Expr>, ref<Expr> > &_replacements) 
+  ExprReplaceVisitor2(const std::map< ref<Expr>, ref<Expr> > &_replacements)
     : ExprVisitor(true),
       replacements(_replacements) {}
 
@@ -79,7 +79,7 @@ bool ConstraintManager::rewriteConstraints(ExprVisitor &visitor) {
   bool changed = false;
 
   constraints.swap(old);
-  for (ConstraintManager::constraints_ty::iterator 
+  for (ConstraintManager::constraints_ty::iterator
          it = old.begin(), ie = old.end(); it != ie; ++it) {
     ref<Expr> &ce = *it;
     ref<Expr> e = visitor.visit(ce);
@@ -96,7 +96,7 @@ bool ConstraintManager::rewriteConstraints(ExprVisitor &visitor) {
 }
 
 void ConstraintManager::simplifyForValidConstraint(ref<Expr> e) {
-  // XXX 
+  // XXX
 }
 
 ref<Expr> ConstraintManager::simplifyExpr(ref<Expr> e) const {
@@ -104,8 +104,8 @@ ref<Expr> ConstraintManager::simplifyExpr(ref<Expr> e) const {
     return e;
 
   std::map< ref<Expr>, ref<Expr> > equalities;
-  
-  for (ConstraintManager::constraints_ty::const_iterator 
+
+  for (ConstraintManager::constraints_ty::const_iterator
          it = constraints.begin(), ie = constraints.end(); it != ie; ++it) {
     if (const EqExpr *ee = dyn_cast<EqExpr>(*it)) {
       if (isa<ConstantExpr>(ee->left)) {
@@ -129,10 +129,10 @@ void ConstraintManager::addConstraintInternal(ref<Expr> e) {
 
   switch (e->getKind()) {
   case Expr::Constant:
-    assert(cast<ConstantExpr>(e)->isTrue() && 
+    assert(cast<ConstantExpr>(e)->isTrue() &&
            "attempt to add invalid (false) constraint");
     break;
-    
+
     // split to enable finer grained independence and other optimizations
   case Expr::And: {
     BinaryExpr *be = cast<BinaryExpr>(e);
@@ -157,7 +157,7 @@ void ConstraintManager::addConstraintInternal(ref<Expr> e) {
     constraints.push_back(e);
     break;
   }
-    
+
   default:
     constraints.push_back(e);
     break;

--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -48,43 +48,43 @@ ref<Expr> Expr::createTempRead(const Array *array, Expr::Width w) {
 
   switch (w) {
   default: assert(0 && "invalid width");
-  case Expr::Bool: 
-    return ZExtExpr::create(ReadExpr::create(ul, 
+  case Expr::Bool:
+    return ZExtExpr::create(ReadExpr::create(ul,
                                              ConstantExpr::alloc(0, Expr::Int32)),
                             Expr::Bool);
-  case Expr::Int8: 
-    return ReadExpr::create(ul, 
+  case Expr::Int8:
+    return ReadExpr::create(ul,
                             ConstantExpr::alloc(0,Expr::Int32));
-  case Expr::Int16: 
-    return ConcatExpr::create(ReadExpr::create(ul, 
+  case Expr::Int16:
+    return ConcatExpr::create(ReadExpr::create(ul,
                                                ConstantExpr::alloc(1,Expr::Int32)),
-                              ReadExpr::create(ul, 
+                              ReadExpr::create(ul,
                                                ConstantExpr::alloc(0,Expr::Int32)));
-  case Expr::Int32: 
-    return ConcatExpr::create4(ReadExpr::create(ul, 
+  case Expr::Int32:
+    return ConcatExpr::create4(ReadExpr::create(ul,
                                                 ConstantExpr::alloc(3,Expr::Int32)),
-                               ReadExpr::create(ul, 
+                               ReadExpr::create(ul,
                                                 ConstantExpr::alloc(2,Expr::Int32)),
-                               ReadExpr::create(ul, 
+                               ReadExpr::create(ul,
                                                 ConstantExpr::alloc(1,Expr::Int32)),
-                               ReadExpr::create(ul, 
+                               ReadExpr::create(ul,
                                                 ConstantExpr::alloc(0,Expr::Int32)));
-  case Expr::Int64: 
-    return ConcatExpr::create8(ReadExpr::create(ul, 
+  case Expr::Int64:
+    return ConcatExpr::create8(ReadExpr::create(ul,
                                                 ConstantExpr::alloc(7,Expr::Int32)),
-                               ReadExpr::create(ul, 
+                               ReadExpr::create(ul,
                                                 ConstantExpr::alloc(6,Expr::Int32)),
-                               ReadExpr::create(ul, 
+                               ReadExpr::create(ul,
                                                 ConstantExpr::alloc(5,Expr::Int32)),
-                               ReadExpr::create(ul, 
+                               ReadExpr::create(ul,
                                                 ConstantExpr::alloc(4,Expr::Int32)),
-                               ReadExpr::create(ul, 
+                               ReadExpr::create(ul,
                                                 ConstantExpr::alloc(3,Expr::Int32)),
-                               ReadExpr::create(ul, 
+                               ReadExpr::create(ul,
                                                 ConstantExpr::alloc(2,Expr::Int32)),
-                               ReadExpr::create(ul, 
+                               ReadExpr::create(ul,
                                                 ConstantExpr::alloc(1,Expr::Int32)),
-                               ReadExpr::create(ul, 
+                               ReadExpr::create(ul,
                                                 ConstantExpr::alloc(0,Expr::Int32)));
   }
 }
@@ -114,10 +114,10 @@ int Expr::compare(const Expr &b, ExprEquivSet &equivs) const {
   if (ak!=bk)
     return (ak < bk) ? -1 : 1;
 
-  if (hashValue != b.hashValue) 
+  if (hashValue != b.hashValue)
     return (hashValue < b.hashValue) ? -1 : 1;
 
-  if (int res = compareContents(b)) 
+  if (int res = compareContents(b))
     return res;
 
   unsigned aN = getNumKids();
@@ -184,7 +184,7 @@ unsigned Expr::computeHash() {
     res <<= 1;
     res ^= getKid(i)->hash() * Expr::MAGIC_HASH_CONSTANT;
   }
-  
+
   hashValue = res;
   return hashValue;
 }
@@ -239,7 +239,7 @@ ref<Expr> Expr::createFromKind(Kind k, std::vector<CreateArg> args) {
       assert(numArgs == 1 && args[0].isExpr() &&
              "invalid args array for given opcode");
       return NotOptimizedExpr::create(args[0].expr);
-      
+
     case Select:
       assert(numArgs == 3 && args[0].isExpr() &&
              args[1].isExpr() && args[2].isExpr() &&
@@ -249,19 +249,19 @@ ref<Expr> Expr::createFromKind(Kind k, std::vector<CreateArg> args) {
                                 args[2].expr);
 
     case Concat: {
-      assert(numArgs == 2 && args[0].isExpr() && args[1].isExpr() && 
+      assert(numArgs == 2 && args[0].isExpr() && args[1].isExpr() &&
              "invalid args array for Concat opcode");
-      
+
       return ConcatExpr::create(args[0].expr, args[1].expr);
     }
-      
+
 #define CAST_EXPR_CASE(T)                                    \
       case T:                                                \
         assert(numArgs == 2 &&				     \
                args[0].isExpr() && args[1].isWidth() &&      \
                "invalid args array for given opcode");       \
       return T ## Expr::create(args[0].expr, args[1].width); \
-      
+
 #define BINARY_EXPR_CASE(T)                                 \
       case T:                                               \
         assert(numArgs == 2 &&                              \
@@ -271,7 +271,7 @@ ref<Expr> Expr::createFromKind(Kind k, std::vector<CreateArg> args) {
 
       CAST_EXPR_CASE(ZExt);
       CAST_EXPR_CASE(SExt);
-      
+
       BINARY_EXPR_CASE(Add);
       BINARY_EXPR_CASE(Sub);
       BINARY_EXPR_CASE(Mul);
@@ -285,7 +285,7 @@ ref<Expr> Expr::createFromKind(Kind k, std::vector<CreateArg> args) {
       BINARY_EXPR_CASE(Shl);
       BINARY_EXPR_CASE(LShr);
       BINARY_EXPR_CASE(AShr);
-      
+
       BINARY_EXPR_CASE(Eq);
       BINARY_EXPR_CASE(Ne);
       BINARY_EXPR_CASE(Ult);
@@ -526,7 +526,7 @@ unsigned Array::computeHash() {
     res = (res * Expr::MAGIC_HASH_CONSTANT) + name[i];
   res = (res * Expr::MAGIC_HASH_CONSTANT) + size;
   hashValue = res;
-  return hashValue; 
+  return hashValue;
 }
 /***/
 
@@ -581,7 +581,7 @@ ref<Expr> ReadExpr::create(const UpdateList &ul, ref<Expr> index) {
   return ReadExpr::alloc(ul, index);
 }
 
-int ReadExpr::compareContents(const Expr &b) const { 
+int ReadExpr::compareContents(const Expr &b) const {
   return updates.compare(static_cast<const ReadExpr&>(b).updates);
 }
 
@@ -596,7 +596,7 @@ ref<Expr> SelectExpr::create(ref<Expr> c, ref<Expr> t, ref<Expr> f) {
   } else if (t==f) {
     return t;
   } else if (kt==Expr::Bool) { // c ? t : f  <=> (c and t) or (not c and f)
-    if (ConstantExpr *CE = dyn_cast<ConstantExpr>(t)) {      
+    if (ConstantExpr *CE = dyn_cast<ConstantExpr>(t)) {
       if (CE->isTrue()) {
         return OrExpr::create(c, f);
       } else {
@@ -610,7 +610,7 @@ ref<Expr> SelectExpr::create(ref<Expr> c, ref<Expr> t, ref<Expr> f) {
       }
     }
   }
-  
+
   return SelectExpr::alloc(c, t, f);
 }
 
@@ -618,7 +618,7 @@ ref<Expr> SelectExpr::create(ref<Expr> c, ref<Expr> t, ref<Expr> f) {
 
 ref<Expr> ConcatExpr::create(const ref<Expr> &l, const ref<Expr> &r) {
   Expr::Width w = l->getWidth() + r->getWidth();
-  
+
   // Fold concatenation of constants.
   //
   // FIXME: concat 0 x -> zext x ?
@@ -644,7 +644,7 @@ ref<Expr> ConcatExpr::createN(unsigned n_kids, const ref<Expr> kids[]) {
   assert(n_kids > 0);
   if (n_kids == 1)
     return kids[0];
-  
+
   ref<Expr> r = ConcatExpr::create(kids[n_kids-2], kids[n_kids-1]);
   for (int i=n_kids-3; i>=0; i--)
     r = ConcatExpr::create(kids[i], r);
@@ -662,7 +662,7 @@ ref<Expr> ConcatExpr::create8(const ref<Expr> &kid1, const ref<Expr> &kid2,
 			      const ref<Expr> &kid3, const ref<Expr> &kid4,
 			      const ref<Expr> &kid5, const ref<Expr> &kid6,
 			      const ref<Expr> &kid7, const ref<Expr> &kid8) {
-  return ConcatExpr::create(kid1, ConcatExpr::create(kid2, ConcatExpr::create(kid3, 
+  return ConcatExpr::create(kid1, ConcatExpr::create(kid2, ConcatExpr::create(kid3,
 			      ConcatExpr::create(kid4, ConcatExpr::create4(kid5, kid6, kid7, kid8)))));
 }
 
@@ -671,7 +671,7 @@ ref<Expr> ConcatExpr::create8(const ref<Expr> &kid1, const ref<Expr> &kid2,
 ref<Expr> ExtractExpr::create(ref<Expr> expr, unsigned off, Width w) {
   unsigned kw = expr->getWidth();
   assert(w > 0 && off + w <= kw && "invalid extract");
-  
+
   if (w == kw) {
     return expr;
   } else if (ConstantExpr *CE = dyn_cast<ConstantExpr>(expr)) {
@@ -682,7 +682,7 @@ ref<Expr> ExtractExpr::create(ref<Expr> expr, unsigned off, Width w) {
       // if the extract skips the right side of the concat
       if (off >= ce->getRight()->getWidth())
 	return ExtractExpr::create(ce->getLeft(), off - ce->getRight()->getWidth(), w);
-      
+
       // if the extract skips the left side of the concat
       if (off + w <= ce->getRight()->getWidth())
 	return ExtractExpr::create(ce->getRight(), off, w);
@@ -692,7 +692,7 @@ ref<Expr> ExtractExpr::create(ref<Expr> expr, unsigned off, Width w) {
 				ExtractExpr::create(ce->getKid(1), off, ce->getKid(1)->getWidth() - off));
     }
   }
-  
+
   return ExtractExpr::alloc(expr, off, w);
 }
 
@@ -701,7 +701,7 @@ ref<Expr> ExtractExpr::create(ref<Expr> expr, unsigned off, Width w) {
 ref<Expr> NotExpr::create(const ref<Expr> &e) {
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(e))
     return CE->Not();
-  
+
   return NotExpr::alloc(e);
 }
 
@@ -729,7 +729,7 @@ ref<Expr> SExtExpr::create(const ref<Expr> &e, Width w) {
     return ExtractExpr::create(e, 0, w);
   } else if (ConstantExpr *CE = dyn_cast<ConstantExpr>(e)) {
     return CE->SExt(w);
-  } else {    
+  } else {
     return SExtExpr::alloc(e, w);
   }
 }
@@ -789,7 +789,7 @@ static ref<Expr> AddExpr_create(Expr *l, Expr *r) {
     } else {
       return AddExpr::alloc(l, r);
     }
-  }  
+  }
 }
 
 static ref<Expr> SubExpr_createPartialR(const ref<ConstantExpr> &cl, Expr *r) {
@@ -812,7 +812,7 @@ static ref<Expr> SubExpr_createPartialR(const ref<ConstantExpr> &cl, Expr *r) {
 }
 static ref<Expr> SubExpr_createPartial(Expr *l, const ref<ConstantExpr> &cr) {
   // l - c => l + (-c)
-  return AddExpr_createPartial(l, 
+  return AddExpr_createPartial(l,
                                ConstantExpr::alloc(0, cr->getWidth())->Sub(cr));
 }
 static ref<Expr> SubExpr_create(Expr *l, Expr *r) {
@@ -839,7 +839,7 @@ static ref<Expr> SubExpr_create(Expr *l, Expr *r) {
     } else {
       return SubExpr::alloc(l, r);
     }
-  }  
+  }
 }
 
 static ref<Expr> MulExpr_createPartialR(const ref<ConstantExpr> &cl, Expr *r) {
@@ -860,7 +860,7 @@ static ref<Expr> MulExpr_createPartial(Expr *l, const ref<ConstantExpr> &cr) {
 }
 static ref<Expr> MulExpr_create(Expr *l, Expr *r) {
   Expr::Width type = l->getWidth();
-  
+
   if (type == Expr::Bool) {
     return AndExpr::alloc(l, r);
   } else {
@@ -1031,7 +1031,7 @@ ref<Expr>  _e_op ::create(const ref<Expr> &l, const ref<Expr> &r) {    \
     return _e_op ## _create(l.get(), r.get());                         \
   }                                                                    \
 }
-  
+
 
 static ref<Expr> EqExpr_create(const ref<Expr> &l, const ref<Expr> &r) {
   if (l == r) {
@@ -1045,8 +1045,8 @@ static ref<Expr> EqExpr_create(const ref<Expr> &l, const ref<Expr> &r) {
 /// Tries to optimize EqExpr cl == rd, where cl is a ConstantExpr and
 /// rd a ReadExpr.  If rd is a read into an all-constant array,
 /// returns a disjunction of equalities on the index.  Otherwise,
-/// returns the initial equality expression. 
-static ref<Expr> TryConstArrayOpt(const ref<ConstantExpr> &cl, 
+/// returns the initial equality expression.
+static ref<Expr> TryConstArrayOpt(const ref<ConstantExpr> &cl,
 				  ReadExpr *rd) {
   if (rd->updates.root->isSymbolicArray() || rd->updates.getSize())
     return EqExpr_create(cl, rd);
@@ -1062,9 +1062,9 @@ static ref<Expr> TryConstArrayOpt(const ref<ConstantExpr> &cl,
       // Arbitrary maximum on the size of disjunction.
       if (++numMatches > 100)
         return EqExpr_create(cl, rd);
-      
-      ref<Expr> mayBe = 
-        EqExpr::create(rd->index, ConstantExpr::alloc(i, 
+
+      ref<Expr> mayBe =
+        EqExpr::create(rd->index, ConstantExpr::alloc(i,
                                                       rd->index->getWidth()));
       res = OrExpr::create(res, mayBe);
     }
@@ -1073,7 +1073,7 @@ static ref<Expr> TryConstArrayOpt(const ref<ConstantExpr> &cl,
   return res;
 }
 
-static ref<Expr> EqExpr_createPartialR(const ref<ConstantExpr> &cl, Expr *r) {  
+static ref<Expr> EqExpr_createPartialR(const ref<ConstantExpr> &cl, Expr *r) {
   Expr::Width width = cl->getWidth();
 
   Expr::Kind rk = r->getKind();
@@ -1082,7 +1082,7 @@ static ref<Expr> EqExpr_createPartialR(const ref<ConstantExpr> &cl, Expr *r) {
       return r;
     } else {
       // 0 == ...
-      
+
       if (rk == Expr::Eq) {
         const EqExpr *ree = cast<EqExpr>(r);
 
@@ -1119,7 +1119,7 @@ static ref<Expr> EqExpr_createPartialR(const ref<ConstantExpr> &cl, Expr *r) {
     const ZExtExpr *zee = cast<ZExtExpr>(r);
     Expr::Width fromBits = zee->src->getWidth();
     ref<ConstantExpr> trunc = cl->ZExt(fromBits);
-    
+
     // pathological check, make sure it is possible to
     // zext to this value *from any value*
     if (cl == trunc->ZExt(width)) {
@@ -1131,7 +1131,7 @@ static ref<Expr> EqExpr_createPartialR(const ref<ConstantExpr> &cl, Expr *r) {
     const AddExpr *ae = cast<AddExpr>(r);
     if (isa<ConstantExpr>(ae->left)) {
       // c0 = c1 + b => c0 - c1 = b
-      return EqExpr_createPartialR(cast<ConstantExpr>(SubExpr::create(cl, 
+      return EqExpr_createPartialR(cast<ConstantExpr>(SubExpr::create(cl,
                                                                       ae->left)),
                                    ae->right.get());
     }
@@ -1139,21 +1139,21 @@ static ref<Expr> EqExpr_createPartialR(const ref<ConstantExpr> &cl, Expr *r) {
     const SubExpr *se = cast<SubExpr>(r);
     if (isa<ConstantExpr>(se->left)) {
       // c0 = c1 - b => c1 - c0 = b
-      return EqExpr_createPartialR(cast<ConstantExpr>(SubExpr::create(se->left, 
+      return EqExpr_createPartialR(cast<ConstantExpr>(SubExpr::create(se->left,
                                                                       cl)),
                                    se->right.get());
     }
   } else if (rk == Expr::Read && ConstArrayOpt) {
     return TryConstArrayOpt(cl, static_cast<ReadExpr*>(r));
   }
-    
+
   return EqExpr_create(cl, r);
 }
 
-static ref<Expr> EqExpr_createPartial(Expr *l, const ref<ConstantExpr> &cr) {  
+static ref<Expr> EqExpr_createPartial(Expr *l, const ref<ConstantExpr> &cr) {
   return EqExpr_createPartialR(cr, l);
 }
-  
+
 ref<Expr> NeExpr::create(const ref<Expr> &l, const ref<Expr> &r) {
   return EqExpr::create(ConstantExpr::create(0, Expr::Bool),
                         EqExpr::create(l, r));

--- a/lib/Expr/ExprBuilder.cpp
+++ b/lib/Expr/ExprBuilder.cpp
@@ -164,7 +164,7 @@ namespace {
     ExprBuilder *Base;
 
   public:
-    ChainedBuilder(ExprBuilder *_Builder, ExprBuilder *_Base) 
+    ChainedBuilder(ExprBuilder *_Builder, ExprBuilder *_Base)
       : Builder(_Builder), Base(_Base) {}
     ~ChainedBuilder() { delete Base; }
 
@@ -951,10 +951,10 @@ namespace {
       return Base->Xor(LHS, RHS);
     }
 
-    ref<Expr> Eq(const ref<ConstantExpr> &LHS, 
+    ref<Expr> Eq(const ref<ConstantExpr> &LHS,
                  const ref<NonConstantExpr> &RHS) {
       Expr::Width Width = LHS->getWidth();
-      
+
       if (Width == Expr::Bool) {
         // true == X ==> X
         if (LHS->isTrue())
@@ -967,12 +967,12 @@ namespace {
       return Base->Eq(LHS, RHS);
     }
 
-    ref<Expr> Eq(const ref<NonConstantExpr> &LHS, 
+    ref<Expr> Eq(const ref<NonConstantExpr> &LHS,
                  const ref<ConstantExpr> &RHS) {
       return Eq(RHS, LHS);
     }
 
-    ref<Expr> Eq(const ref<NonConstantExpr> &LHS, 
+    ref<Expr> Eq(const ref<NonConstantExpr> &LHS,
                  const ref<NonConstantExpr> &RHS) {
       return Base->Eq(LHS, RHS);
     }
@@ -986,10 +986,10 @@ namespace {
     SimplifyingBuilder(ExprBuilder *Builder, ExprBuilder *Base)
       : ChainedBuilder(Builder, Base) {}
 
-    ref<Expr> Eq(const ref<ConstantExpr> &LHS, 
+    ref<Expr> Eq(const ref<ConstantExpr> &LHS,
                  const ref<NonConstantExpr> &RHS) {
       Expr::Width Width = LHS->getWidth();
-      
+
       if (Width == Expr::Bool) {
         // true == X ==> X
         if (LHS->isTrue())
@@ -1002,12 +1002,12 @@ namespace {
       return Base->Eq(LHS, RHS);
     }
 
-    ref<Expr> Eq(const ref<NonConstantExpr> &LHS, 
+    ref<Expr> Eq(const ref<NonConstantExpr> &LHS,
                  const ref<ConstantExpr> &RHS) {
       return Eq(RHS, LHS);
     }
 
-    ref<Expr> Eq(const ref<NonConstantExpr> &LHS, 
+    ref<Expr> Eq(const ref<NonConstantExpr> &LHS,
                  const ref<NonConstantExpr> &RHS) {
       // X == X ==> true
       if (LHS == RHS)

--- a/lib/Expr/ExprEvaluator.cpp
+++ b/lib/Expr/ExprEvaluator.cpp
@@ -15,7 +15,7 @@ ExprVisitor::Action ExprEvaluator::evalRead(const UpdateList &ul,
                                             unsigned index) {
   for (const UpdateNode *un=ul.head; un; un=un->next) {
     ref<Expr> ui = visit(un->index);
-    
+
     if (ConstantExpr *CE = dyn_cast<ConstantExpr>(ui)) {
       if (CE->getZExtValue() == index)
         return Action::changeTo(visit(un->value));
@@ -23,13 +23,13 @@ ExprVisitor::Action ExprEvaluator::evalRead(const UpdateList &ul,
       // update index is unknown, so may or may not be index, we
       // cannot guarantee value. we can rewrite to read at this
       // version though (mostly for debugging).
-      
-      return Action::changeTo(ReadExpr::create(UpdateList(ul.root, un), 
-                                               ConstantExpr::alloc(index, 
+
+      return Action::changeTo(ReadExpr::create(UpdateList(ul.root, un),
+                                               ConstantExpr::alloc(index,
                                                                    ul.root->getDomain())));
     }
   }
-  
+
   if (ul.root->isConstantArray() && index < ul.root->size)
     return Action::changeTo(ul.root->constantValues[index]);
 
@@ -59,7 +59,7 @@ ExprVisitor::Action ExprEvaluator::visitExpr(const Expr &e) {
 
 ExprVisitor::Action ExprEvaluator::visitRead(const ReadExpr &re) {
   ref<Expr> v = visit(re.index);
-  
+
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(v)) {
     return evalRead(re.updates, CE->getZExtValue());
   } else {
@@ -85,17 +85,17 @@ ExprVisitor::Action ExprEvaluator::protectedDivOperation(const BinaryExpr &e) {
   }
 }
 
-ExprVisitor::Action ExprEvaluator::visitUDiv(const UDivExpr &e) { 
-  return protectedDivOperation(e); 
+ExprVisitor::Action ExprEvaluator::visitUDiv(const UDivExpr &e) {
+  return protectedDivOperation(e);
 }
-ExprVisitor::Action ExprEvaluator::visitSDiv(const SDivExpr &e) { 
-  return protectedDivOperation(e); 
+ExprVisitor::Action ExprEvaluator::visitSDiv(const SDivExpr &e) {
+  return protectedDivOperation(e);
 }
-ExprVisitor::Action ExprEvaluator::visitURem(const URemExpr &e) { 
-  return protectedDivOperation(e); 
+ExprVisitor::Action ExprEvaluator::visitURem(const URemExpr &e) {
+  return protectedDivOperation(e);
 }
-ExprVisitor::Action ExprEvaluator::visitSRem(const SRemExpr &e) { 
-  return protectedDivOperation(e); 
+ExprVisitor::Action ExprEvaluator::visitSRem(const SRemExpr &e) {
+  return protectedDivOperation(e);
 }
 
 ExprVisitor::Action ExprEvaluator::visitExprPost(const Expr& e) {

--- a/lib/Expr/ExprPPrinter.cpp
+++ b/lib/Expr/ExprPPrinter.cpp
@@ -78,7 +78,7 @@ private:
     return e->getWidth() != Expr::Bool;
   }
 
-  bool isVerySimple(const ref<Expr> &e) { 
+  bool isVerySimple(const ref<Expr> &e) {
     return isa<ConstantExpr>(e) || bindings.find(e)!=bindings.end();
   }
 
@@ -88,7 +88,7 @@ private:
 
 
   // document me!
-  bool isSimple(const ref<Expr> &e) { 
+  bool isSimple(const ref<Expr> &e) {
     if (isVerySimple(e)) {
       return true;
     } else if (const ReadExpr *re = dyn_cast<ReadExpr>(e)) {
@@ -108,7 +108,7 @@ private:
           return false;
       return true;
   }
-  
+
   void scanUpdate(const UpdateNode *un) {
     // FIXME: This needs to be non-recursive.
     if (un) {
@@ -153,9 +153,9 @@ private:
     bool openedList = false, nextShouldBreak = false;
     unsigned outerIndent = PC.pos;
     unsigned middleIndent = 0;
-    for (const UpdateNode *un = head; un; un = un->next) {      
+    for (const UpdateNode *un = head; un; un = un->next) {
       // We are done if we hit the cache.
-      std::map<const UpdateNode*, unsigned>::iterator it = 
+      std::map<const UpdateNode*, unsigned>::iterator it =
         updateBindings.find(un);
       if (it!=updateBindings.end()) {
         if (openedList)
@@ -167,11 +167,11 @@ private:
           PC << "] @";
         if (un != head)
           PC.breakLine(outerIndent);
-        PC << "U" << updateCounter << ":"; 
+        PC << "U" << updateCounter << ":";
         updateBindings.insert(std::make_pair(un, updateCounter++));
         openedList = nextShouldBreak = false;
      }
-    
+
       if (!openedList) {
         openedList = 1;
         PC << '[';
@@ -187,8 +187,8 @@ private:
       PC << "=";
       print(un->value, PC);
       //PC << ')';
-      
-      nextShouldBreak = !(isa<ConstantExpr>(un->index) && 
+
+      nextShouldBreak = !(isa<ConstantExpr>(un->index) &&
                           isa<ConstantExpr>(un->value));
     }
 
@@ -211,26 +211,26 @@ private:
     PC << e->getWidth();
   }
 
-  
+
   bool isReadExprAtOffset(ref<Expr> e, const ReadExpr *base, ref<Expr> offset) {
     const ReadExpr *re = dyn_cast<ReadExpr>(e.get());
-      
+
     // right now, all Reads are byte reads but some
     // transformations might change this
     if (!re || (re->getWidth() != Expr::Int8))
       return false;
-      
-    // Check if the index follows the stride. 
+
+    // Check if the index follows the stride.
     // FIXME: How aggressive should this be simplified. The
     // canonicalizing builder is probably the right choice, but this
     // is yet another area where we would really prefer it to be
     // global or else use static methods.
     return SubExpr::create(re->index, base->index) == offset;
   }
-  
-  
+
+
   /// hasOrderedReads: \arg e must be a ConcatExpr, \arg stride must
-  /// be 1 or -1.  
+  /// be 1 or -1.
   ///
   /// If all children of this Concat are reads or concats of reads
   /// with consecutive offsets according to the given \arg stride, it
@@ -240,34 +240,34 @@ private:
   const ReadExpr* hasOrderedReads(ref<Expr> e, int stride) {
     assert(e->getKind() == Expr::Concat);
     assert(stride == 1 || stride == -1);
-    
+
     const ReadExpr *base = dyn_cast<ReadExpr>(e->getKid(0));
-    
+
     // right now, all Reads are byte reads but some
     // transformations might change this
     if (!base || base->getWidth() != Expr::Int8)
       return NULL;
-    
+
     // Get stride expr in proper index width.
     Expr::Width idxWidth = base->index->getWidth();
     ref<Expr> strideExpr = ConstantExpr::alloc(stride, idxWidth);
     ref<Expr> offset = ConstantExpr::create(0, idxWidth);
-    
+
     e = e->getKid(1);
-    
+
     // concat chains are unbalanced to the right
     while (e->getKind() == Expr::Concat) {
       offset = AddExpr::create(offset, strideExpr);
       if (!isReadExprAtOffset(e->getKid(0), base, offset))
 	return NULL;
-      
+
       e = e->getKid(1);
     }
-    
+
     offset = AddExpr::create(offset, strideExpr);
     if (!isReadExprAtOffset(e, base, offset))
       return NULL;
-    
+
     if (stride == -1)
       return cast<ReadExpr>(e.get());
     else return base;
@@ -307,7 +307,7 @@ private:
 
   void printExpr(const Expr *ep, PrintContext &PC, unsigned indent, bool printConstWidth=false) {
     bool simple = hasSimpleKids(ep);
-    
+
     print(ep->getKid(0), PC);
     for (unsigned i=1; i<ep->getNumKids(); i++) {
       printSeparator(PC, simple, indent);
@@ -352,14 +352,14 @@ public:
     print(e, PC);
   }
 
-  void printConst(const ref<ConstantExpr> &e, PrintContext &PC, 
+  void printConst(const ref<ConstantExpr> &e, PrintContext &PC,
                   bool printWidth) {
     if (e->getWidth() == Expr::Bool)
       PC << (e->isTrue() ? "true" : "false");
     else {
       if (PCAllConstWidths)
 	printWidth = true;
-    
+
       if (printWidth)
 	PC << "(w" << e->getWidth() << " ";
 
@@ -373,7 +373,7 @@ public:
 
       if (printWidth)
 	PC << ")";
-    }    
+    }
   }
 
   void print(const ref<Expr> &e, PrintContext &PC, bool printConstWidth=false) {
@@ -425,7 +425,7 @@ public:
         } else if (e->getKind() == Expr::Concat || e->getKind() == Expr::SExt)
 	  printExpr(e.get(), PC, indent, true);
 	else
-          printExpr(e.get(), PC, indent);	
+          printExpr(e.get(), PC, indent);
         PC << ")";
       }
     }
@@ -447,7 +447,7 @@ ExprPPrinter *klee::ExprPPrinter::create(llvm::raw_ostream &os) {
 }
 
 void ExprPPrinter::printOne(llvm::raw_ostream &os,
-                            const char *message, 
+                            const char *message,
                             const ref<Expr> &e) {
   PPrinter p(os);
   p.scan(e);
@@ -493,7 +493,7 @@ void ExprPPrinter::printQuery(llvm::raw_ostream &os,
                               const Array * const *evalArraysEnd,
                               bool printArrayDecls) {
   PPrinter p(os);
-  
+
   for (ConstraintManager::const_iterator it = constraints.begin(),
          ie = constraints.end(); it != ie; ++it)
     p.scan(*it);
@@ -503,7 +503,7 @@ void ExprPPrinter::printQuery(llvm::raw_ostream &os,
     p.scan(*it);
 
   PrintContext PC(os);
-  
+
   // Print array declarations.
   if (printArrayDecls) {
     for (const Array * const* it = evalArraysBegin; it != evalArraysEnd; ++it)
@@ -533,7 +533,7 @@ void ExprPPrinter::printQuery(llvm::raw_ostream &os,
   }
 
   PC << "(query [";
-  
+
   // Ident at constraint list;
   unsigned indent = PC.pos;
   for (ConstraintManager::const_iterator it = constraints.begin(),

--- a/lib/Expr/ExprUtil.cpp
+++ b/lib/Expr/ExprUtil.cpp
@@ -16,14 +16,14 @@
 
 using namespace klee;
 
-void klee::findReads(ref<Expr> e, 
+void klee::findReads(ref<Expr> e,
                      bool visitUpdates,
                      std::vector< ref<ReadExpr> > &results) {
-  // Invariant: \forall_{i \in stack} !i.isConstant() && i \in visited 
+  // Invariant: \forall_{i \in stack} !i.isConstant() && i \in visited
   std::vector< ref<Expr> > stack;
   ExprHashSet visited;
   std::set<const UpdateNode *> updates;
-  
+
   if (!isa<ConstantExpr>(e)) {
     visited.insert(e);
     stack.push_back(e);
@@ -41,7 +41,7 @@ void klee::findReads(ref<Expr> e,
       if (!isa<ConstantExpr>(re->index) &&
           visited.insert(re->index).second)
         stack.push_back(re->index);
-      
+
       if (visitUpdates) {
         // XXX this is probably suboptimal. We want to avoid a potential
         // explosion traversing update lists which can be quite
@@ -97,7 +97,7 @@ protected:
 public:
   std::set<const Array*> results;
   std::vector<const Array*> &objects;
-  
+
   SymbolicObjectFinder(std::vector<const Array*> &_objects)
     : objects(_objects) {}
 };
@@ -120,7 +120,7 @@ ExprVisitor::Action ConstantArrayFinder::visitRead(const ReadExpr &re) {
 }
 
 template<typename InputIterator>
-void klee::findSymbolicObjects(InputIterator begin, 
+void klee::findSymbolicObjects(InputIterator begin,
                                InputIterator end,
                                std::vector<const Array*> &results) {
   SymbolicObjectFinder of(results);

--- a/lib/Expr/ExprVisitor.cpp
+++ b/lib/Expr/ExprVisitor.cpp
@@ -40,7 +40,7 @@ ref<Expr> ExprVisitor::visit(const ref<Expr> &e) {
 }
 
 ref<Expr> ExprVisitor::visitActual(const ref<Expr> &e) {
-  if (isa<ConstantExpr>(e)) {    
+  if (isa<ConstantExpr>(e)) {
     return e;
   } else {
     Expr &ep = *e.get();
@@ -96,7 +96,7 @@ ref<Expr> ExprVisitor::visitActual(const ref<Expr> &e) {
     switch(res.kind) {
     default:
       assert(0 && "invalid kind");
-    case Action::DoChildren: {  
+    case Action::DoChildren: {
       bool rebuild = false;
       ref<Expr> e(&ep), kids[8];
       unsigned count = ep.getNumKids();
@@ -135,126 +135,126 @@ ExprVisitor::Action ExprVisitor::visitExprPost(const Expr&) {
 }
 
 ExprVisitor::Action ExprVisitor::visitNotOptimized(const NotOptimizedExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitRead(const ReadExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitSelect(const SelectExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitConcat(const ConcatExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitExtract(const ExtractExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitZExt(const ZExtExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitSExt(const SExtExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitAdd(const AddExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitSub(const SubExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitMul(const MulExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitUDiv(const UDivExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitSDiv(const SDivExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitURem(const URemExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitSRem(const SRemExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitNot(const NotExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitAnd(const AndExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitOr(const OrExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitXor(const XorExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitShl(const ShlExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitLShr(const LShrExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitAShr(const AShrExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitEq(const EqExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitNe(const NeExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitUlt(const UltExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitUle(const UleExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitUgt(const UgtExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitUge(const UgeExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitSlt(const SltExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitSle(const SleExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitSgt(const SgtExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 
 ExprVisitor::Action ExprVisitor::visitSge(const SgeExpr&) {
-  return Action::doChildren(); 
+  return Action::doChildren();
 }
 

--- a/lib/Expr/Lexer.cpp
+++ b/lib/Expr/Lexer.cpp
@@ -63,8 +63,8 @@ static inline bool isInternalIdentifierChar(int Char) {
   return isalnum(Char) || Char == '_' || Char == '.' || Char == '-';
 }
 
-Lexer::Lexer(const llvm::MemoryBuffer *MB) 
-  : BufferPos(MB->getBufferStart()), BufferEnd(MB->getBufferEnd()), 
+Lexer::Lexer(const llvm::MemoryBuffer *MB)
+  : BufferPos(MB->getBufferStart()), BufferEnd(MB->getBufferEnd()),
     LineNumber(1), ColumnNumber(0) {
 }
 
@@ -126,7 +126,7 @@ static bool isReservedKW(const char *Str, unsigned N) {
     if (i==N || Str[i]=='.')
       return true;
   }
-  
+
   return false;
 }
 static bool isWidthKW(const char *Str, unsigned N) {
@@ -159,8 +159,8 @@ Token &Lexer::SetIdentifierTokenKind(Token &Result) {
       return SetTokenKind(Result, Token::KWFalse);
     if (memcmp("query", Result.start, 5) == 0)
       return SetTokenKind(Result, Token::KWQuery);
-    break;      
-    
+    break;
+
   case 6:
     if (memcmp("define", Result.start, 6) == 0)
       return SetTokenKind(Result, Token::KWReserved);
@@ -211,7 +211,7 @@ Token &Lexer::Lex(Token &Result) {
   Result.kind = Token::Unknown;
   Result.length = 0;
   Result.start = BufferPos;
-  
+
   // Skip whitespace.
   while (isspace(PeekNextChar()))
     GetNextChar();
@@ -222,7 +222,7 @@ Token &Lexer::Lex(Token &Result) {
   int Char = GetNextChar();
   switch (Char) {
   case -1:  return SetTokenKind(Result, Token::EndOfFile);
-    
+
   case '(': return SetTokenKind(Result, Token::LParen);
   case ')': return SetTokenKind(Result, Token::RParen);
   case ',': return SetTokenKind(Result, Token::Comma);

--- a/lib/Expr/Parser.cpp
+++ b/lib/Expr/Parser.cpp
@@ -40,15 +40,15 @@ namespace {
     ParseResult(T _Value) : IsValid(true), Value(_Value) {}
     ParseResult(bool _IsValid, T _Value) : IsValid(_IsValid), Value(_Value) {}
 
-    bool isValid() { 
-      return IsValid; 
+    bool isValid() {
+      return IsValid;
     }
-    T get() { 
+    T get() {
       assert(IsValid && "get() on invalid ParseResult!");
-      return Value; 
+      return Value;
     }
   };
-  
+
   class ExprResult {
     bool IsValid;
     ExprHandle Value;
@@ -59,12 +59,12 @@ namespace {
     ExprResult(ref<ConstantExpr> _Value) : IsValid(true), Value(_Value.get()) {}
     ExprResult(bool _IsValid, ExprHandle _Value) : IsValid(_IsValid), Value(_Value) {}
 
-    bool isValid() { 
-      return IsValid; 
+    bool isValid() {
+      return IsValid;
     }
-    ExprHandle get() { 
+    ExprHandle get() {
       assert(IsValid && "get() on invalid ParseResult!");
-      return Value; 
+      return Value;
     }
   };
 
@@ -87,11 +87,11 @@ namespace {
                                                    IsNumber(true) {}
     explicit NumberOrExprResult(ExprResult _AsExpr) : AsExpr(_AsExpr),
                                                       IsNumber(false) {}
-    
+
     bool isNumber() const { return IsNumber; }
-    const Token &getNumber() const { 
+    const Token &getNumber() const {
       assert(IsNumber && "Invalid accessor call.");
-      return AsNumber; 
+      return AsNumber;
     }
     const ExprResult &getExpr() const {
       assert(!IsNumber && "Invalid accessor call.");
@@ -125,13 +125,13 @@ namespace {
     /// Tok - The currently lexed token.
     Token Tok;
 
-    /// ParenLevel - The current depth of matched '(' tokens. 
+    /// ParenLevel - The current depth of matched '(' tokens.
     unsigned ParenLevel;
     /// SquareLevel - The current depth of matched '[' tokens.
     unsigned SquareLevel;
 
     /* Core parsing functionality */
-    
+
     const Identifier *GetOrCreateIdentifier(const Token &Tok);
 
     void GetNextNonCommentToken() {
@@ -187,7 +187,7 @@ namespace {
       case Token::RParen: return ConsumeRParen();
       case Token::LSquare: return ConsumeLSquare();
       case Token::RSquare: return ConsumeRSquare();
-      default: 
+      default:
         return ConsumeToken();
       }
     }
@@ -201,7 +201,7 @@ namespace {
       // with the current token an rparen. In most cases this should
       // have been handled differently (error reported,
       // whatever). Audit & resolve.
-      assert(Level <= ParenLevel && 
+      assert(Level <= ParenLevel &&
              "Refusing to skip until rparen at higher level.");
       while (Tok.kind != Token::EndOfFile) {
         if (Tok.kind == Token::RParen && ParenLevel == Level) {
@@ -217,7 +217,7 @@ namespace {
     void SkipUntilRParen() {
       SkipUntilRParen(ParenLevel);
     }
-    
+
     /// ExpectRParen - Utility method to close an sexp. This expects to
     /// eat an rparen, and emits a diagnostic and skips to the next one
     /// (or EOF) if it cannot.
@@ -240,7 +240,7 @@ namespace {
       // with the current token an rparen. In most cases this should
       // have been handled differently (error reported,
       // whatever). Audit & resolve.
-      assert(Level <= ParenLevel && 
+      assert(Level <= ParenLevel &&
              "Refusing to skip until rparen at higher level.");
       while (Tok.kind != Token::EndOfFile) {
         if (Tok.kind == Token::RSquare && ParenLevel == Level) {
@@ -256,7 +256,7 @@ namespace {
     void SkipUntilRSquare() {
       SkipUntilRSquare(ParenLevel);
     }
-    
+
     /// ExpectRSquare - Utility method to close an array. This expects
     /// to eat an rparen, and emits a diagnostic and skips to the next
     /// one (or EOF) if it cannot.
@@ -304,7 +304,7 @@ namespace {
     ExprResult ParseAnyReadParenExpr(const Token &Name,
                                      unsigned Kind,
                                      Expr::Width ResTy);
-    void ParseMatchedBinaryArgs(const Token &Name, 
+    void ParseMatchedBinaryArgs(const Token &Name,
                                 TypeResult ExpectType,
                                 ExprResult &LHS, ExprResult &RHS);
     ExprResult ParseNumber(Expr::Width Width);
@@ -316,7 +316,7 @@ namespace {
     TypeResult ParseTypeSpecifier();
 
     /*** Diagnostics ***/
-    
+
     void Error(const char *Message, const Token &At);
     void Error(const char *Message) { Error(Message, Tok); }
 
@@ -346,7 +346,7 @@ namespace {
     }
 
     virtual unsigned GetNumErrors() const {
-      return NumErrors; 
+      return NumErrors;
     }
   };
 }
@@ -395,14 +395,14 @@ Decl *ParserImpl::ParseTopLevelDecl() {
 /// ParseArrayDecl - Parse an array declaration. The lexer should be positioned
 /// at the opening 'array'.
 ///
-/// array-declaration = "array" name "[" [ size ] "]" ":" domain "->" range 
+/// array-declaration = "array" name "[" [ size ] "]" ":" domain "->" range
 ///                       "=" array-initializer
 /// array-initializer = "symbolic" | "{" { numeric-literal } "}"
 DeclResult ParserImpl::ParseArrayDecl() {
   // FIXME: Recovery here is horrible, we need to scan to next decl start or
   // something.
   ConsumeExpectedToken(Token::KWArray);
-  
+
   if (Tok.kind != Token::Identifier) {
     Error("expected identifier token.");
     return DeclResult();
@@ -415,7 +415,7 @@ DeclResult ParserImpl::ParseArrayDecl() {
   std::vector< ref<ConstantExpr> > Values;
 
   ConsumeToken();
-  
+
   if (Tok.kind != Token::LSquare) {
     Error("expected '['.");
     goto exit;
@@ -430,7 +430,7 @@ DeclResult ParserImpl::ParseArrayDecl() {
     goto exit;
   }
   ConsumeRSquare();
-  
+
   if (Tok.kind != Token::Colon) {
     Error("expected ':'.");
     goto exit;
@@ -452,7 +452,7 @@ DeclResult ParserImpl::ParseArrayDecl() {
   ConsumeExpectedToken(Token::Equals);
 
   if (Tok.kind == Token::KWSymbolic) {
-    ConsumeExpectedToken(Token::KWSymbolic);    
+    ConsumeExpectedToken(Token::KWSymbolic);
   } else if (Tok.kind == Token::LSquare) {
     ConsumeLSquare();
     while (Tok.kind != Token::RSquare) {
@@ -525,7 +525,7 @@ DeclResult ParserImpl::ParseArrayDecl() {
                                      &Values[0] + Values.size());
   else
     Root = TheArrayCache.CreateArray(Label->Name, Size.get());
-  ArrayDecl *AD = new ArrayDecl(Label, Size.get(), 
+  ArrayDecl *AD = new ArrayDecl(Label, Size.get(),
                                 DomainType.get(), RangeType.get(), Root);
 
   ArraySymTab[Label] = AD;
@@ -563,7 +563,7 @@ DeclResult ParserImpl::ParseCommandDecl() {
 
 /// ParseQueryCommand - Parse query command. The lexer should be
 /// positioned at the 'query' keyword.
-/// 
+///
 /// 'query' expressions-list expression [expressions-list [array-list]]
 DeclResult ParserImpl::ParseQueryCommand() {
   std::vector<ExprHandle> Constraints;
@@ -619,7 +619,7 @@ DeclResult ParserImpl::ParseQueryCommand() {
     SkipUntilRParen();
     return DeclResult();
   }
-  
+
   ConsumeLSquare();
   // FIXME: Should avoid reading past unbalanced parens here.
   while (Tok.kind != Token::RSquare) {
@@ -690,7 +690,7 @@ DeclResult ParserImpl::ParseQueryCommand() {
 /// ParseNumberOrExpr - Parse an expression whose type cannot be
 /// predicted.
 NumberOrExprResult ParserImpl::ParseNumberOrExpr() {
-  if (Tok.kind == Token::Number){ 
+  if (Tok.kind == Token::Number){
     Token Num = Tok;
     ConsumeToken();
     return NumberOrExprResult(Num);
@@ -719,14 +719,14 @@ ExprResult ParserImpl::ParseExpr(TypeResult ExpectedType) {
     ConsumeToken();
     return ExprResult(Builder->Constant(Value, Expr::Bool));
   }
-  
+
   if (Tok.kind == Token::Number) {
     if (!ExpectedType.isValid()) {
       Error("cannot infer type of number.");
       ConsumeToken();
       return ExprResult();
     }
-    
+
     return ParseNumber(ExpectedType.get());
   }
 
@@ -758,7 +758,7 @@ ExprResult ParserImpl::ParseExpr(TypeResult ExpectedType) {
   ExprResult Res = ParseParenExpr(ExpectedType);
   if (!Res.isValid()) {
     // If we know the type, define the identifier just so we don't get
-    // use-of-undef errors. 
+    // use-of-undef errors.
     // FIXME: Maybe we should let the symbol table map to invalid
     // entries?
     if (Label && ExpectedType.isValid()) {
@@ -767,7 +767,7 @@ ExprResult ParserImpl::ParseExpr(TypeResult ExpectedType) {
     }
     return Res;
   } else if (ExpectedType.isValid()) {
-    // Type check result.    
+    // Type check result.
     if (Res.get()->getWidth() != ExpectedType.get()) {
       // FIXME: Need more info, and range
       Error("expression has incorrect type.", Start);
@@ -799,19 +799,19 @@ enum MacroKind {
 /// kind. -1 indicates the kind is variadic or has non-expression
 /// arguments.
 /// \return True if the token is a valid kind or macro name.
-static bool LookupExprInfo(const Token &Tok, unsigned &Kind, 
+static bool LookupExprInfo(const Token &Tok, unsigned &Kind,
                            bool &IsFixed, int &NumArgs) {
 #define SetOK(kind, isfixed, numargs) (Kind=kind, IsFixed=isfixed,\
                                        NumArgs=numargs, true)
   assert(Tok.kind == Token::Identifier && "Unexpected token.");
-  
+
   switch (Tok.length) {
   case 2:
     if (memcmp(Tok.start, "Eq", 2) == 0)
       return SetOK(Expr::Eq, false, 2);
     if (memcmp(Tok.start, "Ne", 2) == 0)
       return SetOK(Expr::Ne, false, 2);
-    
+
     if (memcmp(Tok.start, "Or", 2) == 0)
       return SetOK(Expr::Or, true, 2);
     break;
@@ -851,7 +851,7 @@ static bool LookupExprInfo(const Token &Tok, unsigned &Kind,
       return SetOK(Expr::Sge, false, 2);
     break;
 
-    
+
 
   case 4:
     if (memcmp(Tok.start, "Read", 4) == 0)
@@ -869,20 +869,20 @@ static bool LookupExprInfo(const Token &Tok, unsigned &Kind,
       return SetOK(Expr::URem, true, 2);
     if (memcmp(Tok.start, "SRem", 4) == 0)
       return SetOK(Expr::SRem, true, 2);
-    
+
     if (memcmp(Tok.start, "SExt", 4) == 0)
       return SetOK(Expr::SExt, false, 1);
     if (memcmp(Tok.start, "ZExt", 4) == 0)
       return SetOK(Expr::ZExt, false, 1);
     break;
-    
+
   case 6:
     if (memcmp(Tok.start, "Concat", 6) == 0)
-      return SetOK(eMacroKind_Concat, false, -1); 
+      return SetOK(eMacroKind_Concat, false, -1);
     if (memcmp(Tok.start, "Select", 6) == 0)
       return SetOK(Expr::Select, false, 3);
     break;
-    
+
   case 7:
     if (memcmp(Tok.start, "Extract", 7) == 0)
       return SetOK(Expr::Extract, false, -1);
@@ -912,7 +912,7 @@ ExprResult ParserImpl::ParseParenExpr(TypeResult FIXME_UNUSED) {
   }
 
   ConsumeLParen();
-  
+
   // Check for coercion case (w32 11).
   if (Tok.kind == Token::KWWidth) {
     TypeResult ExpectedType = ParseTypeSpecifier();
@@ -922,18 +922,18 @@ ExprResult ParserImpl::ParseParenExpr(TypeResult FIXME_UNUSED) {
       SkipUntilRParen();
       return ExprResult();
     }
-    
+
     // Make sure this was a type specifier we support.
     ExprResult Res;
-    if (ExpectedType.isValid()) 
+    if (ExpectedType.isValid())
       Res = ParseNumber(ExpectedType.get());
     else
       ConsumeToken();
 
-    ExpectRParen("unexpected argument in coercion.");  
+    ExpectRParen("unexpected argument in coercion.");
     return Res;
   }
-  
+
   if (Tok.kind != Token::Identifier) {
     Error("unexpected token, expected expression.");
     SkipUntilRParen();
@@ -1020,7 +1020,7 @@ ExprResult ParserImpl::ParseUnaryParenExpr(const Token &Name,
   if (!Arg.isValid())
     Arg = Builder->Constant(0, ResTy);
 
-  ExpectRParen("unexpected argument in unary expression.");  
+  ExpectRParen("unexpected argument in unary expression.");
   ExprHandle E = Arg.get();
   switch (Kind) {
   case eMacroKind_Neg:
@@ -1046,7 +1046,7 @@ ExprResult ParserImpl::ParseUnaryParenExpr(const Token &Name,
 ///
 /// Name - The name token of the expression, for diagnostics.
 /// ExpectType - The expected type of the arguments, if known.
-void ParserImpl::ParseMatchedBinaryArgs(const Token &Name, 
+void ParserImpl::ParseMatchedBinaryArgs(const Token &Name,
                                         TypeResult ExpectType,
                                         ExprResult &LHS, ExprResult &RHS) {
   if (Tok.kind == Token::RParen) {
@@ -1076,7 +1076,7 @@ void ParserImpl::ParseMatchedBinaryArgs(const Token &Name,
 
     if (LHS_NOE.isNumber()) {
       NumberOrExprResult RHS_NOE = ParseNumberOrExpr();
-      
+
       if (RHS_NOE.isNumber()) {
         Error("ambiguous arguments to expression.", Name);
       } else {
@@ -1102,7 +1102,7 @@ ExprResult ParserImpl::ParseBinaryParenExpr(const Token &Name,
                                            unsigned Kind, bool IsFixed,
                                            Expr::Width ResTy) {
   ExprResult LHS, RHS;
-  ParseMatchedBinaryArgs(Name, IsFixed ? TypeResult(ResTy) : TypeResult(), 
+  ParseMatchedBinaryArgs(Name, IsFixed ? TypeResult(ResTy) : TypeResult(),
                          LHS, RHS);
   if (!LHS.isValid() || !RHS.isValid())
     return Builder->Constant(0, ResTy);
@@ -1113,7 +1113,7 @@ ExprResult ParserImpl::ParseBinaryParenExpr(const Token &Name,
     return Builder->Constant(0, ResTy);
   }
 
-  switch (Kind) {    
+  switch (Kind) {
   case Expr::Add: return Builder->Add(LHS_E, RHS_E);
   case Expr::Sub: return Builder->Sub(LHS_E, RHS_E);
   case Expr::Mul: return Builder->Mul(LHS_E, RHS_E);
@@ -1143,10 +1143,10 @@ ExprResult ParserImpl::ParseBinaryParenExpr(const Token &Name,
   default:
     Error("FIXME: unhandled kind.", Name);
     return Builder->Constant(0, ResTy);
-  }  
+  }
 }
 
-ExprResult ParserImpl::ParseSelectParenExpr(const Token &Name, 
+ExprResult ParserImpl::ParseSelectParenExpr(const Token &Name,
                                             Expr::Width ResTy) {
   // FIXME: Why does this need to be here?
   if (Tok.kind == Token::RParen) {
@@ -1168,7 +1168,7 @@ ExprResult ParserImpl::ParseSelectParenExpr(const Token &Name,
 ExprResult ParserImpl::ParseConcatParenExpr(const Token &Name,
                                             Expr::Width ResTy) {
   std::vector<ExprHandle> Kids;
-  
+
   unsigned Width = 0;
   while (Tok.kind != Token::RParen) {
     ExprResult E = ParseExpr(TypeResult());
@@ -1178,11 +1178,11 @@ ExprResult ParserImpl::ParseConcatParenExpr(const Token &Name,
       SkipUntilRParen();
       return Builder->Constant(0, ResTy);
     }
-    
+
     Kids.push_back(E.get());
     Width += E.get()->getWidth();
   }
-  
+
   ConsumeRParen();
 
   if (Width != ResTy) {
@@ -1228,7 +1228,7 @@ ExprResult ParserImpl::ParseAnyReadParenExpr(const Token &Name,
   NumberOrExprResult Index = ParseNumberOrExpr();
   VersionResult Array = ParseVersionSpecifier();
   ExpectRParen("unexpected argument in read expression.");
-  
+
   if (!Array.isValid())
     return Builder->Constant(0, ResTy);
 
@@ -1243,7 +1243,7 @@ ExprResult ParserImpl::ParseAnyReadParenExpr(const Token &Name,
     IndexExpr = ParseNumberToken(ArrayDomainType, Index.getNumber());
   else
     IndexExpr = Index.getExpr();
-  
+
   if (!IndexExpr.isValid())
     return Builder->Constant(0, ResTy);
   else if (IndexExpr.get()->getWidth() != ArrayDomainType) {
@@ -1296,7 +1296,7 @@ VersionResult ParserImpl::ParseVersionSpecifier() {
 
     if (Tok.kind != Token::Colon) {
       VersionSymTabTy::iterator it = VersionSymTab.find(Label);
-      
+
       if (it == VersionSymTab.end()) {
         Error("invalid version reference.", LTok);
         return VersionResult(false, UpdateList(0, NULL));
@@ -1319,7 +1319,7 @@ VersionResult ParserImpl::ParseVersionSpecifier() {
     Res =
         VersionResult(true, UpdateList(TheArrayCache.CreateArray("", 0), NULL));
   }
-  
+
   if (Label)
     VersionSymTab.insert(std::make_pair(Label, Res.get()));
   return Res;
@@ -1333,7 +1333,7 @@ namespace {
     NumberOrExprResult RHS;
     Token LHSTok;
     Token RHSTok;
-    
+
     WriteInfo(NumberOrExprResult _LHS, NumberOrExprResult _RHS,
               Token _LHSTok, Token _RHSTok) : LHS(_LHS), RHS(_RHS),
                                               LHSTok(_LHSTok), RHSTok(_RHSTok) {
@@ -1347,24 +1347,24 @@ namespace {
 VersionResult ParserImpl::ParseVersion() {
   if (Tok.kind != Token::LSquare)
     return VersionResult(false, UpdateList(0, NULL));
-  
+
   std::vector<WriteInfo> Writes;
   ConsumeLSquare();
   for (;;) {
     Token LHSTok = Tok;
     NumberOrExprResult LHS = ParseNumberOrExpr();
-    
+
     if (Tok.kind != Token::Equals) {
       Error("expected '='.", Tok);
       break;
     }
-    
+
     ConsumeToken();
     Token RHSTok = Tok;
     NumberOrExprResult RHS = ParseNumberOrExpr();
 
     Writes.push_back(WriteInfo(LHS, RHS, LHSTok, RHSTok));
-    
+
     if (Tok.kind == Token::Comma)
       ConsumeToken();
     else
@@ -1377,7 +1377,7 @@ VersionResult ParserImpl::ParseVersion() {
   if (Tok.kind != Token::At) {
     Error("expected '@'.", Tok);
     return VersionResult(false, UpdateList(0, NULL));
-  } 
+  }
 
   ConsumeExpectedToken(Token::At);
 
@@ -1390,7 +1390,7 @@ VersionResult ParserImpl::ParseVersion() {
   Expr::Width ArrayDomainType = Expr::Int32;
   Expr::Width ArrayRangeType = Expr::Int8;
 
-  for (std::vector<WriteInfo>::reverse_iterator it = Writes.rbegin(), 
+  for (std::vector<WriteInfo>::reverse_iterator it = Writes.rbegin(),
          ie = Writes.rend(); it != ie; ++it) {
     const WriteInfo &WI = *it;
     ExprResult LHS, RHS;
@@ -1415,7 +1415,7 @@ VersionResult ParserImpl::ParseVersion() {
         RHS = ExprResult();
       }
     }
-    
+
     if (LHS.isValid() && RHS.isValid())
       Base.extend(LHS.get(), RHS.get());
   }
@@ -1452,7 +1452,7 @@ ExprResult ParserImpl::ParseNumberToken(Expr::Width Type, const Token &Tok) {
   if ((Tok.length >= 2 && S[0] == '0') &&
       (S[1] == 'b' || S[1] == 'o' || S[1] == 'x')) {
     if (S[1] == 'b') {
-      Radix = 2; 
+      Radix = 2;
       RadixBits = 1;
     } else if (S[1] == 'o') {
       Radix = 8;
@@ -1477,10 +1477,10 @@ ExprResult ParserImpl::ParseNumberToken(Expr::Width Type, const Token &Tok) {
   APInt DigitVal(Val.getBitWidth(), 0);
   for (unsigned i=0; i<N; ++i) {
     unsigned Digit, Char = S[i];
-    
+
     if (Char == '_')
       continue;
-    
+
     if ('0' <= Char && Char <= '9')
       Digit = Char - '0';
     else if ('a' <= Char && Char <= 'z')
@@ -1533,23 +1533,23 @@ void ParserImpl::Error(const char *Message, const Token &At) {
     return;
 
   llvm::errs() << Filename
-            << ":" << At.line << ":" << At.column 
+            << ":" << At.line << ":" << At.column
             << ": error: " << Message << "\n";
 
   // Skip carat diagnostics on EOF token.
   if (At.kind == Token::EndOfFile)
     return;
-  
+
   // Simple caret style diagnostics.
   const char *LineBegin = At.start, *LineEnd = At.start,
     *BufferBegin = TheMemoryBuffer->getBufferStart(),
     *BufferEnd = TheMemoryBuffer->getBufferEnd();
 
   // Run line pointers forward and back.
-  while (LineBegin > BufferBegin && 
+  while (LineBegin > BufferBegin &&
          LineBegin[-1] != '\r' && LineBegin[-1] != '\n')
     --LineBegin;
-  while (LineEnd < BufferEnd && 
+  while (LineEnd < BufferEnd &&
          LineEnd[0] != '\r' && LineEnd[0] != '\n')
     ++LineEnd;
 

--- a/lib/Expr/Updates.cpp
+++ b/lib/Expr/Updates.cpp
@@ -13,17 +13,17 @@
 
 using namespace klee;
 
-UpdateNode::UpdateNode(const UpdateNode *_next, 
-                       const ref<Expr> &_index, 
-                       const ref<Expr> &_value) 
-  : refCount(0),    
+UpdateNode::UpdateNode(const UpdateNode *_next,
+                       const ref<Expr> &_index,
+                       const ref<Expr> &_value)
+  : refCount(0),
     next(_next),
     index(_index),
     value(_value) {
-  // FIXME: What we need to check here instead is that _value is of the same width 
+  // FIXME: What we need to check here instead is that _value is of the same width
   // as the range of the array that the update node is part of.
   /*
-  assert(_value->getWidth() == Expr::Int8 && 
+  assert(_value->getWidth() == Expr::Int8 &&
          "Update value should be 8-bit wide.");
   */
   computeHash();
@@ -45,7 +45,7 @@ UpdateNode::~UpdateNode() {
 }
 
 int UpdateNode::compare(const UpdateNode &b) const {
-  if (int i = index.compare(b.index)) 
+  if (int i = index.compare(b.index))
     return i;
   return value.compare(b.value);
 }
@@ -143,7 +143,7 @@ UpdateList &UpdateList::operator=(const UpdateList &b) {
 }
 
 void UpdateList::extend(const ref<Expr> &index, const ref<Expr> &value) {
-  
+
   if (root) {
     assert(root->getDomain() == index->getWidth());
     assert(root->getRange() == value->getWidth());
@@ -164,7 +164,7 @@ int UpdateList::compare(const UpdateList &b) const {
     return root < b.root ? -1 : 1;
 
   if (getSize() < b.getSize()) return -1;
-  else if (getSize() > b.getSize()) return 1;    
+  else if (getSize() > b.getSize()) return 1;
 
   // XXX build comparison into update, make fast
   const UpdateNode *an=head, *bn=b.head;
@@ -176,7 +176,7 @@ int UpdateList::compare(const UpdateList &b) const {
         return res;
     }
   }
-  assert(!an && !bn);  
+  assert(!an && !bn);
   return 0;
 }
 

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -82,18 +82,18 @@ namespace {
 
   cl::opt<SwitchImplType>
   SwitchType("switch-type", cl::desc("Select the implementation of switch (default=internal)"),
-             cl::values(clEnumValN(eSwitchTypeSimple, "simple", 
+             cl::values(clEnumValN(eSwitchTypeSimple, "simple",
                                    "lower to ordered branches"),
-                        clEnumValN(eSwitchTypeLLVM, "llvm", 
+                        clEnumValN(eSwitchTypeLLVM, "llvm",
                                    "lower using LLVM"),
-                        clEnumValN(eSwitchTypeInternal, "internal", 
+                        clEnumValN(eSwitchTypeInternal, "internal",
                                    "execute switch internally")
                         KLEE_LLVM_CL_VAL_END),
              cl::init(eSwitchTypeInternal),
 	     cl::cat(ModuleCat));
-  
+
   cl::opt<bool>
-  DebugPrintEscapingFunctions("debug-print-escaping-functions", 
+  DebugPrintEscapingFunctions("debug-print-escaping-functions",
                               cl::desc("Print functions whose address is taken (default=false)"),
 			      cl::cat(ModuleCat));
 
@@ -118,7 +118,7 @@ extern void Optimize(Module *, llvm::ArrayRef<const char *> preservedFunctions);
 
 // what a hack
 static Function *getStubFunctionForCtorList(Module *m,
-                                            GlobalVariable *gv, 
+                                            GlobalVariable *gv,
                                             std::string name) {
   assert(!gv->isDeclaration() && !gv->hasInternalLinkage() &&
          "do not support old LLVM style constructor/destructor lists");
@@ -127,7 +127,7 @@ static Function *getStubFunctionForCtorList(Module *m,
 
   Function *fn = Function::Create(FunctionType::get(Type::getVoidTy(m->getContext()),
 						    nullary, false),
-				  GlobalVariable::InternalLinkage, 
+				  GlobalVariable::InternalLinkage,
 				  name,
                               m);
   BasicBlock *bb = BasicBlock::Create(m->getContext(), "entry", fn);
@@ -386,7 +386,7 @@ KConstant* KModule::getKConstant(const Constant *c) {
 
 unsigned KModule::getConstantID(Constant *c, KInstruction* ki) {
   if (KConstant *kc = getKConstant(c))
-    return kc->id;  
+    return kc->id;
 
   unsigned id = constants.size();
   auto kc = std::unique_ptr<KConstant>(new KConstant(c, id, ki));
@@ -424,7 +424,7 @@ static int getOperandNum(Value *v,
 }
 
 KFunction::KFunction(llvm::Function *_function,
-                     KModule *km) 
+                     KModule *km)
   : function(_function),
     numArgs(function->arg_size()),
     numInstructions(0),
@@ -441,16 +441,16 @@ KFunction::KFunction(llvm::Function *_function,
 
   // The first arg_size() registers are reserved for formals.
   unsigned rnum = numArgs;
-  for (llvm::Function::iterator bbit = function->begin(), 
+  for (llvm::Function::iterator bbit = function->begin(),
          bbie = function->end(); bbit != bbie; ++bbit) {
     for (llvm::BasicBlock::iterator it = bbit->begin(), ie = bbit->end();
          it != ie; ++it)
       registerMap[&*it] = rnum++;
   }
   numRegisters = rnum;
-  
+
   unsigned i = 0;
-  for (llvm::Function::iterator bbit = function->begin(), 
+  for (llvm::Function::iterator bbit = function->begin(),
          bbie = function->end(); bbit != bbie; ++bbit) {
     for (llvm::BasicBlock::iterator it = bbit->begin(), ie = bbit->end();
          it != ie; ++it) {

--- a/lib/Module/LowerSwitch.cpp
+++ b/lib/Module/LowerSwitch.cpp
@@ -30,7 +30,7 @@ char LowerSwitchPass::ID = 0;
 struct SwitchCaseCmp {
   bool operator () (const LowerSwitchPass::SwitchCase& C1,
                     const LowerSwitchPass::SwitchCase& C2) {
-    
+
     const ConstantInt* CI1 = cast<const ConstantInt>(C1.value);
     const ConstantInt* CI2 = cast<const ConstantInt>(C2.value);
     return CI1->getValue().slt(CI2->getValue());
@@ -81,7 +81,7 @@ void LowerSwitchPass::switchConvert(CaseItr begin, CaseItr end,
       assert(blockIndex != -1 && "Switch didn't go to this successor??");
       PN->setIncomingBlock((unsigned)blockIndex, newBlock);
     }
-    
+
     curHead = newBlock;
   }
 
@@ -115,19 +115,19 @@ void LowerSwitchPass::processSwitchInst(SwitchInst *SI) {
     assert(BlockIdx != -1 && "Switch didn't go to this successor??");
     PN->setIncomingBlock((unsigned)BlockIdx, newDefault);
   }
-  
+
   CaseVector cases;
 
   for (auto i : SI->cases())
     cases.push_back(SwitchCase(i.getCaseValue(),
                                i.getCaseSuccessor()));
-  
+
   // reverse cases, as switchConvert constructs a chain of
   //   basic blocks by appending to the front. if we reverse,
   //   the if comparisons will happen in the same order
   //   as the cases appear in the switch
   std::reverse(cases.begin(), cases.end());
-  
+
   switchConvert(cases.begin(), cases.end(), switchValue, origBlock, newDefault);
 
   // We are now done with the switch instruction, so delete it

--- a/lib/Module/PhiCleaner.cpp
+++ b/lib/Module/PhiCleaner.cpp
@@ -17,13 +17,13 @@ char klee::PhiCleanerPass::ID = 0;
 
 bool klee::PhiCleanerPass::runOnFunction(Function &f) {
   bool changed = false;
-  
+
   for (Function::iterator b = f.begin(), be = f.end(); b != be; ++b) {
     BasicBlock::iterator it = b->begin();
 
     if (it->getOpcode() == Instruction::PHI) {
       PHINode *reference = cast<PHINode>(it);
-      
+
       std::set<Value*> phis;
       phis.insert(reference);
 
@@ -63,8 +63,8 @@ bool klee::PhiCleanerPass::runOnFunction(Function &f) {
             // this isn't completely necessary, but in the end this is
             // just a pathological case which does not occur very
             // often.
-            Instruction *tmp = 
-              new BitCastInst(value, 
+            Instruction *tmp =
+              new BitCastInst(value,
                               value->getType(),
                               value->getName() + ".phiclean",
                               pi->getIncomingBlock(i)->getTerminator());
@@ -73,7 +73,7 @@ bool klee::PhiCleanerPass::runOnFunction(Function &f) {
 
           changed = true;
         }
-        
+
         phis.insert(pi);
       }
     }

--- a/lib/Module/RaiseAsm.cpp
+++ b/lib/Module/RaiseAsm.cpp
@@ -101,12 +101,12 @@ bool RaiseAsmPass::runOnModule(Module &M) {
 
     triple = llvm::Triple(HostTriple);
   }
-  
+
   for (Module::iterator fi = M.begin(), fe = M.end(); fi != fe; ++fi) {
     for (Function::iterator bi = fi->begin(), be = fi->end(); bi != be; ++bi) {
       for (BasicBlock::iterator ii = bi->begin(), ie = bi->end(); ii != ie;) {
         Instruction *i = &*ii;
-        ++ii;  
+        ++ii;
         changed |= runOnInstruction(M, i);
       }
     }

--- a/lib/Solver/CachingSolver.cpp
+++ b/lib/Solver/CachingSolver.cpp
@@ -37,14 +37,14 @@ private:
 
   bool cacheLookup(const Query& query,
                    IncompleteSolver::PartialValidity &result);
-  
+
   struct CacheEntry {
     CacheEntry(const ConstraintManager &c, ref<Expr> q)
       : constraints(c), query(q) {}
 
     CacheEntry(const CacheEntry &ce)
       : constraints(ce.constraints), query(ce.query) {}
-    
+
     ConstraintManager constraints;
     ref<Expr> query;
 
@@ -65,10 +65,10 @@ private:
     }
   };
 
-  typedef unordered_map<CacheEntry, 
-                        IncompleteSolver::PartialValidity, 
+  typedef unordered_map<CacheEntry,
+                        IncompleteSolver::PartialValidity,
                         CacheEntryHash> cache_map;
-  
+
   Solver *solver;
   cache_map cache;
 
@@ -87,7 +87,7 @@ public:
                             std::vector< std::vector<unsigned char> > &values,
                             bool &hasSolution) {
     ++stats::queryCacheMisses;
-    return solver->impl->computeInitialValues(query, objects, values, 
+    return solver->impl->computeInitialValues(query, objects, values,
                                               hasSolution);
   }
   SolverRunStatus getOperationStatusCode();
@@ -121,14 +121,14 @@ bool CachingSolver::cacheLookup(const Query& query,
 
   CacheEntry ce(query.constraints, canonicalQuery);
   cache_map::iterator it = cache.find(ce);
-  
+
   if (it != cache.end()) {
     result = (negationUsed ?
               IncompleteSolver::negatePartialValidity(it->second) :
               it->second);
     return true;
   }
-  
+
   return false;
 }
 
@@ -139,9 +139,9 @@ void CachingSolver::cacheInsert(const Query& query,
   ref<Expr> canonicalQuery = canonicalizeQuery(query.expr, negationUsed);
 
   CacheEntry ce(query.constraints, canonicalQuery);
-  IncompleteSolver::PartialValidity cachedResult = 
+  IncompleteSolver::PartialValidity cachedResult =
     (negationUsed ? IncompleteSolver::negatePartialValidity(result) : result);
-  
+
   cache.insert(std::make_pair(ce, cachedResult));
 }
 
@@ -149,18 +149,18 @@ bool CachingSolver::computeValidity(const Query& query,
                                     Solver::Validity &result) {
   IncompleteSolver::PartialValidity cachedResult;
   bool tmp, cacheHit = cacheLookup(query, cachedResult);
-  
+
   if (cacheHit) {
     switch(cachedResult) {
-    case IncompleteSolver::MustBeTrue:   
+    case IncompleteSolver::MustBeTrue:
       result = Solver::True;
       ++stats::queryCacheHits;
       return true;
-    case IncompleteSolver::MustBeFalse:  
+    case IncompleteSolver::MustBeFalse:
       result = Solver::False;
       ++stats::queryCacheHits;
       return true;
-    case IncompleteSolver::TrueOrFalse:  
+    case IncompleteSolver::TrueOrFalse:
       result = Solver::Unknown;
       ++stats::queryCacheHits;
       return true;
@@ -197,19 +197,19 @@ bool CachingSolver::computeValidity(const Query& query,
   }
 
   ++stats::queryCacheMisses;
-  
+
   if (!solver->impl->computeValidity(query, result))
     return false;
 
   switch (result) {
-  case Solver::True: 
+  case Solver::True:
     cachedResult = IncompleteSolver::MustBeTrue; break;
-  case Solver::False: 
+  case Solver::False:
     cachedResult = IncompleteSolver::MustBeFalse; break;
-  default: 
+  default:
     cachedResult = IncompleteSolver::TrueOrFalse; break;
   }
-  
+
   cacheInsert(query, cachedResult);
   return true;
 }
@@ -228,7 +228,7 @@ bool CachingSolver::computeTruth(const Query& query,
   }
 
   ++stats::queryCacheMisses;
-  
+
   // cache miss: query solver
   if (!solver->impl->computeTruth(query, isValid))
     return false;
@@ -243,7 +243,7 @@ bool CachingSolver::computeTruth(const Query& query,
   } else {
     cachedResult = IncompleteSolver::MayBeFalse;
   }
-  
+
   cacheInsert(query, cachedResult);
   return true;
 }

--- a/lib/Solver/CexCachingSolver.cpp
+++ b/lib/Solver/CexCachingSolver.cpp
@@ -67,14 +67,14 @@ class CexCachingSolver : public SolverImpl {
   typedef std::set<Assignment*, AssignmentLessThan> assignmentsTable_ty;
 
   Solver *solver;
-  
+
   MapOfSets<ref<Expr>, Assignment*> cache;
   // memo table
   assignmentsTable_ty assignmentsTable;
 
-  bool searchForAssignment(KeyType &key, 
+  bool searchForAssignment(KeyType &key,
                            Assignment *&result);
-  
+
   bool lookupAssignment(const Query& query, KeyType &key, Assignment *&result);
 
   bool lookupAssignment(const Query& query, Assignment *&result) {
@@ -83,11 +83,11 @@ class CexCachingSolver : public SolverImpl {
   }
 
   bool getAssignment(const Query& query, Assignment *&result);
-  
+
 public:
   CexCachingSolver(Solver *_solver) : solver(_solver) {}
   ~CexCachingSolver();
-  
+
   bool computeTruth(const Query&, bool &isValid);
   bool computeValidity(const Query&, Solver::Validity &result);
   bool computeValue(const Query&, ref<Expr> &result);
@@ -112,11 +112,11 @@ struct NonNullAssignment {
 
 struct NullOrSatisfyingAssignment {
   KeyType &key;
-  
+
   NullOrSatisfyingAssignment(KeyType &_key) : key(_key) {}
 
-  bool operator()(Assignment *a) const { 
-    return !a || a->satisfies(key.begin(), key.end()); 
+  bool operator()(Assignment *a) const {
+    return !a || a->satisfies(key.begin(), key.end());
   }
 };
 
@@ -142,7 +142,7 @@ bool CexCachingSolver::searchForAssignment(KeyType &key, Assignment *&result) {
       lookup = cache.findSuperset(key, NonNullAssignment());
 
     // Otherwise, look for a subset which is unsatisfiable, see below.
-    if (!lookup) 
+    if (!lookup)
       lookup = cache.findSubset(key, NullAssignment());
 
     // If either lookup succeeded, then we have a cached solution.
@@ -153,7 +153,7 @@ bool CexCachingSolver::searchForAssignment(KeyType &key, Assignment *&result) {
 
     // Otherwise, iterate through the set of current assignments to see if one
     // of them satisfies the query.
-    for (assignmentsTable_ty::iterator it = assignmentsTable.begin(), 
+    for (assignmentsTable_ty::iterator it = assignmentsTable.begin(),
            ie = assignmentsTable.end(); it != ie; ++it) {
       Assignment *a = *it;
       if (a->satisfies(key.begin(), key.end())) {
@@ -175,7 +175,7 @@ bool CexCachingSolver::searchForAssignment(KeyType &key, Assignment *&result) {
     // assignment. While searching subsets, we also explicitly the solutions for
     // satisfiable subsets to see if they solve the current query and return
     // them if so. This is cheap and frequently succeeds.
-    if (!lookup) 
+    if (!lookup)
       lookup = cache.findSubset(key, NullOrSatisfyingAssignment(key));
 
     // If either lookup succeeded, then we have a cached solution.
@@ -184,7 +184,7 @@ bool CexCachingSolver::searchForAssignment(KeyType &key, Assignment *&result) {
       return true;
     }
   }
-  
+
   return false;
 }
 
@@ -196,7 +196,7 @@ bool CexCachingSolver::searchForAssignment(KeyType &key, Assignment *&result) {
 /// either a satisfying assignment (for a satisfiable query), or 0 (for an
 /// unsatisfiable query).
 /// \return True if a cached result was found.
-bool CexCachingSolver::lookupAssignment(const Query &query, 
+bool CexCachingSolver::lookupAssignment(const Query &query,
                                         KeyType &key,
                                         Assignment *&result) {
   key = KeyType(query.constraints.begin(), query.constraints.end());
@@ -215,7 +215,7 @@ bool CexCachingSolver::lookupAssignment(const Query &query,
   if (found)
     ++stats::queryCexCacheHits;
   else ++stats::queryCexCacheMisses;
-    
+
   return found;
 }
 
@@ -229,10 +229,10 @@ bool CexCachingSolver::getAssignment(const Query& query, Assignment *&result) {
 
   std::vector< std::vector<unsigned char> > values;
   bool hasSolution;
-  if (!solver->impl->computeInitialValues(query, objects, values, 
+  if (!solver->impl->computeInitialValues(query, objects, values,
                                           hasSolution))
     return false;
-    
+
   Assignment *binding;
   if (hasSolution) {
     binding = new Assignment(objects, values);
@@ -244,7 +244,7 @@ bool CexCachingSolver::getAssignment(const Query& query, Assignment *&result) {
       delete binding;
       binding = *res.first;
     }
-    
+
     if (DebugCexCacheCheckBinding)
       if (!binding->satisfies(key.begin(), key.end())) {
         query.dump();
@@ -254,7 +254,7 @@ bool CexCachingSolver::getAssignment(const Query& query, Assignment *&result) {
   } else {
     binding = (Assignment*) 0;
   }
-  
+
   result = binding;
   cache.insert(key, binding);
 
@@ -266,7 +266,7 @@ bool CexCachingSolver::getAssignment(const Query& query, Assignment *&result) {
 CexCachingSolver::~CexCachingSolver() {
   cache.clear();
   delete solver;
-  for (assignmentsTable_ty::iterator it = assignmentsTable.begin(), 
+  for (assignmentsTable_ty::iterator it = assignmentsTable.begin(),
          ie = assignmentsTable.end(); it != ie; ++it)
     delete *it;
 }
@@ -279,7 +279,7 @@ bool CexCachingSolver::computeValidity(const Query& query,
     return false;
   assert(a && "computeValidity() must have assignment");
   ref<Expr> q = a->evaluate(query.expr);
-  assert(isa<ConstantExpr>(q) && 
+  assert(isa<ConstantExpr>(q) &&
          "assignment evaluation did not result in constant");
 
   if (cast<ConstantExpr>(q)->isTrue()) {
@@ -291,7 +291,7 @@ bool CexCachingSolver::computeValidity(const Query& query,
       return false;
     result = !a ? Solver::False : Solver::Unknown;
   }
-  
+
   return true;
 }
 
@@ -330,15 +330,15 @@ bool CexCachingSolver::computeValue(const Query& query,
   if (!getAssignment(query.withFalse(), a))
     return false;
   assert(a && "computeValue() must have assignment");
-  result = a->evaluate(query.expr);  
-  assert(isa<ConstantExpr>(result) && 
+  result = a->evaluate(query.expr);
+  assert(isa<ConstantExpr>(result) &&
          "assignment evaluation did not result in constant");
   return true;
 }
 
-bool 
+bool
 CexCachingSolver::computeInitialValues(const Query& query,
-                                       const std::vector<const Array*> 
+                                       const std::vector<const Array*>
                                          &objects,
                                        std::vector< std::vector<unsigned char> >
                                          &values,
@@ -348,7 +348,7 @@ CexCachingSolver::computeInitialValues(const Query& query,
   if (!getAssignment(query, a))
     return false;
   hasSolution = !!a;
-  
+
   if (!a)
     return true;
 
@@ -358,14 +358,14 @@ CexCachingSolver::computeInitialValues(const Query& query,
   for (unsigned i=0; i < objects.size(); ++i) {
     const Array *os = objects[i];
     Assignment::bindings_ty::iterator it = a->bindings.find(os);
-    
+
     if (it == a->bindings.end()) {
       values[i] = std::vector<unsigned char>(os->size, 0);
     } else {
       values[i] = it->second;
     }
   }
-  
+
   return true;
 }
 

--- a/lib/Solver/ConstantDivision.cpp
+++ b/lib/Solver/ConstantDivision.cpp
@@ -16,7 +16,7 @@
 
 namespace klee {
 
-/* Macros and functions which define the basic bit-level operations 
+/* Macros and functions which define the basic bit-level operations
  * needed to implement quick division operations.
  *
  * Based on Hacker's Delight (2003) by Henry S. Warren, Jr.
@@ -79,7 +79,7 @@ static uint32_t exp_base_2(int32_t n) {
 //      below the one we wish to subtract, we simply change that
 //      add to a subtract instead of subtracting the low bit itself.
 // Obviously we must take care when high==64.
-void ComputeMultConstants64(uint64_t multiplicand, 
+void ComputeMultConstants64(uint64_t multiplicand,
                             uint64_t &add, uint64_t &sub) {
   uint64_t x = multiplicand;
   add = sub = 0;
@@ -115,7 +115,7 @@ void ComputeMultConstants64(uint64_t multiplicand,
   assert(multiplicand == add - sub);
 }
 
-void ComputeUDivConstants32(uint32_t d, uint32_t &mprime, uint32_t &sh1, 
+void ComputeUDivConstants32(uint32_t d, uint32_t &mprime, uint32_t &sh1,
                             uint32_t &sh2) {
   int32_t l = LOG2_CEIL( d ); /* signed so l-1 => -1 when l=0 (see sh2) */
   uint32_t mid = exp_base_2(l) - d;
@@ -125,12 +125,12 @@ void ComputeUDivConstants32(uint32_t d, uint32_t &mprime, uint32_t &sh1,
   sh2    = std::max( l-1, 0 );
 }
 
-void ComputeSDivConstants32(int32_t d, int32_t &mprime, int32_t &dsign, 
+void ComputeSDivConstants32(int32_t d, int32_t &mprime, int32_t &dsign,
                             int32_t &shpost ) {
   uint64_t abs_d = ABS( (int64_t)d ); /* use 64-bits in case d is INT32_MIN */
 
   /* LOG2_CEIL works on 32-bits, so we cast abs_d.  The only possible value
-   * outside the 32-bit rep. is 2^31.  This is special cased to save computer 
+   * outside the 32-bit rep. is 2^31.  This is special cased to save computer
    * time since 64-bit routines would be overkill. */
   int32_t l = std::max( 1U, LOG2_CEIL((uint32_t)abs_d) );
   if( abs_d == TWO_TO_THE_31_S64 ) l = 31;

--- a/lib/Solver/ConstantDivision.h
+++ b/lib/Solver/ConstantDivision.h
@@ -17,33 +17,33 @@ namespace klee {
 /// ComputeMultConstants64 - Compute add and sub such that add-sub==x,
 /// while attempting to minimize the number of bits in add and sub
 /// combined.
-void ComputeMultConstants64(uint64_t x, uint64_t &add_out, 
+void ComputeMultConstants64(uint64_t x, uint64_t &add_out,
                             uint64_t &sub_out);
 
-/// Compute the constants to perform a quicker equivalent of a division of some 
-/// 32-bit unsigned integer n by a known constant d (also a 32-bit unsigned 
-/// integer).  The constants to compute n/d without explicit division will be 
+/// Compute the constants to perform a quicker equivalent of a division of some
+/// 32-bit unsigned integer n by a known constant d (also a 32-bit unsigned
+/// integer).  The constants to compute n/d without explicit division will be
 /// stored in mprime, sh1, and sh2 (unsigned 32-bit integers).
-/// 
+///
 /// @param d - denominator (divisor)
-/// 
+///
 /// @param [out] mprime
 /// @param [out] sh1
 /// @param [out] sh2
-void ComputeUDivConstants32(uint32_t d, uint32_t &mprime, uint32_t &sh1, 
+void ComputeUDivConstants32(uint32_t d, uint32_t &mprime, uint32_t &sh1,
                             uint32_t &sh2);
 
-/// Compute the constants to perform a quicker equivalent of a division of some 
-/// 32-bit signed integer n by a known constant d (also a 32-bit signed 
-/// integer).  The constants to compute n/d without explicit division will be 
+/// Compute the constants to perform a quicker equivalent of a division of some
+/// 32-bit signed integer n by a known constant d (also a 32-bit signed
+/// integer).  The constants to compute n/d without explicit division will be
 /// stored in mprime, dsign, and shpost (signed 32-bit integers).
-/// 
+///
 /// @param d - denominator (divisor)
-/// 
+///
 /// @param [out] mprime
 /// @param [out] dsign
 /// @param [out] shpost
-void ComputeSDivConstants32(int32_t d, int32_t &mprime, int32_t &dsign, 
+void ComputeSDivConstants32(int32_t d, int32_t &mprime, int32_t &dsign,
                             int32_t &shpost);
 
 }

--- a/lib/Solver/FastCexSolver.cpp
+++ b/lib/Solver/FastCexSolver.cpp
@@ -42,7 +42,7 @@ static uint64_t minOR(uint64_t a, uint64_t b,
     }
     m >>= 1;
   }
-  
+
   return a | c;
 }
 static uint64_t maxOR(uint64_t a, uint64_t b,
@@ -73,7 +73,7 @@ static uint64_t minAND(uint64_t a, uint64_t b,
     }
     m >>= 1;
   }
-  
+
   return a & c;
 }
 static uint64_t maxAND(uint64_t a, uint64_t b,
@@ -89,7 +89,7 @@ static uint64_t maxAND(uint64_t a, uint64_t b,
     }
     m >>= 1;
   }
-  
+
   return b & d;
 }
 
@@ -124,10 +124,10 @@ public:
 
   bool isEmpty() const noexcept { return m_min > m_max; }
   bool contains(std::uint64_t value) const {
-    return this->intersects(ValueRange(value)); 
+    return this->intersects(ValueRange(value));
   }
-  bool intersects(const ValueRange &b) const { 
-    return !this->set_intersection(b).isEmpty(); 
+  bool intersects(const ValueRange &b) const {
+    return !this->set_intersection(b).isEmpty();
   }
 
   bool isFullRange(unsigned bits) const noexcept {
@@ -243,7 +243,7 @@ public:
   bool mayEqual(const std::uint64_t b) const noexcept {
     return m_min <= b && m_max >= b;
   }
-  
+
   bool mustEqual(const ValueRange &b) const noexcept {
     return isFixed() && b.isFixed() && m_min == b.m_min;
   }
@@ -251,14 +251,14 @@ public:
 
   std::uint64_t min() const noexcept {
     assert(!isEmpty() && "cannot get minimum of empty range");
-    return m_min; 
+    return m_min;
   }
 
   std::uint64_t max() const noexcept {
     assert(!isEmpty() && "cannot get maximum of empty range");
-    return m_max; 
+    return m_max;
   }
-  
+
   std::int64_t minSigned(unsigned bits) const {
     assert((m_min >> bits) == 0 && (m_max >> bits) == 0 &&
            "range is outside given number of bits");
@@ -326,7 +326,7 @@ public:
     }
   }
 
-  const CexValueData getPossibleValues(size_t index) const { 
+  const CexValueData getPossibleValues(size_t index) const {
     return possibleContents[index];
   }
   void setPossibleValues(size_t index, CexValueData values) {
@@ -336,7 +336,7 @@ public:
     possibleContents[index] = CexValueData(value);
   }
 
-  const CexValueData getExactValues(size_t index) const { 
+  const CexValueData getExactValues(size_t index) const {
     return exactContents[index];
   }
   void setExactValues(size_t index, CexValueData values) {
@@ -353,13 +353,13 @@ public:
 class CexRangeEvaluator : public ExprRangeEvaluator<ValueRange> {
 public:
   std::map<const Array*, CexObjectData*> &objects;
-  CexRangeEvaluator(std::map<const Array*, CexObjectData*> &_objects) 
+  CexRangeEvaluator(std::map<const Array*, CexObjectData*> &_objects)
     : objects(_objects) {}
 
   ValueRange getInitialReadRange(const Array &array, ValueRange index) {
     // Check for a concrete read of a constant array.
-    if (array.isConstantArray() && 
-        index.isFixed() && 
+    if (array.isConstantArray() &&
+        index.isFixed() &&
         index.min() < array.size)
       return ValueRange(array.constantValues[index.min()]->getZExtValue(8));
 
@@ -373,18 +373,18 @@ protected:
     // If the index is out of range, we cannot assign it a value, since that
     // value cannot be part of the assignment.
     if (index >= array.size)
-      return ReadExpr::create(UpdateList(&array, 0), 
+      return ReadExpr::create(UpdateList(&array, 0),
                               ConstantExpr::alloc(index, array.getDomain()));
-      
+
     std::map<const Array*, CexObjectData*>::iterator it = objects.find(&array);
-    return ConstantExpr::alloc((it == objects.end() ? 127 : 
+    return ConstantExpr::alloc((it == objects.end() ? 127 :
                                 it->second->getPossibleValue(index)),
                                array.getRange());
   }
 
 public:
   std::map<const Array*, CexObjectData*> &objects;
-  CexPossibleEvaluator(std::map<const Array*, CexObjectData*> &_objects) 
+  CexPossibleEvaluator(std::map<const Array*, CexObjectData*> &_objects)
     : objects(_objects) {}
 };
 
@@ -394,17 +394,17 @@ protected:
     // If the index is out of range, we cannot assign it a value, since that
     // value cannot be part of the assignment.
     if (index >= array.size)
-      return ReadExpr::create(UpdateList(&array, 0), 
+      return ReadExpr::create(UpdateList(&array, 0),
                               ConstantExpr::alloc(index, array.getDomain()));
-      
+
     std::map<const Array*, CexObjectData*>::iterator it = objects.find(&array);
     if (it == objects.end())
-      return ReadExpr::create(UpdateList(&array, 0), 
+      return ReadExpr::create(UpdateList(&array, 0),
                               ConstantExpr::alloc(index, array.getDomain()));
 
     CexValueData cvd = it->second->getExactValues(index);
     if (!cvd.isFixed())
-      return ReadExpr::create(UpdateList(&array, 0), 
+      return ReadExpr::create(UpdateList(&array, 0),
                               ConstantExpr::alloc(index, array.getDomain()));
 
     return ConstantExpr::alloc(cvd.min(), array.getRange());
@@ -412,7 +412,7 @@ protected:
 
 public:
   std::map<const Array*, CexObjectData*> &objects;
-  CexExactEvaluator(std::map<const Array*, CexObjectData*> &_objects) 
+  CexExactEvaluator(std::map<const Array*, CexObjectData*> &_objects)
     : objects(_objects) {}
 };
 
@@ -517,7 +517,7 @@ public:
         // (either because the condition cannot be that, or the
         // resulting range given that condition is not in the required
         // range).
-        // 
+        //
         // Currently we just force both into the range. A hybrid would
         // be to evaluate the ranges for each of the children... if
         // one of the ranges happens to already be a subset of the
@@ -542,7 +542,7 @@ public:
       ConcatExpr *ce = cast<ConcatExpr>(e);
       Expr::Width LSBWidth = ce->getKid(1)->getWidth();
       Expr::Width MSBWidth = ce->getKid(1)->getWidth();
-      propogatePossibleValues(ce->getKid(0), 
+      propogatePossibleValues(ce->getKid(0),
                               range.extract(LSBWidth, LSBWidth + MSBWidth));
       propogatePossibleValues(ce->getKid(1), range.extract(0, LSBWidth));
       break;
@@ -563,7 +563,7 @@ public:
     case Expr::ZExt: {
       CastExpr *ce = cast<CastExpr>(e);
       unsigned inBits = ce->src->getWidth();
-      ValueRange input = 
+      ValueRange input =
         range.set_intersection(ValueRange(0, bits64::maxValueOfNBits(inBits)));
       propogatePossibleValues(ce->src, input);
       break;
@@ -575,7 +575,7 @@ public:
       CastExpr *ce = cast<CastExpr>(e);
       unsigned inBits = ce->src->getWidth();
       unsigned outBits = ce->width;
-      ValueRange output = 
+      ValueRange output =
         range.set_difference(ValueRange(1<<(inBits-1),
                                         (bits64::maxValueOfNBits(outBits) -
                                          bits64::maxValueOfNBits(inBits-1)-1)));
@@ -650,7 +650,7 @@ public:
               // all is well
             } else {
               // XXX heuristic, which order?
-              
+
               // force left to value we need
               propogatePossibleValue(be->left, 1);
               left = evalRangeForExpr(be->left);
@@ -686,7 +686,7 @@ public:
             } else {
               CexValueData range;
               if (value==0) {
-                range = CexValueData(1, 
+                range = CexValueData(1,
                                      bits64::maxValueOfNBits(CE->getWidth()));
               } else {
                 // FIXME: heuristic / lossy, could be better to pick larger
@@ -712,7 +712,7 @@ public:
 
     case Expr::Ult: {
       BinaryExpr *be = cast<BinaryExpr>(e);
-      
+
       // XXX heuristic / lossy, what order if conflict
 
       if (range.isFixed()) {
@@ -725,7 +725,7 @@ public:
 
         if (left.isFixed()) {
           if (range.min()) {
-            propogatePossibleValues(be->right, CexValueData(left.min()+1, 
+            propogatePossibleValues(be->right, CexValueData(left.min()+1,
                                                             maxValue));
           } else {
             propogatePossibleValues(be->right, CexValueData(0, left.min()));
@@ -734,7 +734,7 @@ public:
           if (range.min()) {
             propogatePossibleValues(be->left, CexValueData(0, right.min()-1));
           } else {
-            propogatePossibleValues(be->left, CexValueData(right.min(), 
+            propogatePossibleValues(be->left, CexValueData(right.min(),
                                                            maxValue));
           }
         } else {
@@ -745,7 +745,7 @@ public:
     }
     case Expr::Ule: {
       BinaryExpr *be = cast<BinaryExpr>(e);
-      
+
       // XXX heuristic / lossy, what order if conflict
 
       if (range.isFixed()) {
@@ -757,7 +757,7 @@ public:
         uint64_t maxValue = bits64::maxValueOfNBits(be->right->getWidth());
         if (left.isFixed()) {
           if (range.min()) {
-            propogatePossibleValues(be->right, CexValueData(left.min(), 
+            propogatePossibleValues(be->right, CexValueData(left.min(),
                                                             maxValue));
           } else {
             propogatePossibleValues(be->right, CexValueData(0, left.min()-1));
@@ -766,7 +766,7 @@ public:
           if (range.min()) {
             propogatePossibleValues(be->left, CexValueData(0, right.min()));
           } else {
-            propogatePossibleValues(be->left, CexValueData(right.min()+1, 
+            propogatePossibleValues(be->left, CexValueData(right.min()+1,
                                                            maxValue));
           }
         } else {
@@ -804,7 +804,7 @@ public:
       const Array *array = re->updates.root;
       CexObjectData &cod = getObjectData(array);
       CexValueData index = evalRangeForExpr(re->index);
-        
+
       for (const UpdateNode *un = re->updates.head; un; un = un->next) {
         CexValueData ui = evalRangeForExpr(un->index);
 
@@ -979,7 +979,7 @@ public:
   FastCexSolver();
   ~FastCexSolver();
 
-  IncompleteSolver::PartialValidity computeTruth(const Query&);  
+  IncompleteSolver::PartialValidity computeTruth(const Query&);
   bool computeValue(const Query&, ref<Expr> &result);
   bool computeInitialValues(const Query&,
                             const std::vector<const Array*> &objects,
@@ -1005,9 +1005,9 @@ FastCexSolver::~FastCexSolver() { }
 /// constraints were proven valid or invalid.
 ///
 /// \return - True if the propogation was able to prove validity or invalidity.
-static bool propogateValues(const Query& query, CexData &cd, 
+static bool propogateValues(const Query& query, CexData &cd,
                             bool checkExpr, bool &isValid) {
-  for (ConstraintManager::const_iterator it = query.constraints.begin(), 
+  for (ConstraintManager::const_iterator it = query.constraints.begin(),
          ie = query.constraints.end(); it != ie; ++it) {
     cd.propogatePossibleValue(*it, 1);
     cd.propogateExactValue(*it, 1);
@@ -1018,7 +1018,7 @@ static bool propogateValues(const Query& query, CexData &cd,
   }
 
   KLEE_DEBUG(cd.dump());
-  
+
   // Check the result.
   bool hasSatisfyingAssignment = true;
   if (checkExpr) {
@@ -1032,7 +1032,7 @@ static bool propogateValues(const Query& query, CexData &cd,
     }
   }
 
-  for (ConstraintManager::const_iterator it = query.constraints.begin(), 
+  for (ConstraintManager::const_iterator it = query.constraints.begin(),
          ie = query.constraints.end(); it != ie; ++it) {
     if (hasSatisfyingAssignment && !cd.evaluatePossible(*it)->isTrue())
       hasSatisfyingAssignment = false;
@@ -1053,7 +1053,7 @@ static bool propogateValues(const Query& query, CexData &cd,
   return false;
 }
 
-IncompleteSolver::PartialValidity 
+IncompleteSolver::PartialValidity
 FastCexSolver::computeTruth(const Query& query) {
   CexData cd;
 
@@ -1079,10 +1079,10 @@ bool FastCexSolver::computeValue(const Query& query, ref<Expr> &result) {
   // FIXME: We don't have a way to communicate valid constraints back.
   if (isValid)
     return false;
-  
+
   // Propogation found a satisfying assignment, evaluate the expression.
   ref<Expr> value = cd.evaluatePossible(query.expr);
-  
+
   if (isa<ConstantExpr>(value)) {
     // FIXME: We should be able to make sure this never fails?
     result = value;
@@ -1120,11 +1120,11 @@ FastCexSolver::computeInitialValues(const Query& query,
     data.reserve(array->size);
 
     for (unsigned i=0; i < array->size; i++) {
-      ref<Expr> read = 
+      ref<Expr> read =
         ReadExpr::create(UpdateList(array, 0),
                          ConstantExpr::create(i, array->getDomain()));
       ref<Expr> value = cd.evaluatePossible(read);
-      
+
       if (ConstantExpr *CE = dyn_cast<ConstantExpr>(value)) {
         data.push_back((unsigned char) CE->getZExtValue(8));
       } else {

--- a/lib/Solver/IncompleteSolver.cpp
+++ b/lib/Solver/IncompleteSolver.cpp
@@ -16,10 +16,10 @@ using namespace llvm;
 
 /***/
 
-IncompleteSolver::PartialValidity 
+IncompleteSolver::PartialValidity
 IncompleteSolver::negatePartialValidity(PartialValidity pv) {
   switch(pv) {
-  default: assert(0 && "invalid partial validity");  
+  default: assert(0 && "invalid partial validity");
   case MustBeTrue:  return MustBeFalse;
   case MustBeFalse: return MustBeTrue;
   case MayBeTrue:   return MayBeFalse;
@@ -28,7 +28,7 @@ IncompleteSolver::negatePartialValidity(PartialValidity pv) {
   }
 }
 
-IncompleteSolver::PartialValidity 
+IncompleteSolver::PartialValidity
 IncompleteSolver::computeValidity(const Query& query) {
   PartialValidity trueResult = computeTruth(query);
 
@@ -42,7 +42,7 @@ IncompleteSolver::computeValidity(const Query& query) {
     } else {
       bool trueCorrect = trueResult != None,
         falseCorrect = falseResult != None;
-      
+
       if (trueCorrect && falseCorrect) {
         return TrueOrFalse;
       } else if (trueCorrect) { // ==> trueResult == MayBeFalse
@@ -58,8 +58,8 @@ IncompleteSolver::computeValidity(const Query& query) {
 
 /***/
 
-StagedSolverImpl::StagedSolverImpl(IncompleteSolver *_primary, 
-                                   Solver *_secondary) 
+StagedSolverImpl::StagedSolverImpl(IncompleteSolver *_primary,
+                                   Solver *_secondary)
   : primary(_primary),
     secondary(_secondary) {
 }
@@ -70,12 +70,12 @@ StagedSolverImpl::~StagedSolverImpl() {
 }
 
 bool StagedSolverImpl::computeTruth(const Query& query, bool &isValid) {
-  IncompleteSolver::PartialValidity trueResult = primary->computeTruth(query); 
-  
+  IncompleteSolver::PartialValidity trueResult = primary->computeTruth(query);
+
   if (trueResult != IncompleteSolver::None) {
     isValid = (trueResult == IncompleteSolver::MustBeTrue);
     return true;
-  } 
+  }
 
   return secondary->impl->computeTruth(query, isValid);
 }
@@ -85,13 +85,13 @@ bool StagedSolverImpl::computeValidity(const Query& query,
   bool tmp;
 
   switch(primary->computeValidity(query)) {
-  case IncompleteSolver::MustBeTrue: 
+  case IncompleteSolver::MustBeTrue:
     result = Solver::True;
     break;
-  case IncompleteSolver::MustBeFalse: 
+  case IncompleteSolver::MustBeFalse:
     result = Solver::False;
     break;
-  case IncompleteSolver::TrueOrFalse: 
+  case IncompleteSolver::TrueOrFalse:
     result = Solver::Unknown;
     break;
   case IncompleteSolver::MayBeTrue:
@@ -121,16 +121,16 @@ bool StagedSolverImpl::computeValue(const Query& query,
   return secondary->impl->computeValue(query, result);
 }
 
-bool 
+bool
 StagedSolverImpl::computeInitialValues(const Query& query,
-                                       const std::vector<const Array*> 
+                                       const std::vector<const Array*>
                                          &objects,
                                        std::vector< std::vector<unsigned char> >
                                          &values,
                                        bool &hasSolution) {
   if (primary->computeInitialValues(query, objects, values, hasSolution))
     return true;
-  
+
   return secondary->impl->computeInitialValues(query, objects, values,
                                                hasSolution);
 }

--- a/lib/Solver/IndependentSolver.cpp
+++ b/lib/Solver/IndependentSolver.cpp
@@ -46,7 +46,7 @@ public:
   // returns true iff set is changed by addition
   bool add(const DenseSet &b) {
     bool modified = false;
-    for (typename set_ty::const_iterator it = b.s.begin(), ie = b.s.end(); 
+    for (typename set_ty::const_iterator it = b.s.begin(), ie = b.s.end();
          it != ie; ++it) {
       if (modified || !s.count(*it)) {
         modified = true;
@@ -57,7 +57,7 @@ public:
   }
 
   bool intersects(const DenseSet &b) {
-    for (typename set_ty::iterator it = s.begin(), ie = s.end(); 
+    for (typename set_ty::iterator it = s.begin(), ie = s.end();
          it != ie; ++it)
       if (b.s.count(*it))
         return true;
@@ -75,7 +75,7 @@ public:
   void print(llvm::raw_ostream &os) const {
     bool first = true;
     os << "{";
-    for (typename set_ty::iterator it = s.begin(), ie = s.end(); 
+    for (typename set_ty::iterator it = s.begin(), ie = s.end();
          it != ie; ++it) {
       if (first) {
         first = false;
@@ -118,7 +118,7 @@ public:
     for (unsigned i = 0; i != reads.size(); ++i) {
       ReadExpr *re = reads[i].get();
       const Array *array = re->updates.root;
-      
+
       // Reads of a constant array don't alias.
       if (re->updates.root->isConstantArray() &&
           !re->updates.head)
@@ -139,7 +139,7 @@ public:
       }
     }
   }
-  IndependentElementSet(const IndependentElementSet &ies) : 
+  IndependentElementSet(const IndependentElementSet &ies) :
     elements(ies.elements),
     wholeObjects(ies.wholeObjects),
     exprs(ies.exprs) {}
@@ -154,7 +154,7 @@ public:
   void print(llvm::raw_ostream &os) const {
     os << "{";
     bool first = true;
-    for (std::set<const Array*>::iterator it = wholeObjects.begin(), 
+    for (std::set<const Array*>::iterator it = wholeObjects.begin(),
            ie = wholeObjects.end(); it != ie; ++it) {
       const Array *array = *it;
 
@@ -185,10 +185,10 @@ public:
   // more efficient when this is the smaller set
   bool intersects(const IndependentElementSet &b) {
     // If there are any symbolic arrays in our query that b accesses
-    for (std::set<const Array*>::iterator it = wholeObjects.begin(), 
+    for (std::set<const Array*>::iterator it = wholeObjects.begin(),
            ie = wholeObjects.end(); it != ie; ++it) {
       const Array *array = *it;
-      if (b.wholeObjects.count(array) || 
+      if (b.wholeObjects.count(array) ||
           b.elements.find(array) != b.elements.end())
         return true;
     }
@@ -216,7 +216,7 @@ public:
     }
 
     bool modified = false;
-    for (std::set<const Array*>::const_iterator it = b.wholeObjects.begin(), 
+    for (std::set<const Array*>::const_iterator it = b.wholeObjects.begin(),
            ie = b.wholeObjects.end(); it != ie; ++it) {
       const Array *array = *it;
       elements_ty::iterator it2 = elements.find(array);
@@ -231,7 +231,7 @@ public:
         }
       }
     }
-    for (elements_ty::const_iterator it = b.elements.begin(), 
+    for (elements_ty::const_iterator it = b.elements.begin(),
            ie = b.elements.end(); it != ie; ++it) {
       const Array *array = it->first;
       if (!wholeObjects.count(array)) {
@@ -320,13 +320,13 @@ getAllIndependentConstraintsSets(const Query &query) {
   return factors;
 }
 
-static 
+static
 IndependentElementSet getIndependentConstraints(const Query& query,
                                                 std::vector< ref<Expr> > &result) {
   IndependentElementSet eltsClosure(query.expr);
   std::vector< std::pair<ref<Expr>, IndependentElementSet> > worklist;
 
-  for (ConstraintManager::const_iterator it = query.constraints.begin(), 
+  for (ConstraintManager::const_iterator it = query.constraints.begin(),
          ie = query.constraints.end(); it != ie; ++it)
     worklist.push_back(std::make_pair(*it, IndependentElementSet(*it)));
 
@@ -395,7 +395,7 @@ private:
   Solver *solver;
 
 public:
-  IndependentSolver(Solver *_solver) 
+  IndependentSolver(Solver *_solver)
     : solver(_solver) {}
   ~IndependentSolver() { delete solver; }
 
@@ -410,29 +410,29 @@ public:
   char *getConstraintLog(const Query&);
   void setCoreSolverTimeout(time::Span timeout);
 };
-  
+
 bool IndependentSolver::computeValidity(const Query& query,
                                         Solver::Validity &result) {
   std::vector< ref<Expr> > required;
   IndependentElementSet eltsClosure =
     getIndependentConstraints(query, required);
   ConstraintManager tmp(required);
-  return solver->impl->computeValidity(Query(tmp, query.expr), 
+  return solver->impl->computeValidity(Query(tmp, query.expr),
                                        result);
 }
 
 bool IndependentSolver::computeTruth(const Query& query, bool &isValid) {
   std::vector< ref<Expr> > required;
-  IndependentElementSet eltsClosure = 
+  IndependentElementSet eltsClosure =
     getIndependentConstraints(query, required);
   ConstraintManager tmp(required);
-  return solver->impl->computeTruth(Query(tmp, query.expr), 
+  return solver->impl->computeTruth(Query(tmp, query.expr),
                                     isValid);
 }
 
 bool IndependentSolver::computeValue(const Query& query, ref<Expr> &result) {
   std::vector< ref<Expr> > required;
-  IndependentElementSet eltsClosure = 
+  IndependentElementSet eltsClosure =
     getIndependentConstraints(query, required);
   ConstraintManager tmp(required);
   return solver->impl->computeValue(Query(tmp, query.expr), result);
@@ -550,7 +550,7 @@ bool IndependentSolver::computeInitialValues(const Query& query,
 }
 
 SolverImpl::SolverRunStatus IndependentSolver::getOperationStatusCode() {
-  return solver->impl->getOperationStatusCode();      
+  return solver->impl->getOperationStatusCode();
 }
 
 char *IndependentSolver::getConstraintLog(const Query& query) {

--- a/lib/Solver/MetaSMTBuilder.h
+++ b/lib/Solver/MetaSMTBuilder.h
@@ -927,11 +927,11 @@ MetaSMTBuilder<SolverContext>::constructActual(ref<Expr> e, int *width_out) {
     bool construct_both = true;
 
 #if 0 // not faster per first benchmark
-            
+
             if (_optimizeDivides) {
                 if (ConstantExpr *cre = de->right->asConstant()) {
                     uint64_t divisor = cre->asUInt64;
-    
+
                     //use fast division to compute modulo without explicit division for constant divisor
                     if( *width_out == 32 ) { //only works for 32-bit division
                        	typename SolverContext::result_type quotient = constructSDivByConstant(left, *width_out, divisor);

--- a/lib/Solver/SMTLIBLoggingSolver.cpp
+++ b/lib/Solver/SMTLIBLoggingSolver.cpp
@@ -18,14 +18,14 @@ using namespace klee;
 class SMTLIBLoggingSolver : public QueryLoggingSolver
 {
         private:
-    
+
                 ExprSMTLIBPrinter printer;
 
                 virtual void printQuery(const Query& query,
                                         const Query* falseQuery = 0,
-                                        const std::vector<const Array*>* objects = 0) 
+                                        const std::vector<const Array*>* objects = 0)
                 {
-                        if (0 == falseQuery) 
+                        if (0 == falseQuery)
                         {
                                 printer.setQuery(query);
                         }
@@ -40,8 +40,8 @@ class SMTLIBLoggingSolver : public QueryLoggingSolver
                         }
 
                         printer.generateOutput();
-                }    
-        
+                }
+
 	public:
 		SMTLIBLoggingSolver(Solver *_solver,
                         std::string path,

--- a/lib/Solver/STPBuilder.cpp
+++ b/lib/Solver/STPBuilder.cpp
@@ -81,7 +81,7 @@ STPBuilder::STPBuilder(::VC _vc, bool _optimizeDivides)
 }
 
 STPBuilder::~STPBuilder() {
-  
+
 }
 
 ///
@@ -183,7 +183,7 @@ ExprHandle STPBuilder::bvLeftShift(ExprHandle expr, unsigned shift) {
   } else {
     // stp shift does "expr @ [0 x s]" which we then have to extract,
     // rolling our own gives slightly smaller exprs
-    return vc_bvConcatExpr(vc, 
+    return vc_bvConcatExpr(vc,
                            bvExtract(expr, width - shift - 1, 0),
                            bvZero(shift));
   }
@@ -315,7 +315,7 @@ ExprHandle STPBuilder::constructMulByConstant(ExprHandle expr, unsigned width, u
     if ((add&bit) || (sub&bit)) {
       assert(!((add&bit) && (sub&bit)) && "invalid mult constants");
       ExprHandle op = bvLeftShift(expr, j);
-      
+
       if (add&bit) {
         if (res) {
           res = vc_bvPlusExpr(vc, width, res, op);
@@ -332,17 +332,17 @@ ExprHandle STPBuilder::constructMulByConstant(ExprHandle expr, unsigned width, u
     }
   }
 
-  if (!res) 
+  if (!res)
     res = bvZero(width);
 
   return res;
 }
 
-/* 
- * Compute the 32-bit unsigned integer division of n by a divisor d based on 
+/*
+ * Compute the 32-bit unsigned integer division of n by a divisor d based on
  * the constants derived from the constant divisor d.
  *
- * Returns n/d without doing explicit division.  The cost is 2 adds, 3 shifts, 
+ * Returns n/d without doing explicit division.  The cost is 2 adds, 3 shifts,
  * and a (64-bit) multiply.
  *
  * @param n      numerator (dividend) as an expression
@@ -375,11 +375,11 @@ ExprHandle STPBuilder::constructUDivByConstant(ExprHandle expr_n, unsigned width
   return res;
 }
 
-/* 
- * Compute the 32-bitnsigned integer division of n by a divisor d based on 
+/*
+ * Compute the 32-bitnsigned integer division of n by a divisor d based on
  * the constants derived from the constant divisor d.
  *
- * Returns n/d without doing explicit division.  The cost is 3 adds, 3 shifts, 
+ * Returns n/d without doing explicit division.  The cost is 3 adds, 3 shifts,
  * a (64-bit) multiply, and an XOR.
  *
  * @param n      numerator (dividend) as an expression
@@ -419,7 +419,7 @@ ExprHandle STPBuilder::constructSDivByConstant(ExprHandle expr_n, unsigned width
 
   // q0 = (n_plus_mulsh >> shpost) - XSIGN(n)
   ExprHandle q0           = vc_bvMinusExpr( vc, width, shift_shpost, xsign_of_n );
-  
+
   // n/d = (q0 ^ dsign) - dsign
   ExprHandle q0_xor_dsign = vc_bvXorExpr( vc, q0, expr_dsign );
   ExprHandle res          = vc_bvMinusExpr( vc, width, q0_xor_dsign, expr_dsign );
@@ -428,11 +428,11 @@ ExprHandle STPBuilder::constructSDivByConstant(ExprHandle expr_n, unsigned width
 }
 
 ::VCExpr STPBuilder::getInitialArray(const Array *root) {
-  
+
   assert(root);
   ::VCExpr array_expr;
   bool hashed = _arr_hash.lookupArrayExpr(root, array_expr);
-  
+
   if (!hashed) {
     // STP uniques arrays by name, so we make sure the name is unique by
     // using the size of the array hash as a counter.
@@ -458,10 +458,10 @@ ExprHandle STPBuilder::constructSDivByConstant(ExprHandle expr_n, unsigned width
 	vc_DeleteExpr(prev);
       }
     }
-    
+
     _arr_hash.hashArrayExpr(root, array_expr);
   }
-  
+
   return array_expr;
 }
 
@@ -469,7 +469,7 @@ ExprHandle STPBuilder::getInitialRead(const Array *root, unsigned index) {
   return vc_readExpr(vc, getInitialArray(root), bvConst32(32, index));
 }
 
-::VCExpr STPBuilder::getArrayForUpdate(const Array *root, 
+::VCExpr STPBuilder::getArrayForUpdate(const Array *root,
                                        const UpdateNode *un) {
   if (!un) {
       return getInitialArray(root);
@@ -478,16 +478,16 @@ ExprHandle STPBuilder::getInitialRead(const Array *root, unsigned index) {
       // FIXME: This really needs to be non-recursive.
       ::VCExpr un_expr;
       bool hashed = _arr_hash.lookupUpdateNodeExpr(un, un_expr);
-      
+
       if (!hashed) {
 	un_expr = vc_writeExpr(vc,
                                getArrayForUpdate(root, un->next),
                                construct(un->index, 0),
                                construct(un->value, 0));
-	
+
 	_arr_hash.hashUpdateNodeExpr(un, un_expr);
       }
-      
+
       return un_expr;
   }
 }
@@ -498,7 +498,7 @@ ExprHandle STPBuilder::construct(ref<Expr> e, int *width_out) {
   if (!UseConstructHash || isa<ConstantExpr>(e)) {
     return constructActual(e, width_out);
   } else {
-    ExprHashMap< std::pair<ExprHandle, unsigned> >::iterator it = 
+    ExprHashMap< std::pair<ExprHandle, unsigned> >::iterator it =
       constructed.find(e);
     if (it!=constructed.end()) {
       if (width_out)
@@ -549,7 +549,7 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
     }
     return Res;
   }
-    
+
   // Special
   case Expr::NotOptimized: {
     NotOptimizedExpr *noe = cast<NotOptimizedExpr>(e);
@@ -564,7 +564,7 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
                        getArrayForUpdate(re->updates.root, re->updates.head),
                        construct(re->index, 0));
   }
-    
+
   case Expr::Select: {
     SelectExpr *se = cast<SelectExpr>(e);
     ExprHandle cond = construct(se->cond, 0);
@@ -586,7 +586,7 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
 
   case Expr::Extract: {
     ExtractExpr *ee = cast<ExtractExpr>(e);
-    ExprHandle src = construct(ee->expr, width_out);    
+    ExprHandle src = construct(ee->expr, width_out);
     *width_out = ee->getWidth();
     if (*width_out==1) {
       return bvBoolExtract(src, ee->offset);
@@ -637,7 +637,7 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
     ExprHandle right = construct(se->right, width_out);
     assert(*width_out!=1 && "uncanonicalized sub");
     return vc_bvMinusExpr(vc, *width_out, left, right);
-  } 
+  }
 
   case Expr::Mul: {
     MulExpr *me = cast<MulExpr>(e);
@@ -646,7 +646,7 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
 
     if (ConstantExpr *CE = dyn_cast<ConstantExpr>(me->left))
       if (CE->getWidth() <= 64)
-        return constructMulByConstant(right, *width_out, 
+        return constructMulByConstant(right, *width_out,
                                       CE->getZExtValue());
 
     ExprHandle left = construct(me->left, width_out);
@@ -657,21 +657,21 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
     UDivExpr *de = cast<UDivExpr>(e);
     ExprHandle left = construct(de->left, width_out);
     assert(*width_out!=1 && "uncanonicalized udiv");
-    
+
     if (ConstantExpr *CE = dyn_cast<ConstantExpr>(de->right)) {
       if (CE->getWidth() <= 64) {
         uint64_t divisor = CE->getZExtValue();
-      
+
         if (bits64::isPowerOfTwo(divisor)) {
           return bvRightShift(left,
                               bits64::indexOfSingleBit(divisor));
         } else if (optimizeDivides) {
           if (*width_out == 32) //only works for 32-bit division
-            return constructUDivByConstant( left, *width_out, 
+            return constructUDivByConstant( left, *width_out,
                                             (uint32_t) divisor);
         }
       }
-    } 
+    }
 
     ExprHandle right = construct(de->right, width_out);
     return vc_bvDivExpr(vc, *width_out, left, right);
@@ -701,7 +701,7 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
     URemExpr *de = cast<URemExpr>(e);
     ExprHandle left = construct(de->left, width_out);
     assert(*width_out!=1 && "uncanonicalized urem");
-    
+
     if (ConstantExpr *CE = dyn_cast<ConstantExpr>(de->right)) {
       if (CE->getWidth() <= 64) {
         uint64_t divisor = CE->getZExtValue();
@@ -732,7 +732,7 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
         }
       }
     }
-    
+
     ExprHandle right = construct(de->right, width_out);
     return vc_bvModExpr(vc, *width_out, left, right);
   }
@@ -773,7 +773,7 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
     } else {
       return vc_bvNotExpr(vc, expr);
     }
-  }    
+  }
 
   case Expr::And: {
     AndExpr *ae = cast<AndExpr>(e);
@@ -801,10 +801,10 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
     XorExpr *xe = cast<XorExpr>(e);
     ExprHandle left = construct(xe->left, width_out);
     ExprHandle right = construct(xe->right, width_out);
-    
+
     if (*width_out==1) {
       // XXX check for most efficient?
-      return vc_iteExpr(vc, left, 
+      return vc_iteExpr(vc, left,
                         ExprHandle(vc_notExpr(vc, right)), right);
     } else {
       return vc_bvXorExpr(vc, left, right);
@@ -843,7 +843,7 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
     AShrExpr *ase = cast<AShrExpr>(e);
     ExprHandle left = construct(ase->left, width_out);
     assert(*width_out!=1 && "uncanonicalized ashr");
-    
+
     if (ConstantExpr *CE = dyn_cast<ConstantExpr>(ase->right)) {
       unsigned shift = (unsigned) CE->getLimitedValue();
       ExprHandle signedBool = bvBoolExtract(left, *width_out-1);
@@ -920,7 +920,7 @@ ExprHandle STPBuilder::constructActual(ref<Expr> e, int *width_out) {
   case Expr::Sge:
 #endif
 
-  default: 
+  default:
     assert(0 && "unhandled Expr type");
     return vc_trueExpr(vc);
   }

--- a/lib/Solver/STPBuilder.h
+++ b/lib/Solver/STPBuilder.h
@@ -25,23 +25,23 @@ namespace klee {
     friend class ExprHandle;
     ::VCExpr expr;
     unsigned count;
-    
+
   public:
     ExprHolder(const ::VCExpr _expr) : expr(_expr), count(0) {}
-    ~ExprHolder() { 
-      if (expr) vc_DeleteExpr(expr); 
+    ~ExprHolder() {
+      if (expr) vc_DeleteExpr(expr);
     }
   };
 
   class ExprHandle {
     ExprHolder *H;
-    
+
   public:
     ExprHandle() : H(new ExprHolder(0)) { H->count++; }
     ExprHandle(::VCExpr _expr) : H(new ExprHolder(_expr)) { H->count++; }
     ExprHandle(const ExprHandle &b) : H(b.H) { H->count++; }
     ~ExprHandle() { if (--H->count == 0) delete H; }
-    
+
     ExprHandle &operator=(const ExprHandle &b) {
       if (--H->count == 0) delete H;
       H = b.H;
@@ -52,11 +52,11 @@ namespace klee {
     operator bool () { return H->expr; }
     operator ::VCExpr () { return H->expr; }
   };
-  
+
   class STPArrayExprHash : public ArrayExprHash< ::VCExpr > {
-    
+
     friend class STPBuilder;
-    
+
   public:
     STPArrayExprHash() {};
     virtual ~STPArrayExprHash();
@@ -73,7 +73,7 @@ class STPBuilder {
 
   STPArrayExprHash _arr_hash;
 
-private:  
+private:
 
   ExprHandle bvOne(unsigned width);
   ExprHandle bvZero(unsigned width);
@@ -96,7 +96,7 @@ private:
   ExprHandle extractPartialShiftValue(ExprHandle shift, unsigned width,
                                       unsigned &shiftBits);
 
-  ExprHandle constructAShrByConstant(ExprHandle expr, unsigned shift, 
+  ExprHandle constructAShrByConstant(ExprHandle expr, unsigned shift,
                                      ExprHandle isSigned);
   ExprHandle constructMulByConstant(ExprHandle expr, unsigned width, uint64_t x);
   ExprHandle constructUDivByConstant(ExprHandle expr_n, unsigned width, uint64_t d);
@@ -107,10 +107,10 @@ private:
 
   ExprHandle constructActual(ref<Expr> e, int *width_out);
   ExprHandle construct(ref<Expr> e, int *width_out);
-  
+
   ::VCExpr buildVar(const char *name, unsigned width);
   ::VCExpr buildArray(const char *name, unsigned indexWidth, unsigned valueWidth);
- 
+
 public:
   STPBuilder(::VC _vc, bool _optimizeDivides=true);
   ~STPBuilder();
@@ -119,7 +119,7 @@ public:
   ExprHandle getFalse();
   ExprHandle getInitialRead(const Array *os, unsigned index);
 
-  ExprHandle construct(ref<Expr> e) { 
+  ExprHandle construct(ref<Expr> e) {
     ExprHandle res = construct(e, 0);
     constructed.clear();
     return res;

--- a/lib/Solver/Solver.cpp
+++ b/lib/Solver/Solver.cpp
@@ -22,8 +22,8 @@ const char *Solver::validity_to_str(Validity v) {
   }
 }
 
-Solver::~Solver() { 
-  delete impl; 
+Solver::~Solver() {
+  delete impl;
 }
 
 char *Solver::getConstraintLog(const Query& query) {
@@ -89,12 +89,12 @@ bool Solver::getValue(const Query& query, ref<ConstantExpr> &result) {
   ref<Expr> tmp;
   if (!impl->computeValue(query, tmp))
     return false;
-  
+
   result = cast<ConstantExpr>(tmp);
   return true;
 }
 
-bool 
+bool
 Solver::getInitialValues(const Query& query,
                          const std::vector<const Array*> &objects,
                          std::vector< std::vector<unsigned char> > &values) {
@@ -104,7 +104,7 @@ Solver::getInitialValues(const Query& query,
   // FIXME: Propogate this out.
   if (!hasSolution)
     return false;
-    
+
   return success;
 }
 
@@ -118,9 +118,9 @@ std::pair< ref<Expr>, ref<Expr> > Solver::getRange(const Query& query) {
     if (!evaluate(query, result))
       assert(0 && "computeValidity failed");
     switch (result) {
-    case Solver::True: 
+    case Solver::True:
       min = max = 1; break;
-    case Solver::False: 
+    case Solver::False:
       min = max = 0; break;
     default:
       min = 0, max = 1; break;
@@ -133,10 +133,10 @@ std::pair< ref<Expr>, ref<Expr> > Solver::getRange(const Query& query) {
     while (lo<hi) {
       mid = lo + (hi - lo)/2;
       bool res;
-      bool success = 
+      bool success =
         mustBeTrue(query.withExpr(
                      EqExpr::create(LShrExpr::create(e,
-                                                     ConstantExpr::create(mid, 
+                                                     ConstantExpr::create(mid,
                                                                           width)),
                                     ConstantExpr::create(0, width))),
                    res);
@@ -152,18 +152,18 @@ std::pair< ref<Expr>, ref<Expr> > Solver::getRange(const Query& query) {
 
       bits = lo;
     }
-    
+
     // could binary search for training zeros and offset
     // min max but unlikely to be very useful
 
     // check common case
     bool res = false;
-    bool success = 
-      mayBeTrue(query.withExpr(EqExpr::create(e, ConstantExpr::create(0, 
-                                                                      width))), 
+    bool success =
+      mayBeTrue(query.withExpr(EqExpr::create(e, ConstantExpr::create(0,
+                                                                      width))),
                 res);
 
-    assert(success && "FIXME: Unhandled solver failure");      
+    assert(success && "FIXME: Unhandled solver failure");
     (void) success;
 
     if (res) {
@@ -174,13 +174,13 @@ std::pair< ref<Expr>, ref<Expr> > Solver::getRange(const Query& query) {
       while (lo<hi) {
         mid = lo + (hi - lo)/2;
         bool res = false;
-        bool success = 
-          mayBeTrue(query.withExpr(UleExpr::create(e, 
-                                                   ConstantExpr::create(mid, 
+        bool success =
+          mayBeTrue(query.withExpr(UleExpr::create(e,
+                                                   ConstantExpr::create(mid,
                                                                         width))),
                     res);
 
-        assert(success && "FIXME: Unhandled solver failure");      
+        assert(success && "FIXME: Unhandled solver failure");
         (void) success;
 
         if (res) {
@@ -198,13 +198,13 @@ std::pair< ref<Expr>, ref<Expr> > Solver::getRange(const Query& query) {
     while (lo<hi) {
       mid = lo + (hi - lo)/2;
       bool res;
-      bool success = 
-        mustBeTrue(query.withExpr(UleExpr::create(e, 
-                                                  ConstantExpr::create(mid, 
+      bool success =
+        mustBeTrue(query.withExpr(UleExpr::create(e,
+                                                  ConstantExpr::create(mid,
                                                                        width))),
                    res);
 
-      assert(success && "FIXME: Unhandled solver failure");      
+      assert(success && "FIXME: Unhandled solver failure");
       (void) success;
 
       if (res) {

--- a/lib/Support/RNG.cpp
+++ b/lib/Support/RNG.cpp
@@ -1,13 +1,13 @@
-/* 
+/*
    A C-program for MT19937, with initialization improved 2002/1/26.
    Coded by Takuji Nishimura and Makoto Matsumoto.
    Modified to be a C++ class by Daniel Dunbar.
 
-   Before using, initialize the state by using init_genrand(seed)  
+   Before using, initialize the state by using init_genrand(seed)
    or init_by_array(init_key, key_length).
 
    Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
-   All rights reserved.                          
+   All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions
@@ -20,8 +20,8 @@
         notice, this list of conditions and the following disclaimer in the
         documentation and/or other materials provided with the distribution.
 
-     3. The names of its contributors may not be used to endorse or promote 
-        products derived from this software without specific prior written 
+     3. The names of its contributors may not be used to endorse or promote
+        products derived from this software without specific prior written
         permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -54,8 +54,8 @@ RNG::RNG(unsigned int s) {
 void RNG::seed(unsigned int s) {
   mt[0]= s & 0xffffffffUL;
   for (mti=1; mti<N; mti++) {
-    mt[mti] = 
-      (1812433253UL * (mt[mti-1] ^ (mt[mti-1] >> 30)) + mti); 
+    mt[mti] =
+      (1812433253UL * (mt[mti-1] ^ (mt[mti-1] >> 30)) + mti);
     /* See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier. */
     /* In the previous versions, MSBs of the seed affect   */
     /* only MSBs of the array mt[].                        */
@@ -70,10 +70,10 @@ unsigned int RNG::getInt32() {
   unsigned int y;
   static unsigned int mag01[2]={0x0UL, MATRIX_A};
   /* mag01[x] = x * MATRIX_A  for x=0,1 */
-  
+
   if (mti >= N) { /* generate N words at one time */
     int kk;
-    
+
     for (kk=0;kk<N-M;kk++) {
       y = (mt[kk]&UPPER_MASK)|(mt[kk+1]&LOWER_MASK);
       mt[kk] = mt[kk+M] ^ (y >> 1) ^ mag01[y & 0x1UL];
@@ -84,10 +84,10 @@ unsigned int RNG::getInt32() {
     }
     y = (mt[N-1]&UPPER_MASK)|(mt[0]&LOWER_MASK);
     mt[N-1] = mt[M-1] ^ (y >> 1) ^ mag01[y & 0x1UL];
-    
+
     mti = 0;
   }
-  
+
   y = mt[mti++];
 
   /* Tempering */
@@ -95,7 +95,7 @@ unsigned int RNG::getInt32() {
   y ^= (y << 7) & 0x9d2c5680UL;
   y ^= (y << 15) & 0xefc60000UL;
   y ^= (y >> 18);
-  
+
   return y;
 }
 
@@ -106,32 +106,32 @@ int RNG::getInt31() {
 
 /* generates a random number on [0,1]-real-interval */
 double RNG::getDoubleLR() {
-  return getInt32()*(1.0/4294967295.0); 
-  /* divided by 2^32-1 */ 
+  return getInt32()*(1.0/4294967295.0);
+  /* divided by 2^32-1 */
 }
 
 /* generates a random number on [0,1)-real-interval */
 double RNG::getDoubleL() {
-  return getInt32()*(1.0/4294967296.0); 
+  return getInt32()*(1.0/4294967296.0);
   /* divided by 2^32 */
 }
 
 /* generates a random number on (0,1)-real-interval */
 double RNG::getDouble() {
-  return (((double)getInt32()) + 0.5)*(1.0/4294967296.0); 
+  return (((double)getInt32()) + 0.5)*(1.0/4294967296.0);
   /* divided by 2^32 */
 }
 
 float RNG::getFloatLR() {
-  return getInt32()*(1.0f/4294967295.0f); 
-  /* divided by 2^32-1 */ 
+  return getInt32()*(1.0f/4294967295.0f);
+  /* divided by 2^32-1 */
 }
 float RNG::getFloatL() {
-  return getInt32()*(1.0f/4294967296.0f); 
+  return getInt32()*(1.0f/4294967296.0f);
   /* divided by 2^32 */
 }
 float RNG::getFloat() {
-  return (getInt32() + 0.5f)*(1.0f/4294967296.0f); 
+  return (getInt32() + 0.5f)*(1.0f/4294967296.0f);
   /* divided by 2^32 */
 }
 

--- a/lib/Support/TreeStream.cpp
+++ b/lib/Support/TreeStream.cpp
@@ -25,11 +25,11 @@ using namespace klee;
 
 ///
 
-TreeStreamWriter::TreeStreamWriter(const std::string &_path) 
+TreeStreamWriter::TreeStreamWriter(const std::string &_path)
   : lastID(0),
     bufferCount(0),
     path(_path),
-    output(new std::ofstream(path.c_str(), 
+    output(new std::ofstream(path.c_str(),
                              std::ios::out | std::ios::binary)),
     ids(1) {
   if (!output->good()) {
@@ -62,7 +62,7 @@ TreeOStream TreeStreamWriter::open(const TreeOStream &os) {
 }
 
 void TreeStreamWriter::write(TreeOStream &os, const char *s, unsigned size) {
-  if (bufferCount && 
+  if (bufferCount &&
       (os.id!=lastID || size+bufferCount>bufferSize))
     flushBuffer();
   if (bufferCount) { // (os.id==lastID && size+bufferCount<=bufferSize)
@@ -80,7 +80,7 @@ void TreeStreamWriter::write(TreeOStream &os, const char *s, unsigned size) {
 }
 
 void TreeStreamWriter::flushBuffer() {
-  if (bufferCount) {    
+  if (bufferCount) {
     output->write(reinterpret_cast<const char*>(&lastID), 4);
     output->write(reinterpret_cast<const char*>(&bufferCount), 4);
     output->write(buffer, bufferCount);
@@ -97,7 +97,7 @@ void TreeStreamWriter::readStream(TreeStreamID streamID,
                                   std::vector<unsigned char> &out) {
   assert(streamID>0 && streamID<ids);
   flush();
-  
+
   std::ifstream is(path.c_str(),
                    std::ios::in | std::ios::binary);
   assert(is.good());
@@ -121,7 +121,7 @@ void TreeStreamWriter::readStream(TreeStreamID streamID,
           std::map<unsigned, unsigned>::iterator it = parents.find(id);
           assert(it!=parents.end());
           id = it->second;
-        } 
+        }
         break;
       } else {
         parents.insert(std::make_pair(child,id));
@@ -157,7 +157,7 @@ void TreeStreamWriter::readStream(TreeStreamID streamID,
         while (size--) is.get();
       }
     }
-  }  
+  }
 }
 
 ///

--- a/runtime/Intrinsic/klee_range.c
+++ b/runtime/Intrinsic/klee_range.c
@@ -20,7 +20,7 @@ int klee_range(int start, int end, const char* name) {
   if (start+1==end) {
     return start;
   } else {
-    klee_make_symbolic(&x, sizeof x, name); 
+    klee_make_symbolic(&x, sizeof x, name);
 
     /* Make nicer constraint when simple... */
     if (start==0) {

--- a/runtime/POSIX/fd.h
+++ b/runtime/POSIX/fd.h
@@ -50,7 +50,7 @@ typedef enum {
   eWriteable    = (1 << 3)
 } exe_file_flag_t;
 
-typedef struct {      
+typedef struct {
   int fd;                   /* actual fd if not symbolic */
   unsigned flags;           /* set of exe_file_flag_t values. fields
                                are only defined when flags at least
@@ -66,7 +66,7 @@ typedef struct {
   exe_disk_file_t *sym_files;
   /* --- */
   /* the maximum number of failures on one path; gets decremented after each failure */
-  unsigned max_failures; 
+  unsigned max_failures;
 
   /* Which read, write etc. call should fail */
   int *read_fail, *write_fail, *close_fail, *ftruncate_fail, *getcwd_fail;
@@ -85,7 +85,7 @@ typedef struct {
   /* If set, writes execute as expected.  Otherwise, writes extending
      the file size only change the contents up to the initial
      size. The file offset is always incremented correctly. */
-  int save_all_writes; 
+  int save_all_writes;
 } exe_sym_env_t;
 
 extern exe_file_system_t __exe_fs;

--- a/runtime/POSIX/fd_init.c
+++ b/runtime/POSIX/fd_init.c
@@ -34,16 +34,16 @@ exe_file_system_t __exe_fs;
    mostly care about sym case anyway. */
 
 
-exe_sym_env_t __exe_env = { 
-  {{ 0, eOpen | eReadable, 0, 0}, 
-   { 1, eOpen | eWriteable, 0, 0}, 
+exe_sym_env_t __exe_env = {
+  {{ 0, eOpen | eReadable, 0, 0},
+   { 1, eOpen | eWriteable, 0, 0},
    { 2, eOpen | eWriteable, 0, 0}},
   022,
   0,
   0
 };
 
-static void __create_new_dfile(exe_disk_file_t *dfile, unsigned size, 
+static void __create_new_dfile(exe_disk_file_t *dfile, unsigned size,
                                const char *name, struct stat64 *defaults) {
   struct stat64 *s = malloc(sizeof(*s));
   const char *sp;
@@ -57,14 +57,14 @@ static void __create_new_dfile(exe_disk_file_t *dfile, unsigned size,
   dfile->size = size;
   dfile->contents = malloc(dfile->size);
   klee_make_symbolic(dfile->contents, dfile->size, name);
-  
+
   klee_make_symbolic(s, sizeof(*s), sname);
 
   /* For broken tests */
-  if (!klee_is_symbolic(s->st_ino) && 
+  if (!klee_is_symbolic(s->st_ino) &&
       (s->st_ino & 0x7FFFFFFF) == 0)
     s->st_ino = defaults->st_ino;
-  
+
   /* Important since we copy this out through getdents, and readdir
      will otherwise skip this entry. For same reason need to make sure
      it fits in low bits. */
@@ -103,8 +103,8 @@ static unsigned __sym_uint32(const char *name) {
 /* n_files: number of symbolic input files, excluding stdin
    file_length: size in bytes of each symbolic file, including stdin
    sym_stdout_flag: 1 if stdout should be symbolic, 0 otherwise
-   save_all_writes_flag: 1 if all writes are executed as expected, 0 if 
-                         writes past the initial file size are discarded 
+   save_all_writes_flag: 1 if all writes are executed as expected, 0 if
+                         writes past the initial file size are discarded
 			 (file offset is always incremented)
    max_failures: maximum number of system call failures */
 void klee_init_fds(unsigned n_files, unsigned file_length,
@@ -122,7 +122,7 @@ void klee_init_fds(unsigned n_files, unsigned file_length,
     name[0] = 'A' + k;
     __create_new_dfile(&__exe_fs.sym_files[k], file_length, name, &s);
   }
-  
+
   /* setting symbolic stdin */
   if (stdin_length) {
     __exe_fs.sym_stdin = malloc(sizeof(*__exe_fs.sym_stdin));
@@ -154,7 +154,7 @@ void klee_init_fds(unsigned n_files, unsigned file_length,
     __exe_fs.stdout_writes = 0;
   }
   else __exe_fs.sym_stdout = NULL;
-  
+
   __exe_env.save_all_writes = save_all_writes_flag;
   __exe_env.version = __sym_uint32("model_version");
   klee_assume(__exe_env.version == 1);

--- a/runtime/POSIX/klee_init_env.c
+++ b/runtime/POSIX/klee_init_env.c
@@ -26,7 +26,7 @@ static void __emit_error(const char *msg) {
 
 /* Helper function that converts a string to an integer, and
    terminates the program with an error message is the string is not a
-   proper number */   
+   proper number */
 static long int __str_to_int(char *s, const char *error_msg) {
   long int res = 0;
   char c;
@@ -68,7 +68,7 @@ static char *__get_sym_str(int numChars, char *name) {
 
   for (i=0; i<numChars; i++)
     klee_posix_prefer_cex(s, __isprint(s[i]));
-  
+
   s[numChars] = '\0';
   return s;
 }
@@ -156,7 +156,7 @@ usage: (klee_init_env) [options] [program arguments]\n\
 
       if (sym_arg_num + max_argvs > 99)
         __emit_error("No more than 100 symbolic arguments allowed.");
-      
+
       for (i = 0; i < n_args; i++) {
         sym_arg_name[3] = '0' + sym_arg_num / 10;
         sym_arg_name[4] = '0' + sym_arg_num % 10;

--- a/runtime/POSIX/misc.c
+++ b/runtime/POSIX/misc.c
@@ -27,14 +27,14 @@ static sym_env_var *__klee_sym_env = 0;
 static unsigned __klee_sym_env_count = 0;
 static unsigned __klee_sym_env_nvars = 0;
 static unsigned __klee_sym_env_var_size = 0;
-void __klee_init_environ(unsigned nvars, 
+void __klee_init_environ(unsigned nvars,
                          unsigned var_size) {
   assert(var_size);
   __klee_sym_env = malloc(sizeof(*__klee_sym_env) * nvars);
   assert(__klee_sym_env);
 
   __klee_sym_env_nvars = nvars;
-  __klee_sym_env_var_size = var_size;  
+  __klee_sym_env_var_size = var_size;
 }
 
 static size_t __strlen(const char *s) {
@@ -65,22 +65,22 @@ char *getenv(const char *name) {
       for (i=0; i<__klee_sym_env_count; ++i)
         if (memcmp(__klee_sym_env[i].name, name, len+1)==0)
           return __klee_sym_env[i].value;
-      
+
       /* Otherwise create if room and we choose to */
       if (__klee_sym_env_count < __klee_sym_env_nvars) {
         if (klee_range(0, 2, name)) {
           char *s = malloc(__klee_sym_env_var_size+1);
           klee_make_symbolic(s, __klee_sym_env_var_size+1. "env");
           s[__klee_sym_env_var_size] = '\0';
-          
+
           memcpy(__klee_sym_env[__klee_sym_env_count].name, name, len+1);
           __klee_sym_env[__klee_sym_env_count].value = s;
           ++__klee_sym_env_count;
-          
+
           return s;
         }
       }
-      
+
       return 0;
     }
   }

--- a/runtime/POSIX/selinux.c
+++ b/runtime/POSIX/selinux.c
@@ -46,7 +46,7 @@ int setfscreatecon(KLEE_SELINUX_CTX_CONST char *context) {
   }
 
   /* on my machine, setfscreatecon seems to incorrectly accept one
-     char strings.. Also, make sure mcstrans > 0.2.8 for replay 
+     char strings.. Also, make sure mcstrans > 0.2.8 for replay
      (important bug fixed) */
   if (context[0] != '\0' && context[1] == '\0')
     klee_silent_exit(1);
@@ -59,9 +59,9 @@ int setfscreatecon(KLEE_SELINUX_CTX_CONST char *context) {
 int setfilecon(const char *path, KLEE_SELINUX_CTX_CONST char *con) {
   if (con)
     return 0;
-  
+
   errno = ENOSPC;
-  return -1;  
+  return -1;
 }
 
 int lsetfilecon(const char *path, KLEE_SELINUX_CTX_CONST char *con) {

--- a/runtime/klee-libc/__cxa_atexit.c
+++ b/runtime/klee-libc/__cxa_atexit.c
@@ -30,7 +30,7 @@ int __cxa_atexit(void (*fn)(void*),
                  void *arg,
                  void *dso_handle) {
   klee_warning_once("FIXME: __cxa_atexit being ignored");
-  
+
   /* Better to just report an error here than return 1 (the defined
    * semantics).
    */
@@ -39,11 +39,11 @@ int __cxa_atexit(void (*fn)(void*),
                       __LINE__,
                       "__cxa_atexit: no room in array!",
                       "exec");
-  
+
   AtExit[NumAtExit].fn = fn;
   AtExit[NumAtExit].arg = arg;
   ++NumAtExit;
-  
+
   return 0;
 }
 

--- a/runtime/klee-libc/calloc.c
+++ b/runtime/klee-libc/calloc.c
@@ -41,7 +41,7 @@ void *realloc(void *ptr, size_t nbytes) {
 		/* printf("REALLOC: copying = %d bytes!\n", copy_nbytes); */
 		memcpy(addr, ptr, copy_nbytes);
 		free(ptr);
-	} 
+	}
 	return addr;
 }
 #endif

--- a/runtime/klee-libc/strchr.c
+++ b/runtime/klee-libc/strchr.c
@@ -18,6 +18,6 @@ char *strchr(const char *p, int ch) {
       return 0;
     }
   }
-  /* NOTREACHED */  
+  /* NOTREACHED */
   return 0;
 }

--- a/test/ArrayOpt/test_hybrid.c
+++ b/test/ArrayOpt/test_hybrid.c
@@ -15,16 +15,16 @@ char array[10] = {1,2,2,4,5,3,1,3,2,2};
 
 int main() {
   unsigned char k;
-  
+
   klee_make_symbolic(&k, sizeof(k), "k");
   klee_assume(k < 10);
-  
+
   // CHECK: Yes
   // CHECK-NEXT: No
   if (array[k] >= 1)
     printf("Yes\n");
 
   // CHECK: KLEE: done: completed paths = 1
-  
+
   return 0;
 }

--- a/test/CXX/ArrayNew.cpp
+++ b/test/CXX/ArrayNew.cpp
@@ -28,7 +28,7 @@ int main(int argc) {
   int sum = 0;
   for (i=0; i<4; i++)
     sum += rt[i].getX();
-  
+
   assert(sum==10);
 
   delete[] rt;

--- a/test/CXX/New.cpp
+++ b/test/CXX/New.cpp
@@ -21,7 +21,7 @@ public:
 // it is also failing.
 int main(int argc) {
   Test *rt = new Test(2);
-  
+
   assert(rt->getX()==2);
 
   delete rt;

--- a/test/CXX/SimpleVirtual.cpp
+++ b/test/CXX/SimpleVirtual.cpp
@@ -19,7 +19,7 @@ public:
   virtual int getX() { return 2; };
 };
 
-Thing *getThing(bool which) { 
+Thing *getThing(bool which) {
   return which ? new Thing() : new Thing2();
 }
 
@@ -32,7 +32,7 @@ int main(int argc) {
 
   delete two;
   delete one;
-  
+
   assert(decon==2);
 
   return 0;

--- a/test/CXX/Trivial.cpp
+++ b/test/CXX/Trivial.cpp
@@ -16,7 +16,7 @@ public:
 
 int main() {
   Test rt(2);
-  
+
   assert(rt.getX()==2);
 
   return 0;

--- a/test/Concrete/_testingUtils.c
+++ b/test/Concrete/_testingUtils.c
@@ -9,7 +9,7 @@ void print_int(uint64_t val);
 
 #define TYPED_PRINT(_name_type, _arg_type)  \
     void print_ ## _name_type(_arg_type val) { print_int(val); }
- 
+
 TYPED_PRINT(i1, uint8_t)
 TYPED_PRINT(i8, uint8_t)
 TYPED_PRINT(i16, uint16_t)
@@ -33,11 +33,11 @@ void print_int(uint64_t val) {
         int digit = val / cur;
 
         printf(char_format_string, digit + '0');
-        
+
         val = val % cur;
         cur /= 10;
     }
-    
+
     printf(char_format_string, '\n');
 }
 

--- a/test/Dogfood/ImmutableSet.cpp
+++ b/test/Dogfood/ImmutableSet.cpp
@@ -71,7 +71,7 @@ void check_set(T &set, unsigned num, unsigned *values) {
     assert(set.find(item2) == set.end());
 
     T::iterator lb = set.lower_bound(item2);
-    for (T::iterator it=set.begin(); it!=lb; ++it)      
+    for (T::iterator it=set.begin(); it!=lb; ++it)
       assert(*it < item2);
     for (T::iterator it=lb, ie=set.end(); it!=ie; ++it)
       assert(*it >= item2);
@@ -101,10 +101,10 @@ void test() {
     set = set.insert(item);
     values[num++] = item;
   }
-  
+
   check_set(set, num, values);
 
-  unsigned item = klee_range(0, 256, "range");  
+  unsigned item = klee_range(0, 256, "range");
   if (contains(values, values+num, item)) { // in tree
     // insertion is invariant
     T set2 = set.insert(item);

--- a/test/Expr/ReadExprConsistency.c
+++ b/test/Expr/ReadExprConsistency.c
@@ -20,10 +20,10 @@ int main() {
 	char  arr[3];
   char symbolic;
   klee_make_symbolic(&symbolic, sizeof(symbolic), "symbolic");
-  klee_assume(symbolic >= 0 & symbolic < 3); 
+  klee_assume(symbolic >= 0 & symbolic < 3);
   klee_make_symbolic(arr, sizeof(arr), "arr");
-  
-  
+
+
   char a = arr[2];  // (ReadExpr 2 arr)
   //CHECK: arr[2]:(Read w8 2 arr)
   klee_print_expr("arr[2]", arr[2]);
@@ -32,7 +32,7 @@ int main() {
   //CHECK: arr[2]:(Read w8 2 arr)
   //CHECK-NOT: arr[2]:(Read w8 2 [1=0]@arr)
   klee_print_expr("arr[2]", arr[2]);
-  
+
   if(a == b) printf("Equal!\n");
   else printf("Not Equal!\n");
   return 0;

--- a/test/Feature/ByteSwap.c
+++ b/test/Feature/ByteSwap.c
@@ -6,12 +6,12 @@
 #include <assert.h>
 
 int main() {
-  
+
   uint32_t n = 0;
   klee_make_symbolic(&n, sizeof(n), "n");
-  
+
   uint32_t h = ntohl(n);
   assert(htonl(h) == n);
-  
+
   return 0;
 }

--- a/test/Feature/CopyOnWrite.c
+++ b/test/Feature/CopyOnWrite.c
@@ -12,7 +12,7 @@ void explode(int *ap, int i, int *result) {
   if (i<N) {
     (*result)++;
     if (ap[i]) // just cause a fork
-      branches++; 
+      branches++;
     return explode(ap, i+1, result);
   }
 }

--- a/test/Feature/DanglingConcreteReadExpr.c
+++ b/test/Feature/DanglingConcreteReadExpr.c
@@ -9,7 +9,7 @@ int main() {
   unsigned char x, y;
 
   klee_make_symbolic(&x, sizeof x, "x");
-  
+
   y = x;
 
   // should be exactly two queries (prove x is/is not 10)

--- a/test/Feature/DefineFixedObject.c
+++ b/test/Feature/DefineFixedObject.c
@@ -8,7 +8,7 @@
 
 int main() {
   klee_define_fixed_object(ADDRESS, 4);
-  
+
   int *p = ADDRESS;
 
   *p = 10;

--- a/test/Feature/ExprLogging.c
+++ b/test/Feature/ExprLogging.c
@@ -30,13 +30,13 @@ int main() {
   constantArr[klee_range(0, 16, "idx.0")] = buf[0];
 
   // Use this to trigger an interior update list usage.
-  int y = constantArr[klee_range(0, 16, "idx.1")];  
+  int y = constantArr[klee_range(0, 16, "idx.1")];
 
   constantArr[klee_range(0, 16, "idx.2")] = buf[3];
-  
+
   buf[klee_range(0, 4, "idx.3")] = 0;
   klee_assume(buf[0] == 'h');
-  
+
   int x = *((int*) buf);
   klee_assume(x > 2);
   klee_assume(x == constantArr[12]);

--- a/test/Feature/FloatingPt.c
+++ b/test/Feature/FloatingPt.c
@@ -7,10 +7,10 @@
 int main() {
   double a1 = -1.1;
   double a2 = 1.2;
-  
+
   int b1 = (int) a1;
   assert(b1 == -1);
-  
+
   int b2 = (int) a2;
   assert(b2 == 1);
 

--- a/test/Feature/FunctionPointer.c
+++ b/test/Feature/FunctionPointer.c
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
 
   printf("calling via pass through\n");
   bar(foo);
-        
+
   fp = baz;
   fp("called via fp");
 

--- a/test/Feature/LowerSwitch.c
+++ b/test/Feature/LowerSwitch.c
@@ -11,7 +11,7 @@
 
 int main(int argc, char **argv) {
   int c = klee_range(0, 256, "range");
-  
+
   switch(c) {
   case 0: printf("0\n"); break;
   case 10: printf("10\n"); break;
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
 #define C3(x) C2(x): C2(x+16): C2(x+32): C2(x+48)
   C3(128):
     printf("bignums: %d\n", c); break;
-  default: 
+  default:
     printf("default\n");
     break;
   }

--- a/test/Feature/MakeConcreteSymbolic.c
+++ b/test/Feature/MakeConcreteSymbolic.c
@@ -14,7 +14,7 @@
 int main() {
   int i;
   char a;
-  
+
   a = 10;
   assert(a == 10);
 

--- a/test/Feature/MakeSymbolicName.c
+++ b/test/Feature/MakeSymbolicName.c
@@ -8,7 +8,7 @@ int main() {
   int a[4] = {1, 2, 3, 4};
   unsigned i;
 
-  klee_make_symbolic(&i, sizeof(i), "index");  
+  klee_make_symbolic(&i, sizeof(i), "index");
   if (i > 3)
     klee_silent_exit(0);
 

--- a/test/Feature/MemoryLimit.c
+++ b/test/Feature/MemoryLimit.c
@@ -23,10 +23,10 @@
 
 int main() {
   int i, j, x=0, malloc_failed = 0;
-  
+
 #ifdef LITTLE_ALLOC
   printf("IN LITTLE ALLOC\n");
-    
+
   // 200 MBs total (in 1k chunks)
   for (i=0; i<100 && !malloc_failed; i++) {
     for (j=0; j<(1<<11); j++){
@@ -36,7 +36,7 @@ int main() {
   }
 #else
   printf("IN BIG ALLOC\n");
-  
+
   // 200 MBs total
   for (i=0; i<100 && !malloc_failed; i++) {
     void *p = malloc(1<<21);

--- a/test/Feature/Optimize.c
+++ b/test/Feature/Optimize.c
@@ -18,6 +18,6 @@ int main() {
   } else {
     printf("bad\n");
   }
-  
+
   return 0;
 }

--- a/test/Feature/ReplayPath.c
+++ b/test/Feature/ReplayPath.c
@@ -30,6 +30,6 @@ int main() {
   if (x&2) res *= 7;
   if (!(x&2)) res *= 11;
   printf("res: %d\n", res);
- 
+
   return 0;
 }

--- a/test/Feature/Searchers.c
+++ b/test/Feature/Searchers.c
@@ -42,7 +42,7 @@ int validate(char *buf, int N) {
       return 0;
     }
   }
-  
+
   return 1;
 }
 
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
   int N = SYMBOLIC_SIZE;
   unsigned char *buf = malloc(N);
   int i;
-  
+
   klee_make_symbolic(buf, N, "buf");
   if (validate(buf, N))
     return buf[0];

--- a/test/Feature/SetForking.c
+++ b/test/Feature/SetForking.c
@@ -10,7 +10,7 @@
 
 int main() {
   klee_set_forking(0);
-  
+
   if (klee_range(0, 2, "range")) {
     printf("A\n");
   } else {

--- a/test/Feature/SolverTimeout.c
+++ b/test/Feature/SolverTimeout.c
@@ -14,6 +14,6 @@ int main() {
   if (x*x*x*x*x*x*x*x*x*x*x*x*x*x*x*x + (x*x % (x+12)) == y*y*y*y*y*y*y*y*y*y*y*y*y*y*y*y % i)
     printf("Yes\n");
   else printf("No\n");
-  
+
   return 0;
 }

--- a/test/Feature/VarArgLongDouble.c
+++ b/test/Feature/VarArgLongDouble.c
@@ -29,7 +29,7 @@ int main() {
 
   // AMD64-ABI 3.5.7p5: Step 7. Align l->overflow_arg_area upwards to a 16
   // byte boundary if alignment needed by type exceeds 8 byte boundary.
-  // 
+  //
   // the long double dub requires 16 byte alignment.
   // we try passing one,zero and one, one, zero
   // at least on those will align dub such that it needs the extra alignment

--- a/test/Feature/Vararg.c
+++ b/test/Feature/Vararg.c
@@ -29,7 +29,7 @@ void test1(int x, ...) {
 int sum(int N, ...) {
   int i, res = 0;
   va_list ap,ap2;
-  
+
   va_start(ap, N);
   for (i=0; i<N; i++) {
     if (i==1)
@@ -52,7 +52,7 @@ int va_array(int N, ...) {
 
   for (i=0; i<2; i++)
     va_start(aps[i], N);
-  
+
   for (i=0; i<N; i++) {
     unsigned cmd = va_arg(aps[0], int);
 

--- a/test/Feature/WithLibc.c
+++ b/test/Feature/WithLibc.c
@@ -18,6 +18,6 @@ int main() {
       printf("bad\n");
     }
   }
-  
+
   return 0;
 }

--- a/test/Feature/consecutive_divide_by_zero.c
+++ b/test/Feature/consecutive_divide_by_zero.c
@@ -5,7 +5,7 @@
 
 /* This test case captures a bug where two distinct division
 *  by zero errors are treated as the same error and so
-*  only one test case is generated EVEN IF THERE ARE MULTIPLE 
+*  only one test case is generated EVEN IF THERE ARE MULTIPLE
 *  DISTINCT ERRORS!
 */
 int main() {

--- a/test/Feature/const_array_opt1.c
+++ b/test/Feature/const_array_opt1.c
@@ -11,7 +11,7 @@
 #include <unistd.h>
 #include <assert.h>
 #include <stdio.h>
-  
+
 int main() {
 #define N 8192
 #define N_IDX 16
@@ -20,9 +20,9 @@ int main() {
 
   for (i=0; i<N; i++)
     a[i] = i % 256;
-  
+
   klee_make_symbolic(k, sizeof(k), "k");
-  
+
   for (i=0; i<N_IDX; i++) {
     if (k[i] >= N)
       klee_silent_exit(0);

--- a/test/Feature/utils.h
+++ b/test/Feature/utils.h
@@ -7,7 +7,7 @@ uint32_t util_make_and_i1(uint32_t a, uint32_t b);
 uint32_t util_make_or_i1(uint32_t a, uint32_t b);
 
 uint16_t util_make_concat2(uint8_t a, uint8_t b);
-uint32_t util_make_concat4(uint8_t a, uint8_t b, 
+uint32_t util_make_concat4(uint8_t a, uint8_t b,
                            uint8_t c, uint8_t d);
 uint64_t util_make_concat8(uint8_t a, uint8_t b,
                            uint8_t c, uint8_t d,

--- a/test/Merging/state_termination.c
+++ b/test/Merging/state_termination.c
@@ -1,6 +1,6 @@
 // RUN: %clang -emit-llvm -g -c -o %t.bc %s
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs  %t.bc 
+// RUN: %klee --output-dir=%t.klee-out --use-merge --debug-log-merge --search=dfs  %t.bc
 
 #include "klee/klee.h"
 

--- a/test/Programs/pcregrep.c
+++ b/test/Programs/pcregrep.c
@@ -79,7 +79,7 @@ extern void *__builtin_alloca(unsigned int);
 #define LLVM_ASM(X)
 #endif
 
-#if __GNUC__ < 4 /* Old GCC's, or compilers not GCC */ 
+#if __GNUC__ < 4 /* Old GCC's, or compilers not GCC */
 #define __builtin_stack_save() 0   /* not implemented */
 #define __builtin_stack_restore(X) /* noop */
 #endif

--- a/test/Runtime/POSIX/DirConsistency.c
+++ b/test/Runtime/POSIX/DirConsistency.c
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
       foundA = 1;
     count++;
   }
-  
+
   closedir(d);
 
   //printf("found A: %d\n", foundA);

--- a/test/Runtime/POSIX/Envp.c
+++ b/test/Runtime/POSIX/Envp.c
@@ -22,6 +22,6 @@ int main(int argcPtr, char **argvPtr, char** envp) {
   }
   printf("home2 = %s\n", home2);
   assert(strcmp(home1, home2) == 0);
-  
+
   return 0;
 }

--- a/test/Runtime/POSIX/FDNumbers.c
+++ b/test/Runtime/POSIX/FDNumbers.c
@@ -13,13 +13,13 @@ int main(int argc, char **argv) {
   assert(!close(1));
   assert(close(0) == -1);
   assert(close(1) == -1);
-  assert(open("A", O_TRUNC) == 0);  
+  assert(open("A", O_TRUNC) == 0);
   assert(dup(0) == 1);
   assert(open("A", O_TRUNC) == 4);
   assert(!close(1));
   assert(open("A", O_TRUNC) == 1);
   assert(dup(0) != 1);
   assert(dup2(0,1) == 1);
-  
+
   return 0;
 }

--- a/test/Runtime/POSIX/FD_Fail.c
+++ b/test/Runtime/POSIX/FD_Fail.c
@@ -6,18 +6,18 @@
 #include <assert.h>
 
 int main(int argc, char** argv) {
-  char buf[1024];  
+  char buf[1024];
   FILE* f = fopen("/etc/mtab", "r");
   assert(f);
-    
+
   int r = fread(buf, 1, 100, f);
-  printf("fread(): %s\n", 
+  printf("fread(): %s\n",
          r ? "ok" : "fail");
   // CHECK-DAG: fread(): ok
   // CHECK-DAG: fread(): fail
 
   r = fclose(f);
-  printf("fclose(): %s\n", 
+  printf("fclose(): %s\n",
          r ? "ok" : "fail");
   // CHECK-DAG: fclose(): ok
   // CHECK-DAG: fclose(): fail

--- a/test/Runtime/POSIX/FilePerm.c
+++ b/test/Runtime/POSIX/FilePerm.c
@@ -1,11 +1,11 @@
 // RUN: %clang %s -emit-llvm %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --posix-runtime %t.bc --sym-files 1 10 --sym-stdout 2>%t.log 
+// RUN: %klee --output-dir=%t.klee-out --posix-runtime %t.bc --sym-files 1 10 --sym-stdout 2>%t.log
 // RUN: test -f %t.klee-out/test000001.ktest
 // RUN: test -f %t.klee-out/test000002.ktest
 // RUN: test -f %t.klee-out/test000003.ktest
 
-#include <stdio.h>       
+#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/test/Runtime/POSIX/FileTime.c
+++ b/test/Runtime/POSIX/FileTime.c
@@ -42,6 +42,6 @@ int main(int argc, char** argv) {
 
   assert(sb.st_atim.tv_sec >= now.tv_sec && sb.st_atim.tv_sec <= someTimeAfter.tv_sec);
   assert(sb.st_mtim.tv_sec >= now.tv_sec && sb.st_mtim.tv_sec <= someTimeAfter.tv_sec);
-  
+
   return 0;
 }

--- a/test/Runtime/POSIX/Read1.c
+++ b/test/Runtime/POSIX/Read1.c
@@ -15,14 +15,14 @@ int main(int argc, char** argv) {
   // If count is zero, read() returns zero and has  no  other  results. (man page)
   int x = read(0, 0, 0);
   assert(x == 0);
-  
+
   int fd = open("A", O_RDONLY);
   assert(fd != -1);
 
   // EFAULT buf is outside your accessible address space. (man page)
   x = read(fd, 0, 1);
   assert(x == -1 && errno == EFAULT);
- 
+
   // EBADF  fd is not a valid file descriptor (man page)
   x = read(-1, buf, 1);
   assert(x == -1 && errno == EBADF);
@@ -30,6 +30,6 @@ int main(int argc, char** argv) {
   fd = open("A", O_RDONLY);
   assert(fd != -1);
   x = read(fd, buf, 1);
-  assert(x == 1);  
+  assert(x == 1);
 }
 

--- a/test/Runtime/POSIX/Replay.c
+++ b/test/Runtime/POSIX/Replay.c
@@ -24,13 +24,13 @@
 int main(int argc, char** argv) {
   int fd, n;
   char buf[1024];
-  
+
   fd = open("A", O_RDONLY);
   assert(fd != -1);
   n = read(fd, buf, 3);
   assert(n == 3);
 
-  /* Generate a single test, with the first three chars 
+  /* Generate a single test, with the first three chars
      in the file 'abc' */
   if (buf[0] == 'a' && buf[1] == 'b' && buf[2] == 'c')
     printf("Yes\n");
@@ -40,4 +40,4 @@ int main(int argc, char** argv) {
   return 0;
 }
 
-    
+

--- a/test/Runtime/POSIX/SELinux/SELinux.c
+++ b/test/Runtime/POSIX/SELinux/SELinux.c
@@ -16,11 +16,11 @@ int main(int argc, char** argv) {
 
   int selinux = is_selinux_enabled();
   printf("selinux enabled = %d\n", selinux);
-  
+
   if (setfscreatecon(argv[1]) < 0)
     printf("Error: set\n");
   else printf("Success: set\n");
-  
+
   if (getfscreatecon(&con) < 0)
     printf("Error: get\n");
   else printf("Success: get\n");

--- a/test/Runtime/POSIX/SeedAndFail.c
+++ b/test/Runtime/POSIX/SeedAndFail.c
@@ -15,7 +15,7 @@
 
 int main(int argc, char** argv) {
   char buf[32];
-  
+
   int fd = open("A", O_RDWR | O_CREAT, S_IRWXU);
   assert(fd != -1);
   int nbytes = write(fd, "Hello", sizeof("Hello"));
@@ -26,7 +26,7 @@ int main(int argc, char** argv) {
 
   nbytes = read(fd, buf, sizeof("Hello"));
   assert(nbytes == sizeof("Hello"));
-  
+
   int r = close(fd);
   assert(r == 0);
 

--- a/test/Runtime/POSIX/Stdin.c
+++ b/test/Runtime/POSIX/Stdin.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
     char buf[10];
     int n = read(0, buf, 5);
     assert(n == 4);
-    
+
     if (strcmp(buf, "HI!")) {
       printf("read:sym:yes\n");
     } else {

--- a/test/Runtime/POSIX/Write1.c
+++ b/test/Runtime/POSIX/Write1.c
@@ -7,13 +7,13 @@
 
 int main(int argc, char** argv) {
   char buf[32];
-  
+
   FILE* f = fopen("A", "w");
   if (!f)
     klee_silent_exit(0);
   fwrite("Hello", sizeof("Hello"), 1, f);
   fclose(f);
-  
+
   f = fopen("A", "r");
   fread(buf, sizeof("Hello"), 1, f);
   fclose(f);

--- a/test/Runtime/POSIX/Write2.c
+++ b/test/Runtime/POSIX/Write2.c
@@ -9,7 +9,7 @@ int main(int argc, char** argv) {
   const char* msg = "This will eventually overflow stdout. ";
   char buf[32];
   int i;
-  
+
   FILE* f = stdout;//fopen("A", "w");
   if (!f)
     klee_silent_exit(0);

--- a/test/Runtime/Uclibc/2007-10-08-optimization-calls-wrong-libc-functions.c
+++ b/test/Runtime/Uclibc/2007-10-08-optimization-calls-wrong-libc-functions.c
@@ -17,6 +17,6 @@ int main() {
   if (a) {
     assert(0);
   }
-  
+
   return 0;
 }

--- a/test/regression/2007-08-01-cache-unclear-on-overwrite-flushed.c
+++ b/test/regression/2007-08-01-cache-unclear-on-overwrite-flushed.c
@@ -5,7 +5,7 @@
 #include <assert.h>
 #include <stdio.h>
 
-int main() {  
+int main() {
   unsigned char x;
 
   klee_make_symbolic(&x, sizeof x, "x");

--- a/test/regression/2007-08-06-64bit-shift.c
+++ b/test/regression/2007-08-06-64bit-shift.c
@@ -6,7 +6,7 @@
 
 int main() {
   int d;
-  
+
   klee_make_symbolic(&d, sizeof(d), "d");
 
   int l = d - 1;

--- a/test/regression/2007-08-06-access-after-free.c
+++ b/test/regression/2007-08-06-access-after-free.c
@@ -20,10 +20,10 @@ int main() {
     // pulling the state from the parent, where
     // it is not free
     assert(p[0] > 10);
-   
+
     return 0;
   }
-  
+
   assert(p[0] > 10);
 
   return 0;

--- a/test/regression/2007-08-16-valid-write-to-freed-object.c
+++ b/test/regression/2007-08-16-valid-write-to-freed-object.c
@@ -18,7 +18,7 @@ int main() {
   //
   // to support this we need to have a facility for making
   // state local copies of a freed object.
-  if (sym() == 0) 
+  if (sym() == 0)
     printf("ok\n");
 
   return 0;

--- a/test/regression/2007-10-12-failed-make-symbolic-after-copy.c
+++ b/test/regression/2007-10-12-failed-make-symbolic-after-copy.c
@@ -8,7 +8,7 @@ int main() {
 
   klee_make_symbolic(&x, sizeof x, "x");
   if (x>=4) klee_silent_exit(0);
-  
+
   y[x] = 0;
 
   if (x) { // force branch so y is copied

--- a/test/regression/2015-08-05-invalid-fork.c
+++ b/test/regression/2015-08-05-invalid-fork.c
@@ -1,6 +1,6 @@
-/* Reported by @kren1 in #262 
-   The test makes sure that the string "Should be printed once" 
-   is printed a single time. 
+/* Reported by @kren1 in #262
+   The test makes sure that the string "Should be printed once"
+   is printed a single time.
 */
 #include "klee/klee.h"
 

--- a/test/regression/2016-04-14-sdiv-2.c
+++ b/test/regression/2016-04-14-sdiv-2.c
@@ -21,6 +21,6 @@ int main(void)
 
   if (m/2 == 2)
     printf("m is 2\n");
-  
+
   return 0;
-} 
+}

--- a/test/regression/2016-06-28-div-zero-bug.c
+++ b/test/regression/2016-06-28-div-zero-bug.c
@@ -10,8 +10,8 @@ int b, a, g;
 
 int *c = &b, *d = &b, *f = &a;
 
-int safe_div(short p1, int p2) { 
-  return p2 == 0 ? p1 : p2; 
+int safe_div(short p1, int p2) {
+  return p2 == 0 ? p1 : p2;
 }
 
 int main() {

--- a/tools/kleaver/main.cpp
+++ b/tools/kleaver/main.cpp
@@ -131,8 +131,8 @@ static std::string escapedString(const char *start, unsigned length) {
     } else if (c == '\n') {
       s << "\\n";
     } else {
-      s << "\\x" 
-        << hexdigit(((unsigned char) c >> 4) & 0xF) 
+      s << "\\x"
+        << hexdigit(((unsigned char) c >> 4) & 0xF)
         << hexdigit((unsigned char) c & 0xF);
     }
   }
@@ -197,7 +197,7 @@ static bool EvaluateInputAST(const char *Filename,
   if (unsigned N = P->GetNumErrors()) {
     llvm::errs() << Filename << ": parse failure: " << N << " errors.\n";
     success = false;
-  }  
+  }
 
   if (!success)
     return false;
@@ -236,14 +236,14 @@ static bool EvaluateInputAST(const char *Filename,
                     << ")";
         }
       } else if (!QC->Values.empty()) {
-        assert(QC->Objects.empty() && 
+        assert(QC->Objects.empty() &&
                "FIXME: Support counterexamples for values and objects!");
         assert(QC->Values.size() == 1 &&
                "FIXME: Support counterexamples for multiple values!");
         assert(QC->Query->isFalse() &&
                "FIXME: Support counterexamples with non-trivial query!");
         ref<ConstantExpr> result;
-        if (S->getValue(Query(ConstraintManager(QC->Constraints), 
+        if (S->getValue(Query(ConstraintManager(QC->Constraints),
                               QC->Values[0]),
                         result)) {
           llvm::outs() << "INVALID\n";
@@ -255,8 +255,8 @@ static bool EvaluateInputAST(const char *Filename,
         }
       } else {
         std::vector< std::vector<unsigned char> > result;
-        
-        if (S->getInitialValues(Query(ConstraintManager(QC->Constraints), 
+
+        if (S->getInitialValues(Query(ConstraintManager(QC->Constraints),
                                       QC->Query),
                                 QC->Objects, result)) {
           llvm::outs() << "INVALID\n";
@@ -280,7 +280,7 @@ static bool EvaluateInputAST(const char *Filename,
             llvm::outs() << " FAIL (reason: "
                       << SolverImpl::getOperationStatusString(retCode)
                       << ")";
-          }           
+          }
           else {
             llvm::outs() << "VALID (counterexample request ignored)";
           }
@@ -303,13 +303,13 @@ static bool EvaluateInputAST(const char *Filename,
     llvm::outs()
       << "--\n"
       << "total queries = " << queries << "\n"
-      << "total queries constructs = " 
+      << "total queries constructs = "
       << *theStatisticManager->getStatisticByName("QueriesConstructs") << "\n"
-      << "valid queries = " 
+      << "valid queries = "
       << *theStatisticManager->getStatisticByName("QueriesValid") << "\n"
-      << "invalid queries = " 
+      << "invalid queries = "
       << *theStatisticManager->getStatisticByName("QueriesInvalid") << "\n"
-      << "query cex = " 
+      << "query cex = "
       << *theStatisticManager->getStatisticByName("QueriesCEX") << "\n";
   }
 
@@ -402,7 +402,7 @@ int main(int argc, char **argv) {
   llvm::cl::ParseCommandLineOptions(argc, argv);
 
   std::string ErrorStr;
-  
+
   auto MBResult = MemoryBuffer::getFileOrSTDIN(InputFile.c_str());
   if (!MBResult) {
     llvm::errs() << argv[0] << ": error: " << MBResult.getError().message()
@@ -410,7 +410,7 @@ int main(int argc, char **argv) {
     return 1;
   }
   std::unique_ptr<MemoryBuffer> &MB = *MBResult;
-  
+
   ExprBuilder *Builder = 0;
   switch (BuilderKind) {
   case DefaultBuilder:

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -137,7 +137,7 @@ namespace {
   RunInDir("run-in-dir",
            cl::desc("Change to the given directory before starting execution (default=location of tested file)."),
            cl::cat(StartCat));
-  
+
   cl::opt<std::string>
   OutputDir("output-dir",
             cl::desc("Directory in which to write results (default=klee-out-<N>)"),
@@ -159,7 +159,7 @@ namespace {
   WarnAllExternals("warn-all-external-symbols",
                    cl::desc("Issue a warning on startup for all external symbols (default=false)."),
                    cl::cat(StartCat));
-  
+
 
   /*** Linking options ***/
 
@@ -224,10 +224,10 @@ namespace {
 
 
   /*** Replaying options ***/
-  
+
   cl::OptionCategory ReplayCat("Replaying options",
                                "These options impact replaying of test cases.");
-  
+
   cl::opt<bool>
   ReplayKeepSymbolic("replay-keep-symbolic",
                      cl::desc("Replay the test cases only by asserting "

--- a/unittests/Expr/ExprTest.cpp
+++ b/unittests/Expr/ExprTest.cpp
@@ -55,7 +55,7 @@ TEST(ExprTest, ConcatExtract) {
   EXPECT_EQ( Expr::Concat, extract2->getKid(1)->getKid(1)->getKind());
   EXPECT_EQ( c100, extract2->getKid(1)->getKid(1)->getKid(0));
   EXPECT_EQ( Expr::Extract, extract2->getKid(1)->getKid(1)->getKid(1)->getKind());
-  
+
   ref<Expr> extract3 = ExtractExpr::create(concat1, 24, 1);
   EXPECT_EQ(Expr::Extract, extract3->getKind());
 
@@ -77,7 +77,7 @@ TEST(ExprTest, ConcatExtract) {
   EXPECT_EQ(c100, extract6->getKid(1)->getKid(1)->getKid(0));
   EXPECT_EQ(Expr::Extract, extract6->getKid(1)->getKid(1)->getKid(1)->getKind());
 
-  ref<Expr> concat10 = ConcatExpr::create4(read8, c100, c100, read8);    
+  ref<Expr> concat10 = ConcatExpr::create4(read8, c100, c100, read8);
   ref<Expr> extract10 = ExtractExpr::create(concat10, 8, 16);
   EXPECT_EQ(Expr::Constant, extract10->getKind());
 }
@@ -89,23 +89,23 @@ TEST(ExprTest, ExtractConcat) {
 
   const Array *array2 = ac.CreateArray("arr3", 256);
   ref<Expr> read8_2 = Expr::createTempRead(array2, 8);
-  
+
   ref<Expr> extract1 = ExtractExpr::create(read64, 36, 4);
   ref<Expr> extract2 = ExtractExpr::create(read64, 32, 4);
-  
+
   ref<Expr> extract3 = ExtractExpr::create(read64, 12, 3);
   ref<Expr> extract4 = ExtractExpr::create(read64, 10, 2);
   ref<Expr> extract5 = ExtractExpr::create(read64, 2, 8);
-   
+
   ref<Expr> kids1[6] = { extract1, extract2,
 			 read8_2,
 			 extract3, extract4, extract5 };
   ref<Expr> concat1 = ConcatExpr::createN(6, kids1);
   EXPECT_EQ(29U, concat1->getWidth());
-  
+
   ref<Expr> extract6 = ExtractExpr::create(read8_2, 2, 5);
   ref<Expr> extract7 = ExtractExpr::create(read8_2, 1, 1);
-  
+
   ref<Expr> kids2[3] = { extract1, extract6, extract7 };
   ref<Expr> concat2 = ConcatExpr::createN(3, kids2);
   EXPECT_EQ(10U, concat2->getWidth());

--- a/unittests/Ref/RefTest.cpp
+++ b/unittests/Ref/RefTest.cpp
@@ -20,16 +20,16 @@ int finished = 0;
 struct Expr
 {
   int refCount;
-  Expr() : refCount(0) { 
-    //std::cout << "Expr(" << this << ") created\n"; 
+  Expr() : refCount(0) {
+    //std::cout << "Expr(" << this << ") created\n";
   }
-  ~Expr() { 
-    //std::cout << "Expr(" << this << ") destroyed\n"; 
+  ~Expr() {
+    //std::cout << "Expr(" << this << ") destroyed\n";
     EXPECT_EQ(finished, 1);
   }
 };
 
-TEST(RefTest, SelfAssign) 
+TEST(RefTest, SelfAssign)
 {
   struct Expr *r_e = new Expr();
   ref<Expr> r(r_e);

--- a/unittests/Solver/SolverTest.cpp
+++ b/unittests/Solver/SolverTest.cpp
@@ -47,7 +47,7 @@ void testOperation(Solver &solver,
                    Expr::Width operandWidth,
                    Expr::Width resultWidth) {
   std::vector<Expr::CreateArg> symbolicArgs;
-  
+
   for (unsigned i = 0; i < T::numKids; i++) {
     if (!T::isValidKidWidth(i, operandWidth))
       return;
@@ -55,13 +55,13 @@ void testOperation(Solver &solver,
     unsigned size = Expr::getMinBytesForWidth(operandWidth);
     static uint64_t id = 0;
     const Array *array = ac.CreateArray("arr" + llvm::utostr(++id), size);
-    symbolicArgs.push_back(Expr::CreateArg(Expr::createTempRead(array, 
+    symbolicArgs.push_back(Expr::CreateArg(Expr::createTempRead(array,
                                                                 operandWidth)));
   }
-  
+
   if (T::needsResultType())
     symbolicArgs.push_back(Expr::CreateArg(resultWidth));
-  
+
   ref<Expr> fullySymbolicExpr = Expr::createFromKind(T::kind, symbolicArgs);
 
   // For each kid, replace the kid with a constant value and verify
@@ -71,16 +71,16 @@ void testOperation(Solver &solver,
     std::vector<Expr::CreateArg> partiallyConstantArgs(symbolicArgs);
     partiallyConstantArgs[kid] = getConstant(value, operandWidth);
 
-    ref<Expr> expr = 
+    ref<Expr> expr =
       NotOptimizedExpr::create(EqExpr::create(partiallyConstantArgs[kid].expr,
                                               symbolicArgs[kid].expr));
-    
+
     ref<Expr> partiallyConstantExpr =
       Expr::createFromKind(T::kind, partiallyConstantArgs);
-    
-    ref<Expr> queryExpr = EqExpr::create(fullySymbolicExpr, 
+
+    ref<Expr> queryExpr = EqExpr::create(fullySymbolicExpr,
                                          partiallyConstantExpr);
-    
+
     ConstraintManager constraints;
     constraints.addConstraint(expr);
     bool res;
@@ -88,18 +88,18 @@ void testOperation(Solver &solver,
     EXPECT_EQ(true, success) << "Constraint solving failed";
 
     if (success) {
-      EXPECT_EQ(true, res) << "Evaluation failed!\n" 
-                           << "query " << queryExpr 
+      EXPECT_EQ(true, res) << "Evaluation failed!\n"
+                           << "query " << queryExpr
                            << " with " << expr;
     }
   }
 }
 
 template<class T>
-void testOpcode(Solver &solver, bool tryBool = true, bool tryZero = true, 
+void testOpcode(Solver &solver, bool tryBool = true, bool tryZero = true,
                 unsigned maxWidth = 64) {
   for (unsigned j=0; j<sizeof(g_types)/sizeof(g_types[0]); j++) {
-    Expr::Width type = g_types[j]; 
+    Expr::Width type = g_types[j];
 
     if (type > maxWidth) continue;
 
@@ -115,14 +115,14 @@ void testOpcode(Solver &solver, bool tryBool = true, bool tryZero = true,
 
       for (unsigned k=0; k<sizeof(g_types)/sizeof(g_types[0]); k++) {
         Expr::Width resultType = g_types[k];
-          
+
         // nasty hack to give only Trunc/ZExt/SExt the right types
         if (T::kind == Expr::SExt || T::kind == Expr::ZExt) {
-          if (Expr::getMinBytesForWidth(type) >= 
-              Expr::getMinBytesForWidth(resultType)) 
+          if (Expr::getMinBytesForWidth(type) >=
+              Expr::getMinBytesForWidth(resultType))
             continue;
         }
-            
+
         testOperation<T>(solver, value, type, resultType);
       }
     }
@@ -139,7 +139,7 @@ TEST(SolverTest, Evaluation) {
   testOpcode<SelectExpr>(*solver);
   testOpcode<ZExtExpr>(*solver);
   testOpcode<SExtExpr>(*solver);
-  
+
   testOpcode<AddExpr>(*solver);
   testOpcode<SubExpr>(*solver);
   testOpcode<MulExpr>(*solver, false, true, 8);

--- a/unittests/TreeStream/TreeStreamTest.cpp
+++ b/unittests/TreeStream/TreeStreamTest.cpp
@@ -11,7 +11,7 @@ using namespace klee;
 TEST(TreeStreamTest, Basic) {
   TreeStreamWriter tsw("tsw1.out");
   ASSERT_TRUE(tsw.good());
-  
+
   TreeOStream tos = tsw.open();
   tos.write("abc", 3);
   tos.write("defg", 4);
@@ -20,19 +20,19 @@ TEST(TreeStreamTest, Basic) {
   std::vector<unsigned char> out;
   tsw.readStream(tos.getID(), out);
   ASSERT_EQ(7u, out.size());
-  
+
   for (unsigned char c = 'a'; c <= 'g'; c++)
     ASSERT_EQ(c, out[c - 'a']);
 }
 
 
 /* This tests the case when we perform a write with a size larger than
-   the buffer size, which is a constant set to 4*4096.  This test fails 
+   the buffer size, which is a constant set to 4*4096.  This test fails
    without #704 */
 TEST(TreeStreamTest, WriteLargerThanBufferSize) {
   TreeStreamWriter tsw("tsw2.out");
   ASSERT_TRUE(tsw.good());
-  
+
   TreeOStream tos = tsw.open();
 #define NBYTES 5*4096UL
   char buf[NBYTES];


### PR DESCRIPTION
Hwn hacking on KLEE I'm constantly fighting my text editor that removes trailing whitespaces in files I edit. To make my diffs look cleaner, I have to remove this changes either by turning this feature off for a while, or trying to remember again that git flag that ignores whitespace-only changes.

I thought that making a sweeping change to fix all whitespace issues at once might be worthwhile.