### PR TITLE
Remove tr1

### DIFF
--- a/include/klee/Expr/ArrayCache.h
+++ b/include/klee/Expr/ArrayCache.h
@@ -13,16 +13,8 @@
 #include "klee/Expr/Expr.h"
 #include "klee/Expr/ArrayExprHash.h" // For klee::ArrayHashFn
 
-// FIXME: Remove this hack when we switch to C++11
-#ifdef _LIBCPP_VERSION
-#include <unordered_set>
-#define unordered_set std::unordered_set
-#else
-#include <tr1/unordered_set>
-#define unordered_set std::tr1::unordered_set
-#endif
-
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace klee {
@@ -68,14 +60,13 @@ public:
                            Expr::Width _range = Expr::Int8);
 
 private:
-  typedef unordered_set<const Array *, klee::ArrayHashFn,
-                        klee::EquivArrayCmpFn> ArrayHashMap;
+  typedef std::unordered_set<const Array *, klee::ArrayHashFn,
+                             klee::EquivArrayCmpFn>
+      ArrayHashMap;
   ArrayHashMap cachedSymbolicArrays;
   typedef std::vector<const Array *> ArrayPtrVec;
   ArrayPtrVec concreteArrays;
 };
 }
-
-#undef unordered_set
 
 #endif /* KLEE_ARRAYCACHE_H */

--- a/include/klee/Expr/ExprHashMap.h
+++ b/include/klee/Expr/ExprHashMap.h
@@ -19,9 +19,7 @@ namespace klee {
 
   namespace util {
     struct ExprHash  {
-      unsigned operator()(const ref<Expr> e) const {
-        return e->hash();
-      }
+      unsigned operator()(const ref<Expr> &e) const { return e->hash(); }
     };
     
     struct ExprCmp {

--- a/include/klee/Expr/ExprHashMap.h
+++ b/include/klee/Expr/ExprHashMap.h
@@ -12,18 +12,8 @@
 
 #include "klee/Expr/Expr.h"
 
-#include <ciso646>
-#ifdef _LIBCPP_VERSION
 #include <unordered_map>
 #include <unordered_set>
-#define unordered_map std::unordered_map
-#define unordered_set std::unordered_set
-#else
-#include <tr1/unordered_map>
-#include <tr1/unordered_set>
-#define unordered_map std::tr1::unordered_map
-#define unordered_set std::tr1::unordered_set
-#endif
 
 namespace klee {
 
@@ -40,23 +30,15 @@ namespace klee {
       }
     };
   }
-  
-  template<class T> 
-  class ExprHashMap : 
 
-    public unordered_map<ref<Expr>,
-                         T,
-                         klee::util::ExprHash,
-                         klee::util::ExprCmp> {
-  };
-  
-  typedef unordered_set<ref<Expr>,
-                        klee::util::ExprHash,
-                        klee::util::ExprCmp> ExprHashSet;
+  template <class T>
+  class ExprHashMap
+      : public std::unordered_map<ref<Expr>, T, klee::util::ExprHash,
+                                  klee::util::ExprCmp> {};
 
-}
-
-#undef unordered_map
-#undef unordered_set
+  typedef std::unordered_set<ref<Expr>, klee::util::ExprHash,
+                             klee::util::ExprCmp>
+      ExprHashSet;
+} // namespace klee
 
 #endif /* KLEE_EXPRHASHMAP_H */

--- a/lib/Solver/CachingSolver.cpp
+++ b/lib/Solver/CachingSolver.cpp
@@ -16,14 +16,7 @@
 #include "klee/Solver/SolverImpl.h"
 #include "klee/Solver/SolverStats.h"
 
-#include <ciso646>
-#ifdef _LIBCPP_VERSION
 #include <unordered_map>
-#define unordered_map std::unordered_map
-#else
-#include <tr1/unordered_map>
-#define unordered_map std::tr1::unordered_map
-#endif
 
 using namespace klee;
 
@@ -65,10 +58,10 @@ private:
     }
   };
 
-  typedef unordered_map<CacheEntry, 
-                        IncompleteSolver::PartialValidity, 
-                        CacheEntryHash> cache_map;
-  
+  typedef std::unordered_map<CacheEntry, IncompleteSolver::PartialValidity,
+                             CacheEntryHash>
+      cache_map;
+
   Solver *solver;
   cache_map cache;
 


### PR DESCRIPTION
Remove support for old tr1 unordered set and map.

And check hashes using call-by-reference instead of call-by-value to avoid inc/dec of reference counters.