### PR TITLE
[gen-bout] Add leading zeros to genbout

### DIFF
--- a/tools/gen-bout/gen-bout.cpp
+++ b/tools/gen-bout/gen-bout.cpp
@@ -126,7 +126,7 @@ int main(int argc, char *argv[]) {
       static int total_args = 0;
 
       char arg[1024];
-      snprintf(arg, sizeof(arg), "arg%d", total_args++);
+      snprintf(arg, sizeof(arg), "arg%02d", total_args++);
       push_obj(&b, (const char *)arg, nbytes, (unsigned char *)argv[i]);
 
       char *buf1 = (char *)malloc(1024);


### PR DESCRIPTION
This PR makes the naming of argument object consitent between `gen-bout` and posix runtime.

Currently first arg name is `arg1` in `gen-bout` and `arg01` in posix runtime. This PR makes them both `arg01`