### PR TITLE
Fix handling of debug information of functions

### DIFF
--- a/lib/Module/InstructionInfoTable.cpp
+++ b/lib/Module/InstructionInfoTable.cpp
@@ -81,14 +81,6 @@ buildInstructionToLineMap(const llvm::Module &m) {
   return mapping;
 }
 
-static std::string getFullPath(llvm::StringRef Directory,
-                               llvm::StringRef FileName) {
-  llvm::SmallString<128> file_pathname(Directory);
-  llvm::sys::path::append(file_pathname, FileName);
-
-  return file_pathname.str();
-}
-
 class DebugInfoExtractor {
   std::vector<std::unique_ptr<std::string>> &internedStrings;
   std::map<uintptr_t, uint64_t> lineTable;
@@ -126,7 +118,7 @@ public:
     auto dsub = llvm::getDISubprogram(&Func);
 #endif
     if (dsub != nullptr) {
-      auto path = getFullPath(dsub->getDirectory(), dsub->getFilename());
+      auto path = dsub->getFilename();
       return std::unique_ptr<FunctionInfo>(new FunctionInfo(
           0, getInternedString(path), dsub->getLine(), asmLine));
     }

--- a/test/Feature/SourceMapping.c
+++ b/test/Feature/SourceMapping.c
@@ -11,7 +11,7 @@
 
 // Assuming the compiler doesn't reorder things, f0 should be first, and it
 // should immediately follow the first file name marker.
-// CHECK: fl={{.*}}/SourceMapping.c
+// CHECK: fl={{.*}}test/Feature/SourceMapping.c
 // CHECK-NEXT: fn=f0
 
 // Ensure we have a known position for the first instruction (instr and line
@@ -35,6 +35,8 @@ int f1(int a, int b) {
 // This check just brackets the checks above, to make sure they fall in the
 // appropriate region of the run.istats file.
 //
+// Explicitly check that there is no duplication of the path
+// CHECK-NOT: fl={{.*}}/test/Feature/{{.*}}/test/Feature/SourceMapping.c
 // CHECK: fn=main
 int main() {
   int x = f1(1, 2);


### PR DESCRIPTION
Fix tracking of filenames where functions are defined.

Extend test case to avoid duplicate file path elements.