### PR TITLE
Setting 'FatalErrors' to false when calling 'createVerifierPass' #937

### DIFF
--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -366,7 +366,7 @@ void KModule::checkModule() {
 
   legacy::PassManager pm;
   if (!DontVerify)
-    pm.add(createVerifierPass());
+    pm.add(createVerifierPass(/* FatalErrors */ false));
   pm.add(operandTypeCheckPass);
   pm.run(*module);
 

--- a/lib/Module/Optimize.cpp
+++ b/lib/Module/Optimize.cpp
@@ -91,14 +91,14 @@ static inline void addPass(legacy::PassManager &PM, Pass *P) {
 
   // If we are verifying all of the intermediate steps, add the verifier...
   if (VerifyEach)
-    PM.add(createVerifierPass());
+    PM.add(createVerifierPass(/* FatalErrors */ false));
 }
 
 namespace llvm {
 
 
 static void AddStandardCompilePasses(legacy::PassManager &PM) {
-  PM.add(createVerifierPass());                  // Verify that input is correct
+  PM.add(createVerifierPass(/* FatalErrors */ false));                  // Verify that input is correct
 
   // If the -strip-debug command line option was specified, do it.
   if (StripDebug)
@@ -172,7 +172,7 @@ void Optimize(Module *M, llvm::ArrayRef<const char *> preservedFunctions) {
 
   // If we're verifying, start off with a verification pass.
   if (VerifyEach)
-    Passes.add(createVerifierPass());
+    Passes.add(createVerifierPass(/* FatalErrors */ false));
 
 #ifdef USE_WORKAROUND_LLVM_PR39177
   addPass(Passes, new klee::WorkaroundLLVMPR39177Pass());


### PR DESCRIPTION
This is an attempted fix for the issues in #937. I am not saying that this PR is immediately ready for integration, but it:

1. fixes the issue I am facing in #937
2. appears to have no regressions:

```
[100%] Running system tests
Testing Time: 27.63s
  Expected Passes    : 280
  Expected Failures  : 2
  Unsupported Tests  : 10
[100%] Built target systemtests
[100%] Built target check
```

### Things to do

- [ ] Add a test for the example from #937