### PR TITLE
[Solver:STP] Fix handling of array names

### DIFF
--- a/lib/Solver/STPBuilder.cpp
+++ b/lib/Solver/STPBuilder.cpp
@@ -436,12 +436,8 @@ ExprHandle STPBuilder::constructSDivByConstant(ExprHandle expr_n, unsigned width
   if (!hashed) {
     // STP uniques arrays by name, so we make sure the name is unique by
     // using the size of the array hash as a counter.
-    std::string unique_id = llvm::itostr(_arr_hash._array_hash.size());
-    unsigned const uid_length = unique_id.length();
-    unsigned const space = (root->name.length() > 32 - uid_length)
-                               ? (32 - uid_length)
-                               : root->name.length();
-    std::string unique_name = root->name.substr(0, space) + unique_id;
+    std::string unique_id = llvm::utostr(_arr_hash._array_hash.size());
+    std::string unique_name = root->name + unique_id;
 
     array_expr = buildArray(unique_name.c_str(), root->getDomain(),
                             root->getRange());

--- a/lib/Solver/Z3Builder.cpp
+++ b/lib/Solver/Z3Builder.cpp
@@ -392,12 +392,8 @@ Z3ASTHandle Z3Builder::getInitialArray(const Array *root) {
   if (!hashed) {
     // Unique arrays by name, so we make sure the name is unique by
     // using the size of the array hash as a counter.
-    std::string unique_id = llvm::itostr(_arr_hash._array_hash.size());
-    unsigned const uid_length = unique_id.length();
-    unsigned const space = (root->name.length() > 32 - uid_length)
-                               ? (32 - uid_length)
-                               : root->name.length();
-    std::string unique_name = root->name.substr(0, space) + unique_id;
+    std::string unique_id = llvm::utostr(_arr_hash._array_hash.size());
+    std::string unique_name = root->name + unique_id;
 
     array_expr = buildArray(unique_name.c_str(), root->getDomain(),
                             root->getRange());

--- a/test/regression/2020-04-27-stp-array-names.c
+++ b/test/regression/2020-04-27-stp-array-names.c
@@ -1,0 +1,24 @@
+// RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -output-dir=%t.klee-out --search=bfs --max-instructions=1000 %t.bc
+b;
+a(c) {
+  if (!c)
+    abort();
+}
+main() {
+  int e;
+  short d;
+  klee_make_symbolic(&d, sizeof(d), "__sym___VERIFIER_nondet_short");
+  b = d;
+  a(b > 0);
+  int f[b];
+  int g[b];
+  for (;;) {
+    short d;
+    klee_make_symbolic(&d, sizeof(d), "__sym___VERIFIER_nondet_short");
+    a(d >= 0 && d < b);
+    f[d];
+    g[b - 1 - d];
+  }
+}


### PR DESCRIPTION
Array names used for STP queries used to be restricted to 32 characters,
with the last characters replaced by a unique number.

Similarly, an array is made unique by `klee_make_symbolic`.

Unfortunately, both combined can lead to the generation of the same STP array name for different arrays.
This leads to wrong queries with invalid results.

This is more likely be triggered with longer names for `klee_make_symbolic`

Fixes #1257