### PR TITLE
Additional test for dealing with vector instructions

### DIFF
--- a/test/VectorInstructions/memset.c
+++ b/test/VectorInstructions/memset.c
@@ -1,0 +1,11 @@
+// RUN: rm -rf %t.klee-out
+// RUN: %clang %s -emit-llvm %O0opt -g -c -o %t1.bc
+// RUN: %klee --output-dir=%t.klee-out --optimize=true --exit-on-error %t1.bc
+
+#include <string.h>
+
+int main(int argc, char** argv) {
+  char arr[1000];
+  memset(arr, 1, sizeof(arr));
+  return arr[argc];
+}


### PR DESCRIPTION
This test exposes the failure fixed by #1102 in certain configurations.  I can reproduce it on my machine, but I want to double-check that our CI catches this failure before merging #1102.  