### PR TITLE
stats: minor changes

### DIFF
--- a/include/klee/Solver/SolverStats.h
+++ b/include/klee/Solver/SolverStats.h
@@ -23,7 +23,6 @@ namespace stats {
   extern Statistic queryCacheMisses;
   extern Statistic queryCexCacheHits;
   extern Statistic queryCexCacheMisses;
-  extern Statistic queryConstructTime;
   extern Statistic queryConstructs;
   extern Statistic queryCounterexamples;
   extern Statistic queryTime;

--- a/include/klee/Statistic.h
+++ b/include/klee/Statistic.h
@@ -10,8 +10,6 @@
 #ifndef KLEE_STATISTIC_H
 #define KLEE_STATISTIC_H
 
-#include "klee/Config/Version.h"
-#include "llvm/Support/DataTypes.h"
 #include <string>
 
 namespace klee {
@@ -25,22 +23,21 @@ namespace klee {
   /// not the actual values. Values are managed by the global
   /// StatisticManager to enable transparent support for instruction
   /// level and call path level statistics.
-  class Statistic {
+  class Statistic final {
     friend class StatisticManager;
     friend class StatisticRecord;
 
   private:
-    unsigned id;
+    std::uint32_t id;
     const std::string name;
     const std::string shortName;
 
   public:
-    Statistic(const std::string &_name, 
-              const std::string &_shortName);
-    ~Statistic();
+    Statistic(const std::string &name, const std::string &shortName);
+    ~Statistic() = default;
 
     /// getID - Get the unique statistic ID.
-    unsigned getID() { return id; }
+    std::uint32_t getID() const { return id; }
 
     /// getName - Get the statistic name.
     const std::string &getName() const { return name; }
@@ -50,16 +47,16 @@ namespace klee {
     const std::string &getShortName() const { return shortName; }
 
     /// getValue - Get the current primary statistic value.
-    uint64_t getValue() const;
+    std::uint64_t getValue() const;
 
-    /// operator uint64_t - Get the current primary statistic value.
-    operator uint64_t () const { return getValue(); }
+    /// operator std::uint64_t - Get the current primary statistic value.
+    operator std::uint64_t() const { return getValue(); }
 
     /// operator++ - Increment the statistic by 1.
-    Statistic &operator ++() { return (*this += 1); }
+    Statistic &operator++() { return (*this += 1); }
 
     /// operator+= - Increment the statistic by \arg addend.
-    Statistic &operator +=(const uint64_t addend);
+    Statistic &operator+=(std::uint64_t addend);
   };
 }
 

--- a/lib/Basic/Statistics.cpp
+++ b/lib/Basic/Statistics.cpp
@@ -64,21 +64,16 @@ static StatisticManager &getStatisticManager() {
 
 /* *** */
 
-Statistic::Statistic(const std::string &_name, 
-                     const std::string &_shortName) 
-  : name(_name), 
-    shortName(_shortName) {
+Statistic::Statistic(const std::string &name, const std::string &shortName)
+  : name{name}, shortName{shortName} {
   getStatisticManager().registerStatistic(*this);
 }
 
-Statistic::~Statistic() {
-}
-
-Statistic &Statistic::operator +=(const uint64_t addend) {
+Statistic &Statistic::operator+=(std::uint64_t addend) {
   theStatisticManager->incrementStatistic(*this, addend);
   return *this;
 }
 
-uint64_t Statistic::getValue() const {
+std::uint64_t Statistic::getValue() const {
   return theStatisticManager->getValue(*this);
 }

--- a/lib/Solver/SolverStats.cpp
+++ b/lib/Solver/SolverStats.cpp
@@ -19,7 +19,6 @@ Statistic stats::queryCacheHits("QueryCacheHits", "QChits") ;
 Statistic stats::queryCacheMisses("QueryCacheMisses", "QCmisses");
 Statistic stats::queryCexCacheHits("QueryCexCacheHits", "QCexHits") ;
 Statistic stats::queryCexCacheMisses("QueryCexCacheMisses", "QCexMisses");
-Statistic stats::queryConstructTime("QueryConstructTime", "QBtime") ;
 Statistic stats::queryConstructs("QueriesConstructs", "QB");
 Statistic stats::queryCounterexamples("QueriesCEX", "Qcex");
 Statistic stats::queryTime("QueryTime", "Qtime");

--- a/lib/Solver/SolverStats.cpp
+++ b/lib/Solver/SolverStats.cpp
@@ -19,7 +19,7 @@ Statistic stats::queryCacheHits("QueryCacheHits", "QChits") ;
 Statistic stats::queryCacheMisses("QueryCacheMisses", "QCmisses");
 Statistic stats::queryCexCacheHits("QueryCexCacheHits", "QCexHits") ;
 Statistic stats::queryCexCacheMisses("QueryCexCacheMisses", "QCexMisses");
-Statistic stats::queryConstructs("QueriesConstructs", "QB");
+Statistic stats::queryConstructs("QueryConstructs", "QB");
 Statistic stats::queryCounterexamples("QueriesCEX", "Qcex");
 Statistic stats::queryTime("QueryTime", "Qtime");
 

--- a/tools/kleaver/main.cpp
+++ b/tools/kleaver/main.cpp
@@ -302,15 +302,15 @@ static bool EvaluateInputAST(const char *Filename,
   if (uint64_t queries = *theStatisticManager->getStatisticByName("Queries")) {
     llvm::outs()
       << "--\n"
-      << "total queries = " << queries << "\n"
-      << "total queries constructs = " 
-      << *theStatisticManager->getStatisticByName("QueriesConstructs") << "\n"
+      << "total queries = " << queries << '\n'
+      << "total query constructs = "
+      << *theStatisticManager->getStatisticByName("QueryConstructs") << '\n'
       << "valid queries = " 
-      << *theStatisticManager->getStatisticByName("QueriesValid") << "\n"
+      << *theStatisticManager->getStatisticByName("QueriesValid") << '\n'
       << "invalid queries = " 
-      << *theStatisticManager->getStatisticByName("QueriesInvalid") << "\n"
+      << *theStatisticManager->getStatisticByName("QueriesInvalid") << '\n'
       << "query cex = " 
-      << *theStatisticManager->getStatisticByName("QueriesCEX") << "\n";
+      << *theStatisticManager->getStatisticByName("QueriesCEX") << '\n';
   }
 
   return success;

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1518,7 +1518,7 @@ int main(int argc, char **argv, char **envp) {
   uint64_t queryCounterexamples =
     *theStatisticManager->getStatisticByName("QueriesCEX");
   uint64_t queryConstructs =
-    *theStatisticManager->getStatisticByName("QueriesConstructs");
+    *theStatisticManager->getStatisticByName("QueryConstructs");
   uint64_t instructions =
     *theStatisticManager->getStatisticByName("Instructions");
   uint64_t forks =


### PR DESCRIPTION
* remove unused `queryConstructTime`
* rename `QueriesConstructs` to `QueryConstructs` to match internal/klee-stats naming
* minor update of the `Statistic` class definition