### PR TITLE
Fixed documentation for command line argument link-llvm-lib

### DIFF
--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -185,10 +185,10 @@ namespace {
        cl::cat(LinkCat));
 
   cl::list<std::string>
-  LinkLibraries("link-llvm-lib",
-		cl::desc("Link the given library before execution. Can be used multiple times."),
-		cl::value_desc("library file"),
-                cl::cat(LinkCat));
+      LinkLibraries("link-llvm-lib",
+                    cl::desc("Link the given bitcode library before execution, "
+                             "e.g. .bca, .bc, .a. Can be used multiple times."),
+                    cl::value_desc("bitcode library file"), cl::cat(LinkCat));
 
   cl::opt<bool>
   WithPOSIXRuntime("posix-runtime",
@@ -1299,8 +1299,8 @@ int main(int argc, char **argv, char **envp) {
   for (const auto &library : LinkLibraries) {
     if (!klee::loadFile(library, mainModule->getContext(), loadedModules,
                         errorMsg))
-      klee_error("error loading free standing support '%s': %s",
-                 library.c_str(), errorMsg.c_str());
+      klee_error("error loading bitcode library '%s': %s", library.c_str(),
+                 errorMsg.c_str());
   }
 
   // FIXME: Change me to std types.


### PR DESCRIPTION
Currently, arbitrary *.bc files or archives containing .bc files (.bca or .a) can
be linked using `--link-llvm-lib`. Change documentation of command line argument to make this clear.

This feature is useful to keep avoid linking the bitcode libraries with the application as bitcode file in the first place.

Fix error message in case library could not be loaded.