### PR TITLE
[posix-runtime] Simple GET/SET_LK model

### DIFF
--- a/test/Runtime/POSIX/Fcntl.c
+++ b/test/Runtime/POSIX/Fcntl.c
@@ -14,5 +14,12 @@ int main(int argc, char **argv) {
   assert(fcntl(fd, F_SETFD, FD_CLOEXEC, 1) == 0);
   assert((fcntl(fd, F_GETFD) & FD_CLOEXEC) != 0);
 
+  struct flock lck;
+  assert(fcntl(fd, F_GETLK, &lck) == 0);
+  assert(lck.l_type == F_UNLCK);
+  lck.l_type = F_RDLCK;
+  assert(fcntl(fd, F_SETLK, &lck) == 0);
+  lck.l_type = F_UNLCK;
+  assert(fcntl(fd, F_SETLK, &lck) == 0);
   return 0;
 }


### PR DESCRIPTION
This PR adds a simple model for GET/SET_LK `fcntl` commands. It basically assumes the program does the correct thing with locking. This is needed to  run  `sqlite3` with a symbolic db.