### PR TITLE
Remove python2 from osx CI

### DIFF
--- a/scripts/build/p-klee-osx.inc
+++ b/scripts/build/p-klee-osx.inc
@@ -1,15 +1,5 @@
 # Build dependencies
 install_build_dependencies_klee() {
-  set +e
   brew upgrade python               # upgrade to Python 3
-  brew install python@2             # install Python 2 (OSX version outdated + pip missing)
-  brew link --overwrite python@2    # keg-only => link manually
-  rm -f /usr/local/bin/{python,pip} # re-link python/pip to Python 2
-  py2path=$(find /usr/local/Cellar/python@2/ -name "python" -type f | head -n 1)
-  pip2path=$(find /usr/local/Cellar/python@2/ -name "pip" -type f | head -n 1)
-  ln -s "${py2path}" /usr/local/bin/python
-  ln -s "${pip2path}" /usr/local/bin/pip
-  set -e
-  pip install lit
-  pip3 install tabulate
+  pip3 install lit tabulate
 }


### PR DESCRIPTION
Python 2 should not be needed anymore, so we remove it from osx CI.

Also see #1186.