### PR TITLE
Fix InterleavedSearcher::empty and InterleavedSearcher::selectState only checking the first searcher

### DIFF
--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -457,8 +457,12 @@ InterleavedSearcher::~InterleavedSearcher() {
 }
 
 ExecutionState &InterleavedSearcher::selectState() {
-  Searcher *s = searchers[--index];
-  if (index==0) index = searchers.size();
+  assert(!empty());
+  Searcher *s;
+  do {
+    s = searchers[--index];
+    if (index==0) index = searchers.size();
+  } while(s->empty());
   return s->selectState();
 }
 

--- a/lib/Core/Searcher.h
+++ b/lib/Core/Searcher.h
@@ -314,7 +314,13 @@ namespace klee {
     void update(ExecutionState *current,
                 const std::vector<ExecutionState *> &addedStates,
                 const std::vector<ExecutionState *> &removedStates);
-    bool empty() { return searchers[0]->empty(); }
+    bool empty() {
+      for (searchers_ty::iterator it = searchers.begin(), ie = searchers.end();
+           it != ie; ++it)
+        if(!(*it)->empty())
+          return false;
+      return true;
+    }
     void printName(llvm::raw_ostream &os) {
       os << "<InterleavedSearcher> containing "
          << searchers.size() << " searchers:\n";


### PR DESCRIPTION
`InterleavedSearcher::empty()` now properly checks all searchers, and `InterleavedSearcher::selectState` falls back on the next ones.

The `assert(!empty());` in `InterleavedSearcher::selectState` is there to prevent an infinite loop.