### PR TITLE
Hotfix Travis-CI on osx

### DIFF
--- a/scripts/build/p-klee-osx.inc
+++ b/scripts/build/p-klee-osx.inc
@@ -4,12 +4,12 @@ install_build_dependencies_klee() {
   brew upgrade python               # upgrade to Python 3
   brew install python@2             # install Python 2 (OSX version outdated + pip missing)
   brew link --overwrite python@2    # keg-only => link manually
+  set -e
   rm -f /usr/local/bin/{python,pip} # re-link python/pip to Python 2
-  py2path=$(find /usr/local/Cellar/python@2/ -name "python" -type f | head -n 1)
+  py2path=$(find /usr/local/Cellar/python@2/ -name "python" "(" -type f -o -type l ")" | head -n 1)
   pip2path=$(find /usr/local/Cellar/python@2/ -name "pip" -type f | head -n 1)
   ln -s "${py2path}" /usr/local/bin/python
   ln -s "${pip2path}" /usr/local/bin/pip
-  set -e
   pip install lit
   pip3 install tabulate
 }


### PR DESCRIPTION
For versions of brew python@2 >= 2.7.15 the "python" program seems to no longer be a file, but a symlink instead. 

We thus adapt the `find`-call so that it also finds symlinks.

We move `set -e` further up, because a failure to create one of the symlinks also counts as an error, and was wrongly ignored before.

This fixes CI on osx, an example of the error that otherwise occurs in new python@2 versions can be seen in this CI-log: https://travis-ci.org/klee/klee/jobs/615639920#L11090-L11109

Additionally, it might make sense to remove python2 completely from osx if it is no longer required, but I wanted to prevent CI from breaking for all new/updated PRs first.