### PR TITLE
Assume assembly.ll is local to the run.istats file

### DIFF
--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -639,7 +639,7 @@ void StatsTracker::writeIStats() {
   if (UseCallPaths)
     callPathManager.getSummaryStatistics(callSiteStats);
 
-  of << "ob=" << objectFilename << "\n";
+  of << "ob=" << llvm::sys::path::filename(objectFilename).str() << "\n";
 
   for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
        fnIt != fn_ie; ++fnIt) {

--- a/test/Feature/SourceMapping.c
+++ b/test/Feature/SourceMapping.c
@@ -7,7 +7,7 @@
 // RUN: FileCheck < %t.klee-out/run.istats %s
 
 // CHECK: positions: instr line
-// CHECK: ob={{.*}}/SourceMapping.c{{.*}}/assembly.ll
+// CHECK: ob=assembly.ll
 
 // Assuming the compiler doesn't reorder things, f0 should be first, and it
 // should immediately follow the first file name marker.


### PR DESCRIPTION
Assuming a `klee-out-*` directory is moved to a different path location, subsequent analysis of the run.istats with KCachegrind focusing on assembly is impossible as the `assembly.ll` cannot be found.
The reason is that the absolute path of the object file (assembly.ll) is hard-coded as part of the generated run.istats.

To fix this, assume that the file is local to the `run.istats`.