### PR TITLE
[posix-runtime] slightly improve model

### DIFF
--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -38,6 +38,22 @@ static exe_disk_file_t *__get_sym_file(const char *pathname) {
   if (!pathname)
     return NULL;
 
+  // Handle the case where symbolic file is given as an absolute path, ie.
+  // /current/work/dir/A
+  if (pathname[0] == '/') {
+    char cwd[1024] = {0};
+    if (getcwd(cwd, 1024)) {
+      size_t cwd_len = strlen(cwd);
+      // strip trailing / if present
+      if (cwd_len > 0 && cwd[cwd_len - 1] == '/') {
+        cwd[--cwd_len] = '\0';
+      }
+      if (strncmp(pathname, cwd, cwd_len) == 0) {
+        if (pathname[cwd_len] != '\0')
+          pathname += cwd_len + 1;
+      }
+    }
+  }
   char c = pathname[0];
   unsigned i;
 

--- a/test/Runtime/POSIX/SymFileConsistency.c
+++ b/test/Runtime/POSIX/SymFileConsistency.c
@@ -1,0 +1,32 @@
+// REQUIRES: posix-runtime
+// RUN: %clang %s -emit-llvm %O0opt -c -g -o %t.bc
+// RUN: rm -rf %t.klee-out-tmp
+// RUN: %gentmp %t.klee-out-tmp
+// RUN: %klee --run-in-dir=%t.klee-out-tmp --libc=uclibc --posix-runtime --exit-on-error %t.bc --sym-files 1 1 > %t1.log
+
+// This test checks that symbolic files can be resolved both with a relatve path 
+// ie. 'A' or by its full path ie. '/full/path/to/cwd/A'
+
+#include "klee/klee.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+  struct stat s, s1;
+  int res = stat("A", &s);
+  char cwd[1024];
+  getcwd(cwd, 1024);
+
+  char fullName[1024];
+  snprintf(fullName, 1024, "%s/%s", cwd, "A");
+
+  res = stat(fullName, &s1);
+  assert(s.st_size == s1.st_size);
+
+  return 0;
+}

--- a/test/Runtime/POSIX/SymFileConsistency.c
+++ b/test/Runtime/POSIX/SymFileConsistency.c
@@ -1,8 +1,7 @@
 // REQUIRES: posix-runtime
 // RUN: %clang %s -emit-llvm %O0opt -c -g -o %t.bc
 // RUN: rm -rf %t.klee-out-tmp
-// RUN: %gentmp %t.klee-out-tmp
-// RUN: %klee --run-in-dir=%t.klee-out-tmp --libc=uclibc --posix-runtime --exit-on-error %t.bc --sym-files 1 1 > %t1.log
+// RUN: %klee --output-dir=%t.klee-out-tmp --libc=uclibc --posix-runtime --exit-on-error %t.bc --sym-files 1 1 > %t1.log
 
 // This test checks that symbolic files can be resolved both with a relatve path 
 // ie. 'A' or by its full path ie. '/full/path/to/cwd/A'
@@ -17,10 +16,14 @@
 #include <unistd.h>
 
 int main(int argc, char **argv) {
-  struct stat s, s1;
+  struct stat s, s1, s2;
   int res = stat("A", &s);
   char cwd[1024];
   getcwd(cwd, 1024);
+  char *smallest_cwd = malloc(strlen(cwd) + 1);
+  strcpy(smallest_cwd, cwd);
+  stat(smallest_cwd, &s2);
+  free(smallest_cwd);
 
   char fullName[1024];
   snprintf(fullName, 1024, "%s/%s", cwd, "A");


### PR DESCRIPTION
This PR fixes an issue where you give a full path to the symbolic file. While you could argue that we simply never use realpath for symbolic file, the program can itself infer the absolute path. By concatenating the working directory with the filename. This is what SQLite3 does, see this strace:

```strace
...
lstat("seed.db", {st_mode=S_IFREG|0644, st_size=2048, ...}) = 0
getcwd("/data/klee/build7.0/bin", 511)  = 24
stat("/data/klee/build7.0/bin/seed.db", {st_mode=S_IFREG|0644, st_size=2048, ...}) = 0
open("/data/klee/build7.0/bin/seed.db", O_RDWR|O_CREAT|O_CLOEXEC, 0644) = 3
fstat(3, {st_mode=S_IFREG|0644, st_size=2048, ...}) = 0
...
```

This PR basically tries to skip the current work dir when getting the symbolic files.