### PR TITLE
Fix build scripts for LLVM's git monorepo

### DIFF
--- a/cmake/find_llvm.cmake
+++ b/cmake/find_llvm.cmake
@@ -72,7 +72,7 @@ else()
   # Get LLVM version
   _run_llvm_config(LLVM_PACKAGE_VERSION "--version")
   # Try x.y.z patern
-  set(_llvm_version_regex "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(svn)?$")
+  set(_llvm_version_regex "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(svn|git)?$")
   if ("${LLVM_PACKAGE_VERSION}" MATCHES "${_llvm_version_regex}")
     string(REGEX REPLACE
       "${_llvm_version_regex}"
@@ -91,7 +91,7 @@ else()
       "${LLVM_PACKAGE_VERSION}")
   else()
     # try x.y pattern
-    set(_llvm_version_regex "^([0-9]+)\\.([0-9]+)(svn)?$")
+    set(_llvm_version_regex "^([0-9]+)\\.([0-9]+)(svn|git)?$")
     if ("${LLVM_PACKAGE_VERSION}" MATCHES "${_llvm_version_regex}")
       string(REGEX REPLACE
         "${_llvm_version_regex}"

--- a/scripts/build/p-llvm.inc
+++ b/scripts/build/p-llvm.inc
@@ -101,8 +101,8 @@ download_llvm() {
     branch_name="release/${LLVM_VERSION}.x"
   fi
   git_clone_or_update "https://github.com/llvm/llvm-project.git" "${LLVM_SRC_BASE}" "${branch_name}" || exit 1
-  if [[ "${LLVM_VERSION_MAJOR}" -le 8 ]]; then
-    # Fix the linking for older versions
+  if [[ "${LLVM_VERSION_MAJOR}" -lt 4 ]]; then
+    # Use symlinks for older versions whose build systems do not support the monorepo directory layout
     ln -s "${LLVM_SRC_BASE}/clang" "${LLVM_SRC_BASE}/llvm/tools/"
     ln -s "${LLVM_SRC_BASE}/compiler-rt" "${LLVM_SRC_BASE}/llvm/projects/"
     ln -s "${LLVM_SRC_BASE}/libcxx" "${LLVM_SRC_BASE}/llvm/projects/"
@@ -129,13 +129,16 @@ build_llvm() {
        # Build uninstrumented compiler
        mkdir -p "${SANITIZER_LLVM_UNINSTRUMENTED}"
        cd "${SANITIZER_LLVM_UNINSTRUMENTED}"
-       cmake -GNinja -DCMAKE_BUILD_TYPE=Release "${LLVM_SRC_BASE}/llvm"
+       cmake -GNinja -DCMAKE_BUILD_TYPE=Release \
+        "-DLLVM_ENABLE_PROJECTS=clang;compiler-rt;libcxx;libcxxabi" \
+        "${LLVM_SRC_BASE}/llvm"
        ninja
 
        # Build instrumented libc/libc++
        mkdir -p "${SANITIZER_LLVM_LIBCXX}"
        cd "${SANITIZER_LLVM_LIBCXX}"
        cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        "-DLLVM_ENABLE_PROJECTS=clang;compiler-rt;libcxx;libcxxabi" \
         -DLLVM_USE_SANITIZER=MemoryWithOrigins \
         "${SANITIZER_CMAKE_C_COMPILER[@]}" \
         "${SANITIZER_CMAKE_CXX_COMPILER[@]}" \
@@ -154,6 +157,7 @@ build_llvm() {
           -DCMAKE_C_FLAGS="$C_F" \
           -DCMAKE_CXX_FLAGS="${CXX_F}" \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          "-DLLVM_ENABLE_PROJECTS=clang;compiler-rt;libcxx;libcxxabi" \
           -DLLVM_ENABLE_ASSERTIONS=On \
           -DLLVM_USE_SANITIZER=MemoryWithOrigins \
           -DLLVM_ENABLE_LIBCXX=ON \
@@ -177,6 +181,7 @@ build_llvm() {
   CONFIG=(
      "-DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL}"
      "-DLLVM_BUILD_LLVM_DYLIB=TRUE"
+     "-DLLVM_ENABLE_PROJECTS=clang;compiler-rt;libcxx;libcxxabi"
   )
   # cmake build
   if [[ "${enable_optimized}" == "1" && "${enable_debug}" != "1" ]]; then


### PR DESCRIPTION
I tried out the modifications to the build scripts using LLVM's git monorepo just merged with #1208 on a non-Ubuntu machine, so building LLVM from scratch. This PR fixes two things I noticed during these trials.

The first is the usage of `LLVM_ENABLE_PROJECTS` in LLVM's CMake invocation which makes sure the build system can find the tool and project directories (for `clang` etc.) in lieu of symlinks. This flag is present (and as far as I can tell, working) from LLVM 4 on, which is why I restricted the creation of the symlinks to earlier versions. Without this change, LLVM 9.0 could not be compiled correctly.

The other one is that instead of the `svn` postfix, LLVM now reports its version with `git` when using a non-tagged version.