### PR TITLE
Fix GlobalAlias Initialization

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -750,23 +750,46 @@ void Executor::allocateGlobalObjects(ExecutionState &state) {
   }
 }
 
+void Executor::initializeGlobalAlias(const llvm::Constant *c) {
+  // aliasee may either be a global value or constant expression
+  const auto *ga = dyn_cast<GlobalAlias>(c);
+  if (ga) {
+    if (globalAddresses.count(ga)) {
+      // already resolved by previous invocation
+      return;
+    }
+    const llvm::Constant *aliasee = ga->getAliasee();
+    if (const auto *gv = dyn_cast<GlobalValue>(aliasee)) {
+      // aliasee is global value
+      auto it = globalAddresses.find(gv);
+      // uninitialized only if aliasee is another global alias
+      if (it != globalAddresses.end()) {
+        globalAddresses.emplace(ga, it->second);
+        return;
+      }
+    }
+  }
+
+  // resolve aliases in all sub-expressions
+#if LLVM_VERSION_CODE >= LLVM_VERSION(4, 0)
+  for (const auto *op : c->operand_values()) {
+#else
+  for (auto &it : c->operands()) {
+    const auto *op = &*it;
+#endif
+    initializeGlobalAlias(cast<Constant>(op));
+  }
+
+  if (ga) {
+    // aliasee is constant expression (or global alias)
+    globalAddresses.emplace(ga, evalConstant(ga->getAliasee()));
+  }
+}
+
 void Executor::initializeGlobalAliases() {
   const Module *m = kmodule->module.get();
-
-  // link aliases to their definitions (if bound)
-  for (auto i = m->alias_begin(), ie = m->alias_end(); i != ie; ++i) {
-    // Map the alias to its aliasee's address. This works because we have
-    // addresses for everything, even undefined functions.
-
-    // Alias may refer to other alias, not necessarily known at this point.
-    // Thus, resolve to real alias directly.
-    const GlobalAlias *alias = &*i;
-    while (const auto *ga = dyn_cast<GlobalAlias>(alias->getAliasee())) {
-      assert(ga != alias && "alias pointing to itself");
-      alias = ga;
-    }
-
-    globalAddresses.insert(std::make_pair(&*i, evalConstant(alias->getAliasee())));
+  for (const GlobalAlias &a : m->aliases()) {
+    initializeGlobalAlias(&a);
   }
 }
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -745,35 +745,9 @@ void Executor::allocateGlobalObjects(ExecutionState &state) {
                                         /*alignment=*/globalObjectAlignment);
     if (!mo)
       klee_error("out of memory");
-    ObjectState *os = bindObjectInState(state, mo, false);
     globalObjects.emplace(&v, mo);
     globalAddresses.emplace(&v, mo->getBaseExpr());
-
-    if (v.isDeclaration() && size) {
-      // Program already running -> object already initialized.
-      // Read concrete value and write it to our copy.
-      void *addr;
-      if (v.getName() == "__dso_handle") {
-        addr = &__dso_handle; // wtf ?
-      } else {
-        addr = externalDispatcher->resolveSymbol(v.getName());
-      }
-      if (!addr) {
-        klee_error("Unable to load symbol(%.*s) while initializing globals",
-                    static_cast<int>(v.getName().size()),
-                    v.getName().data()
-        );
-      }
-
-      for (unsigned offset = 0; offset < mo->size; offset++) {
-        os->write8(offset, static_cast<unsigned char*>(addr)[offset]);
-      }
-    } else {
-      if (!v.hasInitializer())
-        os->initializeToRandom();
-    }
   }
-
 }
 
 void Executor::initializeGlobalAliases() {
@@ -803,15 +777,31 @@ void Executor::initializeGlobalObjects(ExecutionState &state) {
   // calls
   std::vector<ObjectState *> constantObjects;
   for (const GlobalVariable &v : m->globals()) {
-    if (v.hasInitializer()) {
-      MemoryObject *mo = globalObjects.find(&v)->second;
-      const ObjectState *os = state.addressSpace.findObject(mo);
-      assert(os);
-      ObjectState *wos = state.addressSpace.getWriteable(mo, os);
+    MemoryObject *mo = globalObjects.find(&v)->second;
+    ObjectState *os = bindObjectInState(state, mo, false);
 
-      initializeGlobalObject(state, wos, v.getInitializer(), 0);
+    if (v.isDeclaration() && mo->size) {
+      // Program already running -> object already initialized.
+      // Read concrete value and write it to our copy.
+      void *addr;
+      if (v.getName() == "__dso_handle") {
+        addr = &__dso_handle; // wtf ?
+      } else {
+        addr = externalDispatcher->resolveSymbol(v.getName());
+      }
+      if (!addr) {
+        klee_error("Unable to load symbol(%.*s) while initializing globals",
+                   static_cast<int>(v.getName().size()), v.getName().data());
+      }
+      for (unsigned offset = 0; offset < mo->size; offset++) {
+        os->write8(offset, static_cast<unsigned char *>(addr)[offset]);
+      }
+    } else if (v.hasInitializer()) {
+      initializeGlobalObject(state, os, v.getInitializer(), 0);
       if (v.isConstant())
-        constantObjects.emplace_back(wos);
+        constantObjects.emplace_back(os);
+    } else {
+      os->initializeToRandom();
     }
   }
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -645,7 +645,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
 }
 
 void Executor::allocateGlobalObjects(ExecutionState &state) {
-  Module *m = kmodule->module.get();
+  const Module *m = kmodule->module.get();
 
   if (m->getModuleInlineAsm() != "")
     klee_warning("executable has module level assembly (ignoring)");
@@ -653,22 +653,21 @@ void Executor::allocateGlobalObjects(ExecutionState &state) {
   // object. given that we use malloc to allocate memory in states this also
   // ensures that we won't conflict. we don't need to allocate a memory object
   // since reading/writing via a function pointer is unsupported anyway.
-  for (Module::iterator i = m->begin(), ie = m->end(); i != ie; ++i) {
-    Function *f = &*i;
-    ref<ConstantExpr> addr(0);
+  for (const Function &f : *m) {
+    ref<ConstantExpr> addr;
 
     // If the symbol has external weak linkage then it is implicitly
     // not defined in this module; if it isn't resolvable then it
     // should be null.
-    if (f->hasExternalWeakLinkage() && 
-        !externalDispatcher->resolveSymbol(f->getName())) {
+    if (f.hasExternalWeakLinkage() &&
+        !externalDispatcher->resolveSymbol(f.getName())) {
       addr = Expr::createPointer(0);
     } else {
-      addr = Expr::createPointer(reinterpret_cast<std::uint64_t>(f));
-      legalFunctions.insert(reinterpret_cast<std::uint64_t>(f));
+      addr = Expr::createPointer(reinterpret_cast<std::uint64_t>(&f));
+      legalFunctions.insert(reinterpret_cast<std::uint64_t>(&f));
     }
-    
-    globalAddresses.insert(std::make_pair(f, addr));
+
+    globalAddresses.emplace(&f, addr);
   }
 
 #ifndef WINDOWS
@@ -705,82 +704,76 @@ void Executor::allocateGlobalObjects(ExecutionState &state) {
 #endif
 #endif
 
+  for (const GlobalVariable &v : m->globals()) {
+    std::size_t globalObjectAlignment = getAllocationAlignment(&v);
+    Type *ty = v.getType()->getElementType();
+    std::uint64_t size = 0;
+    if (ty->isSized())
+      size = kmodule->targetData->getTypeStoreSize(ty);
 
-  for (Module::const_global_iterator i = m->global_begin(),
-         e = m->global_end();
-       i != e; ++i) {
-    const GlobalVariable *v = &*i;
-    size_t globalObjectAlignment = getAllocationAlignment(v);
-    if (i->isDeclaration()) {
+    if (v.isDeclaration()) {
       // FIXME: We have no general way of handling unknown external
       // symbols. If we really cared about making external stuff work
       // better we could support user definition, or use the EXE style
       // hack where we check the object file information.
 
-      Type *ty = i->getType()->getElementType();
-      uint64_t size = 0;
-      if (ty->isSized()) {
-	size = kmodule->targetData->getTypeStoreSize(ty);
-      } else {
-        klee_warning("Type for %.*s is not sized", (int)i->getName().size(),
-			i->getName().data());
+      if (!ty->isSized()) {
+        klee_warning("Type for %.*s is not sized",
+                     static_cast<int>(v.getName().size()), v.getName().data());
       }
 
       // XXX - DWD - hardcode some things until we decide how to fix.
 #ifndef WINDOWS
-      if (i->getName() == "_ZTVN10__cxxabiv117__class_type_infoE") {
+      if (v.getName() == "_ZTVN10__cxxabiv117__class_type_infoE") {
         size = 0x2C;
-      } else if (i->getName() == "_ZTVN10__cxxabiv120__si_class_type_infoE") {
+      } else if (v.getName() == "_ZTVN10__cxxabiv120__si_class_type_infoE") {
         size = 0x2C;
-      } else if (i->getName() == "_ZTVN10__cxxabiv121__vmi_class_type_infoE") {
+      } else if (v.getName() == "_ZTVN10__cxxabiv121__vmi_class_type_infoE") {
         size = 0x2C;
       }
 #endif
 
       if (size == 0) {
-        klee_warning("Unable to find size for global variable: %.*s (use will result in out of bounds access)",
-			(int)i->getName().size(), i->getName().data());
+        klee_warning("Unable to find size for global variable: %.*s (use will "
+                     "result in out of bounds access)",
+                     static_cast<int>(v.getName().size()), v.getName().data());
+      }
+    }
+
+    MemoryObject *mo = memory->allocate(size, /*isLocal=*/false,
+                                        /*isGlobal=*/true, /*allocSite=*/&v,
+                                        /*alignment=*/globalObjectAlignment);
+    if (!mo)
+      klee_error("out of memory");
+    ObjectState *os = bindObjectInState(state, mo, false);
+    globalObjects.emplace(&v, mo);
+    globalAddresses.emplace(&v, mo->getBaseExpr());
+
+    if (v.isDeclaration() && size) {
+      // Program already running -> object already initialized.
+      // Read concrete value and write it to our copy.
+      void *addr;
+      if (v.getName() == "__dso_handle") {
+        addr = &__dso_handle; // wtf ?
+      } else {
+        addr = externalDispatcher->resolveSymbol(v.getName());
+      }
+      if (!addr) {
+        klee_error("Unable to load symbol(%.*s) while initializing globals",
+                    static_cast<int>(v.getName().size()),
+                    v.getName().data()
+        );
       }
 
-      MemoryObject *mo = memory->allocate(size, /*isLocal=*/false,
-                                          /*isGlobal=*/true, /*allocSite=*/v,
-                                          /*alignment=*/globalObjectAlignment);
-      ObjectState *os = bindObjectInState(state, mo, false);
-      globalObjects.insert(std::make_pair(v, mo));
-      globalAddresses.insert(std::make_pair(v, mo->getBaseExpr()));
-
-      // Program already running = object already initialized.  Read
-      // concrete value and write it to our copy.
-      if (size) {
-        void *addr;
-        if (i->getName() == "__dso_handle") {
-          addr = &__dso_handle; // wtf ?
-        } else {
-          addr = externalDispatcher->resolveSymbol(i->getName());
-        }
-        if (!addr)
-          klee_error("unable to load symbol(%s) while initializing globals.", 
-                     i->getName().data());
-
-        for (unsigned offset=0; offset<mo->size; offset++)
-          os->write8(offset, ((unsigned char*)addr)[offset]);
+      for (unsigned offset = 0; offset < mo->size; offset++) {
+        os->write8(offset, static_cast<unsigned char*>(addr)[offset]);
       }
     } else {
-      Type *ty = i->getType()->getElementType();
-      uint64_t size = kmodule->targetData->getTypeStoreSize(ty);
-      MemoryObject *mo = memory->allocate(size, /*isLocal=*/false,
-                                          /*isGlobal=*/true, /*allocSite=*/v,
-                                          /*alignment=*/globalObjectAlignment);
-      if (!mo)
-        llvm::report_fatal_error("out of memory");
-      ObjectState *os = bindObjectInState(state, mo, false);
-      globalObjects.insert(std::make_pair(v, mo));
-      globalAddresses.insert(std::make_pair(v, mo->getBaseExpr()));
-
-      if (!i->hasInitializer())
-          os->initializeToRandom();
+      if (!v.hasInitializer())
+        os->initializeToRandom();
     }
   }
+
 }
 
 void Executor::initializeGlobalAliases() {
@@ -809,18 +802,15 @@ void Executor::initializeGlobalObjects(ExecutionState &state) {
   // remember constant objects to initialise their counter part for external
   // calls
   std::vector<ObjectState *> constantObjects;
-  for (Module::const_global_iterator i = m->global_begin(),
-         e = m->global_end();
-       i != e; ++i) {
-    if (i->hasInitializer()) {
-      const GlobalVariable *v = &*i;
-      MemoryObject *mo = globalObjects.find(v)->second;
+  for (const GlobalVariable &v : m->globals()) {
+    if (v.hasInitializer()) {
+      MemoryObject *mo = globalObjects.find(&v)->second;
       const ObjectState *os = state.addressSpace.findObject(mo);
       assert(os);
       ObjectState *wos = state.addressSpace.getWriteable(mo, os);
-      
-      initializeGlobalObject(state, wos, i->getInitializer(), 0);
-      if (i->isConstant())
+
+      initializeGlobalObject(state, wos, v.getInitializer(), 0);
+      if (v.isConstant())
         constantObjects.emplace_back(wos);
     }
   }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -631,6 +631,20 @@ MemoryObject * Executor::addExternalObject(ExecutionState &state,
 extern void *__dso_handle __attribute__ ((__weak__));
 
 void Executor::initializeGlobals(ExecutionState &state) {
+  // allocate and initialize globals, done in two passes since we may
+  // need address of a global in order to initialize some other one.
+
+  // allocate memory objects for all globals
+  allocateGlobalObjects(state);
+
+  // initialize aliases first, may be needed for global objects
+  initializeGlobalAliases();
+
+  // finally, do the actual initialization
+  initializeGlobalObjects(state);
+}
+
+void Executor::allocateGlobalObjects(ExecutionState &state) {
   Module *m = kmodule->module.get();
 
   if (m->getModuleInlineAsm() != "")
@@ -691,10 +705,7 @@ void Executor::initializeGlobals(ExecutionState &state) {
 #endif
 #endif
 
-  // allocate and initialize globals, done in two passes since we may
-  // need address of a global in order to initialize some other one.
 
-  // allocate memory objects for all globals
   for (Module::const_global_iterator i = m->global_begin(),
          e = m->global_end();
        i != e; ++i) {
@@ -770,7 +781,11 @@ void Executor::initializeGlobals(ExecutionState &state) {
           os->initializeToRandom();
     }
   }
-  
+}
+
+void Executor::initializeGlobalAliases() {
+  const Module *m = kmodule->module.get();
+
   // link aliases to their definitions (if bound)
   for (auto i = m->alias_begin(), ie = m->alias_end(); i != ie; ++i) {
     // Map the alias to its aliasee's address. This works because we have
@@ -786,8 +801,11 @@ void Executor::initializeGlobals(ExecutionState &state) {
 
     globalAddresses.insert(std::make_pair(&*i, evalConstant(alias->getAliasee())));
   }
+}
 
-  // once all objects are allocated, do the actual initialization
+void Executor::initializeGlobalObjects(ExecutionState &state) {
+  const Module *m = kmodule->module.get();
+
   // remember constant objects to initialise their counter part for external
   // calls
   std::vector<ObjectState *> constantObjects;

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -230,6 +230,9 @@ private:
 			      const llvm::Constant *c,
 			      unsigned offset);
   void initializeGlobals(ExecutionState &state);
+  void allocateGlobalObjects(ExecutionState &state);
+  void initializeGlobalAliases();
+  void initializeGlobalObjects(ExecutionState &state);
 
   void stepInstruction(ExecutionState &state);
   void updateStates(ExecutionState *current);

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -226,6 +226,7 @@ private:
   MemoryObject *addExternalObject(ExecutionState &state, void *addr, 
                                   unsigned size, bool isReadOnly);
 
+  void initializeGlobalAlias(const llvm::Constant *c);
   void initializeGlobalObject(ExecutionState &state, ObjectState *os, 
 			      const llvm::Constant *c,
 			      unsigned offset);

--- a/lib/Core/ExecutorUtil.cpp
+++ b/lib/Core/ExecutorUtil.cpp
@@ -49,7 +49,9 @@ namespace klee {
       } else if (const ConstantFP *cf = dyn_cast<ConstantFP>(c)) {
         return ConstantExpr::alloc(cf->getValueAPF().bitcastToAPInt());
       } else if (const GlobalValue *gv = dyn_cast<GlobalValue>(c)) {
-        return globalAddresses.find(gv)->second;
+        auto it = globalAddresses.find(gv);
+        assert(it != globalAddresses.end());
+        return it->second;
       } else if (isa<ConstantPointerNull>(c)) {
         return Expr::createPointer(0);
       } else if (isa<UndefValue>(c) || isa<ConstantAggregateZero>(c)) {

--- a/test/Feature/Alias.c
+++ b/test/Feature/Alias.c
@@ -6,6 +6,10 @@
 
 #include <assert.h>
 
+// alias with bitcast
+// NOTE: this does not have to be before b is known
+extern short d __attribute__((alias("b")));
+
 // alias for global
 int b = 52;
 extern int a __attribute__((alias("b")));
@@ -18,13 +22,26 @@ extern int foo2() __attribute__((alias("foo")));
 int __foo() { return 52; }
 extern int foo() __attribute__((alias("__foo")));
 
+// alias without bitcast
+extern int foo3(void) __attribute__((alias("__foo")));
+
 int *c = &a;
 
 int main() {
   assert(a == 52);
+  assert(*c == 52);
+  assert((int)d == 52);
+
+  assert(c == &b);
+  assert((int*)&d != &b);
+
   assert(foo() == 52);
   assert(foo2() == 52);
-  assert(*c == 52);
+  assert(foo3() == 52);
+
+  assert(foo != __foo);
+  assert(foo2 != __foo);
+  assert(foo3 == __foo);
 
   return 0;
 }

--- a/test/regression/2019-05-30_known-bitcast-alias.ll
+++ b/test/regression/2019-05-30_known-bitcast-alias.ll
@@ -1,0 +1,42 @@
+; RUN: %llvmas %s -o=%t.bc
+; RUN: rm -rf %t.klee-out
+; RUN: %klee -exit-on-error-type=Abort -output-source -output-dir=%t.klee-out %t.bc
+
+@x = global i32 0, align 4
+
+define i32 @__foo() {
+entry:
+  %0 = load i32, i32* @x, align 4
+  %inc = add nsw i32 %0, 1
+  store i32 %inc, i32* @x, align 4
+  ret i32 1
+}
+
+@foo = alias i32 (...), bitcast (i32 ()* @__foo to i32 (...)*)
+@foo2 = alias i32 (...), i32 (...)* @foo
+@foo3 = alias i16 (...), bitcast (i32 (...)* @foo2 to i16 (...)*)
+
+define i32 @main() {
+entry:
+  %call1 = call i32 (...) @foo()
+  %call2 = call i32 (...) @foo2()
+  %call3 = call i16 (...) @foo3()
+  %load = load i32, i32* @x, align 4
+  %inc1 = add nsw i32 %load, %call1
+  %inc2 = add nsw i32 %inc1, %call2
+  %zext = zext i16 %call3 to i32
+  %inc3 = add nsw i32 %inc2, %zext
+  %cmp = icmp ne i32 %inc3, 6
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:
+  call void @klee_abort()
+  unreachable
+
+if.end:
+  ret i32 0
+}
+
+declare void @klee_abort() #1
+
+attributes #1 = { noreturn }

--- a/test/regression/2019-05-30_unknown-bitcast-alias.ll
+++ b/test/regression/2019-05-30_unknown-bitcast-alias.ll
@@ -1,0 +1,44 @@
+; RUN: %llvmas %s -o=%t.bc
+; RUN: rm -rf %t.klee-out
+; RUN: %klee -exit-on-error-type=Abort -output-source -output-dir=%t.klee-out %t.bc
+
+; bitcast of @foo2, which is not known yet
+@foo3 = alias i16 (...), bitcast (i32 (...)* @foo2 to i16 (...)*)
+; @foo is not known yet
+@foo2 = alias i32 (...), i32 (...)* @foo
+@foo = alias i32 (...), bitcast (i32 ()* @__foo to i32 (...)*)
+
+@x = global i32 0, align 4
+
+define i32 @__foo() {
+entry:
+  %0 = load i32, i32* @x, align 4
+  %inc = add nsw i32 %0, 1
+  store i32 %inc, i32* @x, align 4
+  ret i32 1
+}
+
+define i32 @main() {
+entry:
+  %call1 = call i32 (...) @foo()
+  %call2 = call i32 (...) @foo2()
+  %call3 = call i16 (...) @foo3()
+  %load = load i32, i32* @x, align 4
+  %inc1 = add nsw i32 %load, %call1
+  %inc2 = add nsw i32 %inc1, %call2
+  %zext = zext i16 %call3 to i32
+  %inc3 = add nsw i32 %inc2, %zext
+  %cmp = icmp ne i32 %inc3, 6
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:
+  call void @klee_abort()
+  unreachable
+
+if.end:
+  ret i32 0
+}
+
+declare void @klee_abort() #1
+
+attributes #1 = { noreturn }

--- a/test/regression/2019-05-31_simple-unknown-bitcast-alias.ll
+++ b/test/regression/2019-05-31_simple-unknown-bitcast-alias.ll
@@ -1,0 +1,22 @@
+; RUN: %llvmas %s -o=%t.bc
+; RUN: rm -rf %t.klee-out
+; RUN: %klee -output-source -output-dir=%t.klee-out %t.bc
+
+; bitcast of @foo2, which is not known yet
+@foo3 = alias i16 (...), bitcast (i32 (...)* @foo2 to i16 (...)*)
+; @foo is not known yet
+@foo2 = alias i32 (...), i32 (...)* @foo
+@foo = alias i32 (...), bitcast (i32 ()* @__foo to i32 (...)*)
+
+define i32 @__foo() {
+entry:
+  ret i32 42
+}
+
+define i32 @main() {
+entry:
+  call i32 (...) @foo()
+  call i32 (...) @foo2()
+  call i16 (...) @foo3()
+  ret i32 0
+}


### PR DESCRIPTION
Aliases in LLVM IR are allowed to have either a global value (such as a function) or a constant expression (such as a bitcast of a function) as their aliasee. Further, there are no restrictions on the order in which of aliases and their eventual targets may be defined in the module.

This fixes the issue that while trying to initialize an alias, its aliasee (or one of its sub-expressions) is not yet initialized, which (in some cases) led to a segfault or (in other cases) went unnoticed. The patch included in this PR resolves all subexpressions first, in case the aliasee is not (immediately) a global value that has already been initialized.

I included the various regression tests for this issue and extended the existing `Alias.c` feature test.

While fixing the underlying issue, I also split up `initializeGlobals()` and slightly refactored the resulting methods, which I hope is a welcome change. I tried to separate each major step of this process into a single commit to lessen the pain of reviewing these changes.

Fixes #1006, obsoletes #1110.