### PR TITLE
StatsTracker: initialize indexed stats when user searcher requires MD2U

### DIFF
--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -194,7 +194,7 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
     }
   }
 
-  if (OutputIStats)
+  if (useStatistics() || userSearcherRequiresMD2U())
     theStatisticManager->useIndexedStats(km->infos->getMaxID());
 
   for (auto &kfp : km->functions) {


### PR DESCRIPTION
This is the same check used in `Executor::setModule`. Without this check, KLEE will segfault in `StatisticsManager::incrementIndexedValue`, `getIndexedValue`, and `setIndexedValue` when `-output-stats=false` or `-output-istats=false`. This is because `StatisticsManager::indexedStats` has not been allocated (via `StatisticsManager::useIndexedStats`).