### PR TITLE
Add support to provide a specific host address and port for grafana server

### DIFF
--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -165,7 +165,7 @@ def getRow(record, stats, pr):
     return row
 
 
-def grafana(dirs):
+def grafana(dirs, host_address, port):
     dr = getLogFile(dirs[0])
     from flask import Flask, jsonify, request
     import datetime
@@ -234,7 +234,7 @@ def grafana(dirs):
         ret = jsonify(result)
         return ret
 
-    app.run()
+    app.run(host=host_address, port=port)
     return 0
 
 def main():
@@ -255,6 +255,12 @@ def main():
     parser.add_argument('--grafana',
                           action='store_true', dest='grafana',
                           help='Start a grafana web server')
+    parser.add_argument('--grafana-host', dest='grafana_host',
+                          help='IP address grafana web server should listen to',
+                          default="127.0.0.1")
+    parser.add_argument('--grafana-port', dest='grafana_port', type=int,
+                          help='Port grafana web server should listen to',
+                          default=5000)
 
     # argument group for controlling output verboseness
     pControl = parser.add_mutually_exclusive_group(required=False)
@@ -291,7 +297,7 @@ def main():
 
     dirs = getKleeOutDirs(args.dir)
     if args.grafana:
-      return grafana(dirs)
+      return grafana(dirs, args.grafana_host, args.grafana_port)
     if len(dirs) == 0:
         print('no klee output dir found', file=sys.stderr)
         exit(1)


### PR DESCRIPTION
Allows to provide a different IP address for the flask server.

This way, one can allow a binding on all available IP addresses (i.e `--grafana-host="0.0.0.0"`).