### PR TITLE
Add ZESTI like interface as a wrapper script

### DIFF
--- a/test/Replay/klee-replay/KleeZesti.c
+++ b/test/Replay/klee-replay/KleeZesti.c
@@ -1,0 +1,103 @@
+// -- Core testing commands
+// REQUIRES: uclibc
+// REQUIRES: posix-runtime
+// RUN: rm -rf %t.out
+// RUN: rm -f %t.bc
+// RUN: mkdir -p %t.out
+// RUN: echo -n aaaa > %t.out/aaaa.txt
+// RUN: echo -n bbbb > %t.out/bbbb.txt
+// RUN: echo -n ccc > %t.out/cccc.txt
+// RUN: %clang %s -emit-llvm %O0opt -c -o %t.bc
+// RUN: %klee-zesti -only-replay-seeds -libc=uclibc -posix-runtime %t.bc -o -p -q %t.out/bbbb.txt %t.out/cccc.txt < %t.out/aaaa.txt  &> %t.out/out.txt
+// RUN: FileCheck --input-file=%t.out/out.txt %s
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int check_fd(int fd, const int file_size, const char *file_contents) {
+  struct stat fs;
+  char contents[10] = {0};
+
+  if (fstat(fd, &fs) < 0)
+    return -1;
+
+  if (fs.st_size != file_size)
+    return -1;
+
+  read(fd, contents, 10);
+
+  if (strcmp(contents, file_contents) != 0)
+    return -1;
+
+  return 0;
+}
+
+int check_file(const char *file_name, const int file_size, const char *file_contents) {
+  int fd;
+
+  if ((fd = open(file_name, O_RDONLY)) < 0)
+    return -1;
+
+  if (check_fd(fd, file_size, file_contents) < 0)
+    return -1;
+
+  close(fd);
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  if (argc == 6) {
+    // CHECK-DAG: Got 5 args
+    printf("Got 5 args\n");
+  }
+
+  if (strcmp(argv[1], "-o") == 0) {
+    // CHECK-DAG: Got -o flag
+    printf("Got -o flag\n");
+  }
+
+  if (strcmp(argv[2], "-p") == 0) {
+    // CHECK-DAG: Got -p flag
+    printf("Got -p flag\n");
+  }
+
+  if (strcmp(argv[3], "-q") == 0) {
+    // CHECK-DAG: Got -q flag
+    printf("Got -q flag\n");
+  }
+
+  if (strcmp(argv[4], "A") == 0) {
+    // CHECK-DAG: Got A file
+    printf("Got A file\n");
+  }
+
+  if (check_file(argv[4], 4, "bbbb") == 0) {
+    // CHECK-DAG: Got A file size
+    printf("Got A file size\n");
+  }
+
+  if (strcmp(argv[5], "B") == 0) {
+    // CHECK-DAG: Got B file
+    printf("Got B file\n");
+  }
+
+  // File sizes get increased to the highest among files, so even B has file size 4.
+  // This is due to the limitaiton of posix-runtime API
+  if (check_file(argv[5], 4, "ccc") == 0) {
+    // CHECK-DAG: Got B file size
+    printf("Got B file size\n");
+  }
+
+  if (check_fd(0, 4, "aaaa") == 0) {
+    // CHECK-DAG: Got stdin file size
+    printf("Got stdin file size\n");
+  }
+  // CHECK-DAG: KLEE: done: completed paths = 1
+  // CHECK-DAG: KLEE: done: generated tests = 1
+
+  return 0;
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -131,6 +131,7 @@ if len(kleaver_extra_params) != 0:
 # to come first, e.g., klee-replay should come before klee
 subs = [ ('%kleaver', 'kleaver', kleaver_extra_params),
          ('%klee-replay', 'klee-replay', ''),
+         ('%klee-zesti', 'klee-zesti', ''),
          ('%klee','klee', klee_extra_params),
          ('%ktest-tool', 'ktest-tool', ''),
          ('%gen-random-bout', 'gen-random-bout', ''),

--- a/tools/klee-zesti/CMakeLists.txt
+++ b/tools/klee-zesti/CMakeLists.txt
@@ -6,11 +6,8 @@
 # License. See LICENSE.TXT for details.
 #
 #===------------------------------------------------------------------------===#
-add_subdirectory(gen-bout)
-add_subdirectory(gen-random-bout)
-add_subdirectory(kleaver)
-add_subdirectory(klee)
-add_subdirectory(klee-replay)
-add_subdirectory(klee-stats)
-add_subdirectory(klee-zesti)
-add_subdirectory(ktest-tool)
+install(PROGRAMS klee-zesti DESTINATION bin)
+
+# Copy into the build directory's binary directory
+# so system tests can find it
+configure_file(klee-zesti "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/klee-zesti" COPYONLY)

--- a/tools/klee-zesti/klee-zesti
+++ b/tools/klee-zesti/klee-zesti
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+import sys
+import os
+import subprocess
+import tempfile
+import select
+import shutil
+HELP="""OVERVIEW: ZESTI like wrapper of KLEE
+
+USAGE:  klee-zesti [klee-options] <input bytecode> <concrete program arguments>
+
+WARNING this script is not equivalent to ZESTI in ICSE 2012. It just provides a similar interface to KLEE. Namely it first explores the path of <concrete program arguments> and then continues symbolic execution from that point. Most importantly it does not implement the ZESTI searcher.
+"""
+
+
+KLEE="klee"
+GEN_BOUT="gen-bout"
+
+def find_klee_bin_dir():
+  global KLEE
+  global GEN_BOUT
+  bin_dir = os.path.dirname(os.path.realpath(__file__))
+  KLEE = bin_dir + "/klee"
+  GEN_BOUT = bin_dir + "/gen-bout"
+  if not os.path.isfile(KLEE):
+      print("WARNING can't find klee at " + KLEE)
+      KLEE= shutil.which("klee")
+      print("Using klee in PATH", KLEE)
+  if not os.path.isfile(GEN_BOUT):
+      print("WARNING can't find gen-bout at " + GEN_BOUT)
+      GEN_BOUT= shutil.which("gen-bout")
+      print("Using gen-bout in PATH", GEN_BOUT)
+  if GEN_BOUT is None or KLEE is None:
+      print("Failed to find KLEE at this script location or in PATH. Quitting ...")
+      sys.exit(1)
+  print("Using", KLEE)
+ 
+  
+
+def split_args():
+  prog = None
+  prog_args = []
+  klee_args = []
+  is_progargs = False
+  for a in sys.argv[1:]:
+      if is_progargs:
+          prog_args += [a]
+      elif a.startswith("-"):
+          klee_args += [a]
+      else:
+          prog = a
+          is_progargs = True
+  return klee_args, prog, prog_args
+
+def maybe_file_size(name):
+  try:
+    return os.path.getsize(name)
+  except:
+    return None
+
+def get_stdin_file(tmpdir):
+  stdin = ""
+  stdin_size = 0
+  if sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
+    stdin += sys.stdin.readline()
+  if stdin == "":
+      return None, stdin_size
+  stdin_file_name = tmpdir.name + "/stdin.file"
+  with open(stdin_file_name, 'w') as f:
+    stdin_size = f.write(stdin)
+  return stdin_file_name, stdin_size
+    
+  
+
+def prog_args_to_posix(prog_args):
+  posix_args = []
+  sym_file = 'A'
+  sym_file_sizes = [] 
+  gen_out_args = []
+  for parg in prog_args:
+      file_size = maybe_file_size(parg)
+      if file_size is None:
+          posix_args += ['--sym-arg', str(len(parg))]
+          gen_out_args += [parg]
+      else:
+          sym_file_sizes += [file_size]
+          posix_args += [sym_file]
+          sym_file = chr(ord(sym_file) + 1)
+          gen_out_args += ['--sym-file', parg]
+
+  if ord(sym_file) - ord('A') > 0:
+      posix_args += ['--sym-files', str(ord(sym_file) - ord('A')), str(max(sym_file_sizes))]
+  return posix_args, gen_out_args
+
+def create_ktest_file(gen_out_args, tmpdir):
+  out_file=tmpdir + "/test.ktest"
+  subprocess.run([GEN_BOUT, "--bout-file", out_file] + gen_out_args, check=True)
+  return out_file
+
+
+
+def main():
+  klee_args, prog, prog_args = split_args()
+  if len(sys.argv) == 1 or prog is None:
+      print(HELP)
+      return
+  find_klee_bin_dir()
+  tmpdir = tempfile.TemporaryDirectory()
+  stdin_file, stdin_size = get_stdin_file(tmpdir)
+  posix_args, gen_out_args = prog_args_to_posix(prog_args)
+  if stdin_file is not None:
+      gen_out_args += ["--sym-stdin", stdin_file]
+      posix_args += ["--sym-stdin", str(stdin_size)]
+  ktest_file = create_ktest_file(gen_out_args,tmpdir.name)
+  klee_args += ["-seed-file=" + ktest_file]
+  
+  proc = subprocess.Popen([KLEE] + klee_args + [prog] + posix_args, stdout=sys.stdout, stderr=sys.stderr)
+  while proc.returncode is None:
+      try:
+        proc.wait()
+      except KeyboardInterrupt:
+        pass # This is expected when stopping KLEE, so we wait for KLEE to finish
+  sys.exit(proc.returncode)
+
+
+if __name__ == "__main__":
+  main()
+
+


### PR DESCRIPTION
This patch adds a new tool, that adds a zesti like interface to standard `KLEE`.

For example with this PR and given that you have `klee` and `gen-bout` in PATH you can run somethign like:

```
$ ../../scripts/zesti.py -cex-cache-try-all --max-time=7200 --search=random-path --max-memory=4000 -only-output-states-covering-new --simplify-sym-indices --solver-backend=stp --disab
le-inlining -watchdog --libc=uclibc --posix-runtime --external-calls=all --run-in-dir=/tmp/sandbox --switch-t
ype=simple ls.bc -lh
KLEE: KLEE: WATCHDOG: watching 1799

KLEE: NOTE: Using POSIX model: /data/klee/build/Debug+Asserts/lib/libkleeRuntimePOSIX.bca
KLEE: NOTE: Using klee-uclibc : /data/klee/build/Debug+Asserts/lib/klee-uclibc.bca
KLEE: output directory is "/data/klee/build7.0/bin/klee-out-11"
KLEE: Using STP solver backend
KLEE: WARNING: undefined reference to function: __ctype_b_loc
KLEE: WARNING: undefined reference to function: __ctype_get_mb_cur_max
KLEE: KLEE: using 1 seeds

KLEE: WARNING: executable has module level assembly (ignoring)
KLEE: 1 seeds remaining over: 1 states
KLEE: WARNING ONCE: calling external: syscall(16, 0, 21505, 83819312) at /data/klee/runtime/POSIX/fd.c:991 10
KLEE: WARNING ONCE: Alignment of memory from call "malloc" is not modelled. Using alignment of 8.
KLEE: WARNING ONCE: calling __klee_posix_wrapped_main with extra arguments.
KLEE: WARNING ONCE: Alignment of memory from call "realloc" is not modelled. Using alignment of 8.
KLEE: WARNING ONCE: calling external: __ctype_get_mb_cur_max() at ../lib/mbsalign.c:129 49
KLEE: WARNING ONCE: Alignment of memory from call "calloc" is not modelled. Using alignment of 8.
KLEE: WARNING ONCE: calling external: __ctype_b_loc() at ../lib/mbswidth.c:171 11
KLEE: WARNING ONCE: _setjmp: ignoring
total 4.0K
lrwxrwxrwx 1 tk1713 srg KLEE: WARNING ONCE: calling external: gettimeofday(83695360, 0) at /data/klee/runtime
/POSIX/stubs.c:159 20
 9  15  2013 a -> /dev/null
lrwxrwxrwx 1 usernm grp 11  15  2013 b -> /dev/random
-rwx------ 1 usernm grp 30  15  2013 c
-rw------- 1 usernm grp  0  15  2013 d
drwx------ 2 usernm grp 40  15  2013 e
KLEE: WARNING ONCE: calling close_stdout with extra arguments.
KLEE: seeding done (22 states remain)
KLEE: WARNING ONCE: calling external: vprintf(83672416, 87395712) at libc/stdio/fprintf.c:35 14
ls.bc: invalid option -- 
ls.bc: invalid option -- 
ls.bc: invalid option -- 
Try 'ls.bc --help' for more information.
Try 'ls.bc --help' for more information.
Try 'ls.bc --help' for more information.
ls.bc: invalid option -- 
Try 'ls.bc --help' for more information.
```

As far as I understand that's the basic idea of the ZESTI api. You give the progrma under test concrete arguments, which are then symbolised by ZESTI, seeded with the concrete input and then explored. This is exactly what happens here. 

Then as far as I understand, all you need is a special search strategy for full ZESTI experience, but that is orthogonal to this and can be added later.

I guess before merging, the install step needs to be improved (to use the right `klee` executable) and maybe made more robust. But before going there, I'm wondering if there is interest in this?

Multiple symbolic files don't work either, but that can be fixed by a smallish change to `gen-bout`