### PR TITLE
Fix KLEE bug when using uclibc and module contains a custom ctor/dtor

### DIFF
--- a/include/klee/Interpreter.h
+++ b/include/klee/Interpreter.h
@@ -54,14 +54,18 @@ public:
   struct ModuleOptions {
     std::string LibraryDir;
     std::string EntryPoint;
+    std::string LibcMainFunction;
     bool Optimize;
     bool CheckDivZero;
     bool CheckOvershift;
 
     ModuleOptions(const std::string &_LibraryDir,
-                  const std::string &_EntryPoint, bool _Optimize,
+                  const std::string &_EntryPoint, 
+                  const std::string &_LibcMainFunction,
+                  bool _Optimize,
                   bool _CheckDivZero, bool _CheckOvershift)
-        : LibraryDir(_LibraryDir), EntryPoint(_EntryPoint), Optimize(_Optimize),
+        : LibraryDir(_LibraryDir), EntryPoint(_EntryPoint), 
+          LibcMainFunction(_LibcMainFunction), Optimize(_Optimize),
           CheckDivZero(_CheckDivZero), CheckOvershift(_CheckOvershift) {}
   };
 

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -200,14 +200,13 @@ injectStaticConstructorsAndDestructors(Module *m,
 }
 
 /**
- * UCLIBC's main (and libc mains in general) take an app_init and app_fini
- * argument to do all of the static construction/destruction. So, rather
- * than shoving the calls to the constructors and the beginning of main, 
- * we can just update the arguments to the __uclibc_main call to point to the 
- * ctor/dtor stubs.
+ * libc main functions take an app_init and app_fini argument to do all of the
+ * static construction/destruction. So, rather than shoving the calls to the
+ * constructors and the beginning of main, we can just update the arguments to
+ * the __libc_main call to point to the ctor/dtor stubs.
  */
 static void
-fillUclibcMainInitAndFiniArgs(Module *m, llvm::StringRef entryFunction, 
+fillLibcMainInitAndFiniArgs(Module *m, llvm::StringRef entryFunction, 
                               llvm::StringRef libcMainFunction) {
   GlobalVariable *ctors = m->getNamedGlobal("llvm.global_ctors");
   GlobalVariable *dtors = m->getNamedGlobal("llvm.global_dtors");
@@ -331,7 +330,7 @@ void KModule::optimiseAndPrepare(
   if (opts.LibcMainFunction.empty()) {
     injectStaticConstructorsAndDestructors(module.get(), opts.EntryPoint);
   } else {
-    fillUclibcMainInitAndFiniArgs(module.get(), opts.EntryPoint, opts.LibcMainFunction);
+    fillLibcMainInitAndFiniArgs(module.get(), opts.EntryPoint, opts.LibcMainFunction);
   }
   
 

--- a/test/regression/2020-02-12-ctor-bug.c
+++ b/test/regression/2020-02-12-ctor-bug.c
@@ -1,0 +1,18 @@
+// RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
+// RUN: %clang %s -o %t
+// RUN: env TEST_ENV_VAR=foo %t > %S/correct.log
+// RUN: echo -e "TEST_ENV_VAR=foo\n" > %S/test.env
+// RUN: %klee --libc=uclibc --posix-runtime --env-file=%S/test.env %t.bc > %S/test.log
+// RUN: diff %S/correct.log %S/test.log
+#include <stdio.h>
+#include <stdlib.h>
+
+#define ENV_VAR "TEST_ENV_VAR"
+
+void __attribute__((constructor)) ctor(void) {
+    printf("%s=%s\n", ENV_VAR, getenv(ENV_VAR));
+}
+
+int main(int argc, const char *argv[]) {
+    return 0;
+}

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1239,7 +1239,9 @@ int main(int argc, char **argv, char **envp) {
   loadedModules.emplace_back(std::move(M));
 
   std::string LibraryDir = KleeHandler::getRunTimeLibraryPath(argv[0]);
+  std::string LibcMainFunction = Libc == LibcType::UcLibc ? "__uClibc_main" : "";
   Interpreter::ModuleOptions Opts(LibraryDir.c_str(), EntryPoint,
+                                  /*LibcMainFunction=*/LibcMainFunction,
                                   /*Optimize=*/OptimizeModule,
                                   /*CheckDivZero=*/CheckDivZero,
                                   /*CheckOvershift=*/CheckOvershift);


### PR DESCRIPTION
When linking with a user library, the ctor/dtor stubs are inserted at the beginning of the entry function. This is fine when not linking with uclibc, but if you are, you should use the built-in mechanism the uclibc_main function has for calling application inits/finis (as described here: https://refspecs.linuxbase.org/LSB_3.1.0/LSB-generic/LSB-generic/baselib---libc-start-main-.html)

If this is not performed, this leads to bugs where the application tries to use some libc functionality (i.e., expecting environment variables to be accessible using `getenv()`).

## Reproduction

Compile and run `constructor_test.c`:
```c
#include <stdio.h>
#include <stdlib.h>

#define ENV_VAR "TEST_ENV_VAR"

void __attribute__((constructor)) ctor(void) {
    printf("%s=%s\n", ENV_VAR, getenv(ENV_VAR));
}

int main(int argc, const char *argv[]) {
    return 0;
}
```

### On Linux (correct behavior):
```sh
$ TEST_ENV_VAR=foo ./constructor_test 
```
Outputs:
```sh
TEST_ENV_VAR=foo
```

### On KLEE (buggy behavior):
Given `test.env`
```
TEST_ENV_VAR=foo
```

```sh
$ ./klee --libc=uclibc --posix-runtime --env-file=test.env constructor_test.bc
```

Outputs:
```sh
TEST_ENV_VAR=(null)
```

After applying the patch, KLEE demonstrates the same behavior as running on Linux (i.e., outputs `TEST_ENV_VAR=foo`).