### PR TITLE
add LLVM 10.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     ###########################################################################
 
     # Check a subset of the matrix of:
-    #   LLVM  : {3.8, 3.9, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}
+    #   LLVM  : {3.8, 3.9, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0}
     #   SOLVERS : {Z3, STP, STP:Z3, metaSMT}
     #   STP_VERSION   : {2.3.3, master}
     #   METASMT_VERSION : {v4.rc1}
@@ -56,6 +56,7 @@ env:
 
     matrix:
     # Check supported LLVM versions
+    - LLVM_VERSION=10.0
     - LLVM_VERSION=9.0
     - LLVM_VERSION=8.0
     - LLVM_VERSION=7.0

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -155,7 +155,7 @@ config.substitutions.append(
 
 # Add feature for the LLVM version in use, so it can be tested in REQUIRES and
 # XFAIL checks. We also add "not-XXX" variants, for the same reason.
-known_llvm_versions = set(["3.8", "3.9", "4.0", "5.0", "6.0", "7.0", "7.1", "8.0", "9.0"])
+known_llvm_versions = set(["3.8", "3.9", "4.0", "5.0", "6.0", "7.0", "7.1", "8.0", "9.0", "10.0"])
 current_llvm_version = "%s.%s" % (config.llvm_version_major,
                                   config.llvm_version_minor)
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -156,8 +156,8 @@ config.substitutions.append(
 # Add feature for the LLVM version in use, so it can be tested in REQUIRES and
 # XFAIL checks. We also add "not-XXX" variants, for the same reason.
 known_llvm_versions = set(["3.8", "3.9", "4.0", "5.0", "6.0", "7.0", "7.1", "8.0", "9.0", "10.0"])
-current_llvm_version = "%s.%s" % (config.llvm_version_major,
-                                  config.llvm_version_minor)
+current_llvm_version_tuple = (int(config.llvm_version_major), int(config.llvm_version_minor))
+current_llvm_version = "%s.%s" % current_llvm_version_tuple
 
 if current_llvm_version not in known_llvm_versions:
   lit_config.fatal("LLVM Version %s is not listed in known_llvm_versions!"
@@ -165,9 +165,10 @@ if current_llvm_version not in known_llvm_versions:
 
 config.available_features.add("llvm-" + current_llvm_version)
 for version in known_llvm_versions:
+  version_tuple = tuple(int(v) for v in version.split("."))
   if version != current_llvm_version:
     config.available_features.add("not-llvm-" + version)
-  if current_llvm_version >= version:
+  if current_llvm_version_tuple >= version_tuple:
     config.available_features.add("geq-llvm-" + version)
   else:
     config.available_features.add("lt-llvm-" + version)


### PR DESCRIPTION
WIP as LLVM 10 has not been released yet.
So far, these changes are enough to pass KLEE's systemtests.

However, this PR requires a docker image for LLVM 10 so TravisCI will pass.