### PR TITLE
Fast concrete object access

### DIFF
--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -163,7 +163,7 @@ public:
   void popFrame();
 
   void addSymbolic(const MemoryObject *mo, const Array *array);
-  void addConstraint(ref<Expr> e) { constraints.addConstraint(e); }
+  void addConstraint(const ref<Expr> &e) { constraints.addConstraint(e); }
 
   bool merge(const ExecutionState &b);
   void dumpStack(llvm::raw_ostream &out) const;

--- a/include/klee/Expr/Assignment.h
+++ b/include/klee/Expr/Assignment.h
@@ -43,7 +43,7 @@ namespace klee {
     }
     
     ref<Expr> evaluate(const Array *mo, unsigned index) const;
-    ref<Expr> evaluate(ref<Expr> e);
+    ref<Expr> evaluate(const ref<Expr> &e) const;
     void createConstraintsFromAssignment(std::vector<ref<Expr> > &out) const;
 
     template<typename InputIterator>
@@ -81,9 +81,9 @@ namespace klee {
     }
   }
 
-  inline ref<Expr> Assignment::evaluate(ref<Expr> e) { 
+  inline ref<Expr> Assignment::evaluate(const ref<Expr> &e) const {
     AssignmentEvaluator v(*this);
-    return v.visit(e); 
+    return v.visit(e);
   }
 
   template<typename InputIterator>

--- a/include/klee/Expr/Constraints.h
+++ b/include/klee/Expr/Constraints.h
@@ -38,11 +38,11 @@ public:
 
   // given a constraint which is known to be valid, attempt to
   // simplify the existing constraint set
-  void simplifyForValidConstraint(ref<Expr> e);
+  void simplifyForValidConstraint(const ref<Expr> &e);
 
-  ref<Expr> simplifyExpr(ref<Expr> e) const;
+  ref<Expr> simplifyExpr(const ref<Expr> &e) const;
 
-  void addConstraint(ref<Expr> e);
+  void addConstraint(const ref<Expr> &e);
 
   bool empty() const noexcept { return constraints.empty(); }
   ref<Expr> back() const { return constraints.back(); }
@@ -64,7 +64,7 @@ private:
   // returns true iff the constraints were modified
   bool rewriteConstraints(ExprVisitor &visitor);
 
-  void addConstraintInternal(ref<Expr> e);
+  void addConstraintInternal(const ref<Expr> &e);
 };
 
 } // namespace klee

--- a/include/klee/Expr/Expr.h
+++ b/include/klee/Expr/Expr.h
@@ -1036,7 +1036,7 @@ public:
   ///
   /// Example: unit8_t byte= (unit8_t) constant->getZExtValue(8);
   uint64_t getZExtValue(unsigned bits = 64) const {
-    assert(getWidth() <= bits && "Value may be out of range!");
+    assert(value.getActiveBits() <= bits && "Value will be out of range!");
     return value.getZExtValue();
   }
 

--- a/include/klee/Expr/ExprUtil.h
+++ b/include/klee/Expr/ExprUtil.h
@@ -24,14 +24,13 @@ namespace klee {
   /// is true then this will including those reachable by traversing
   /// update lists. Note that this may be slow and return a large
   /// number of results.
-  void findReads(ref<Expr> e, 
-                 bool visitUpdates,
-                 std::vector< ref<ReadExpr> > &result);
-  
+  void findReads(const ref<Expr> &e, bool visitUpdates,
+                 std::vector<ref<ReadExpr>> &result);
+
   /// Return a list of all unique symbolic objects referenced by the given
   /// expression.
-  void findSymbolicObjects(ref<Expr> e,
-                           std::vector<const Array*> &results);
+  void findSymbolicObjects(const ref<Expr> &e,
+                           std::vector<const Array *> &results);
 
   /// Return a list of all unique symbolic objects referenced by the
   /// given expression range.

--- a/include/klee/Solver/Solver.h
+++ b/include/klee/Solver/Solver.h
@@ -26,9 +26,8 @@ namespace klee {
     const ConstraintManager &constraints;
     ref<Expr> expr;
 
-    Query(const ConstraintManager& _constraints, ref<Expr> _expr)
-      : constraints(_constraints), expr(_expr) {
-    }
+    Query(const ConstraintManager &_constraints, ref<Expr> _expr)
+        : constraints(_constraints), expr(std::move(_expr)) {}
 
     /// withExpr - Return a copy of the query with the given expression.
     Query withExpr(ref<Expr> _expr) const {

--- a/lib/Core/Context.cpp
+++ b/lib/Core/Context.cpp
@@ -35,11 +35,11 @@ const Context &Context::get() {
 // FIXME: This is a total hack, just to avoid a layering issue until this stuff
 // moves out of Expr.
 
-ref<Expr> Expr::createSExtToPointerWidth(ref<Expr> e) {
+ref<Expr> Expr::createSExtToPointerWidth(const ref<Expr> &e) {
   return SExtExpr::create(e, Context::get().getPointerWidth());
 }
 
-ref<Expr> Expr::createZExtToPointerWidth(ref<Expr> e) {
+ref<Expr> Expr::createZExtToPointerWidth(const ref<Expr> &e) {
   return ZExtExpr::create(e, Context::get().getPointerWidth());
 }
 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -329,11 +329,11 @@ private:
   /// function is a wrapper around the state's addConstraint function
   /// which also manages propagation of implied values,
   /// validity checks, and seed patching.
-  void addConstraint(ExecutionState &state, ref<Expr> condition);
+  void addConstraint(ExecutionState &state, const ref<Expr> &condition);
 
   // Called on [for now] concrete reads, replaces constant with a symbolic
   // Used for testing.
-  ref<Expr> replaceReadWithSymbolic(ExecutionState &state, ref<Expr> e);
+  ref<Expr> replaceReadWithSymbolic(ExecutionState &state, const ref<Expr> &e);
 
   const Cell& eval(KInstruction *ki, unsigned index, 
                    ExecutionState &state) const;
@@ -372,7 +372,7 @@ private:
   /// Return a unique constant value for the given expression in the
   /// given state, if it has one (i.e. it provably only has a single
   /// value). Otherwise return the original expression.
-  ref<Expr> toUnique(const ExecutionState &state, ref<Expr> &e);
+  ref<Expr> toUnique(const ExecutionState &state, const ref<Expr> &e);
 
   /// Return a constant value for the given expression, forcing it to
   /// be constant in the given state by adding a constraint if
@@ -380,15 +380,17 @@ private:
   /// should generally be avoided.
   ///
   /// \param purpose An identify string to printed in case of concretization.
-  ref<klee::ConstantExpr> toConstant(ExecutionState &state, ref<Expr> e, 
+  ref<klee::ConstantExpr> toConstant(ExecutionState &state, const ref<Expr> &e,
                                      const char *purpose);
 
   /// Bind a constant value for e to the given target. NOTE: This
   /// function may fork state if the state has multiple seeds.
-  void executeGetValue(ExecutionState &state, ref<Expr> e, KInstruction *target);
+  void executeGetValue(ExecutionState &state, const ref<Expr> &e,
+                       KInstruction *target);
 
   /// Get textual information regarding a memory address.
-  std::string getAddressInfo(ExecutionState &state, ref<Expr> address) const;
+  std::string getAddressInfo(ExecutionState &state,
+                             const ref<Expr> &address) const;
 
   // Determines the \param lastInstruction of the \param state which is not KLEE
   // internal and returns its InstructionInfo

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -249,7 +249,7 @@ isByteConcrete(i) => !isByteKnownSymbolic(i)
 !isByteFlushed(i) => (isByteConcrete(i) || isByteKnownSymbolic(i))
  */
 
-void ObjectState::fastRangeCheckOffset(ref<Expr> offset,
+void ObjectState::fastRangeCheckOffset(const ref<Expr> &offset,
                                        unsigned *base_r,
                                        unsigned *size_r) const {
   *base_r = 0;
@@ -369,7 +369,7 @@ ref<Expr> ObjectState::read8(unsigned offset) const {
   }    
 }
 
-ref<Expr> ObjectState::read8(ref<Expr> offset) const {
+ref<Expr> ObjectState::read8(const ref<Expr> &offset) const {
   assert(!isa<ConstantExpr>(offset) && "constant offset passed to symbolic read8");
   unsigned base, size;
   fastRangeCheckOffset(offset, &base, &size);
@@ -395,7 +395,7 @@ void ObjectState::write8(unsigned offset, uint8_t value) {
   markByteUnflushed(offset);
 }
 
-void ObjectState::write8(unsigned offset, ref<Expr> value) {
+void ObjectState::write8(unsigned offset, const ref<Expr> &value) {
   // can happen when ExtractExpr special cases
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(value)) {
     write8(offset, (uint8_t) CE->getZExtValue(8));
@@ -407,7 +407,7 @@ void ObjectState::write8(unsigned offset, ref<Expr> value) {
   }
 }
 
-void ObjectState::write8(ref<Expr> offset, ref<Expr> value) {
+void ObjectState::write8(const ref<Expr> &offset, const ref<Expr> &value) {
   assert(!isa<ConstantExpr>(offset) && "constant offset passed to symbolic write8");
   unsigned base, size;
   fastRangeCheckOffset(offset, &base, &size);
@@ -426,9 +426,9 @@ void ObjectState::write8(ref<Expr> offset, ref<Expr> value) {
 
 /***/
 
-ref<Expr> ObjectState::read(ref<Expr> offset, Expr::Width width) const {
+ref<Expr> ObjectState::read(const ref<Expr> &_offset, Expr::Width width) const {
   // Truncate offset to 32-bits.
-  offset = ZExtExpr::create(offset, Expr::Int32);
+  ref<Expr> offset = ZExtExpr::create(_offset, Expr::Int32);
 
   // Check for reads at constant offsets.
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(offset))
@@ -471,9 +471,9 @@ ref<Expr> ObjectState::read(unsigned offset, Expr::Width width) const {
   return Res;
 }
 
-void ObjectState::write(ref<Expr> offset, ref<Expr> value) {
+void ObjectState::write(const ref<Expr> &_offset, const ref<Expr> &value) {
   // Truncate offset to 32-bits.
-  offset = ZExtExpr::create(offset, Expr::Int32);
+  ref<Expr> offset = ZExtExpr::create(_offset, Expr::Int32);
 
   // Check for writes at constant offsets.
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(offset)) {
@@ -498,7 +498,7 @@ void ObjectState::write(ref<Expr> offset, ref<Expr> value) {
   }
 }
 
-void ObjectState::write(unsigned offset, ref<Expr> value) {
+void ObjectState::write(unsigned offset, const ref<Expr> &value) {
   // Check for writes of constant values.
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(value)) {
     Expr::Width w = CE->getWidth();
@@ -529,7 +529,7 @@ void ObjectState::write(unsigned offset, ref<Expr> value) {
     unsigned idx = Context::get().isLittleEndian() ? i : (NumBytes - i - 1);
     write8(offset + idx, ExtractExpr::create(value, 8 * i, Expr::Int8));
   }
-} 
+}
 
 void ObjectState::write16(unsigned offset, uint16_t value) {
   unsigned NumBytes = 2;

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -476,6 +476,8 @@ ref<Expr> ObjectState::read(unsigned offset, Expr::Width width) const {
   // Treat bool specially, it is the only non-byte sized write we allow.
   if (width == Expr::Bool)
     return ExtractExpr::create(read8(offset), 0, Expr::Bool);
+  if (width == Expr::Int8)
+    return read8(offset);
 
   // Otherwise, follow the slow general case.
   unsigned NumBytes = width / 8;

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -266,6 +266,9 @@ private:
   void markByteUnflushed(unsigned offset);
   void setKnownSymbolic(unsigned offset, Expr *value);
 
+  /// Return true if object is only concrete
+  /// \return
+  bool isConcreteOnly() const;
   ArrayCache *getArrayCache() const;
 };
   

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -120,6 +120,15 @@ public:
   ref<Expr> getOffsetExpr(const ref<Expr> &pointer) const {
     return SubExpr::create(pointer, getBaseExpr());
   }
+
+  /// Return the offset of the object the pointer is pointing to.
+  /// \param pointer
+  /// \return offset with respect to this object
+  uint64_t getOffset(uint64_t pointer) const {
+    assert(pointer >= address);
+    return pointer - address;
+  }
+
   ref<Expr> getBoundsCheckPointer(const ref<Expr> &pointer) const {
     return getBoundsCheckOffset(getOffsetExpr(pointer));
   }
@@ -144,6 +153,17 @@ public:
                                                  Context::get().getPointerWidth()));
     } else {
       return ConstantExpr::alloc(0, Expr::Bool);
+    }
+  }
+
+  /// Return first invalid offset of this object if a size object should be read
+  /// \param bytes potential bytes-wide access
+  /// \return first invalid offset
+  uint64_t getBoundsCheckOffset(unsigned bytes) const {
+    if (bytes <= size) {
+      return size - bytes + 1;
+    } else {
+      return 0;
     }
   }
 

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -117,17 +117,18 @@ public:
   ref<ConstantExpr> getSizeExpr() const { 
     return ConstantExpr::create(size, Context::get().getPointerWidth());
   }
-  ref<Expr> getOffsetExpr(ref<Expr> pointer) const {
+  ref<Expr> getOffsetExpr(const ref<Expr> &pointer) const {
     return SubExpr::create(pointer, getBaseExpr());
   }
-  ref<Expr> getBoundsCheckPointer(ref<Expr> pointer) const {
+  ref<Expr> getBoundsCheckPointer(const ref<Expr> &pointer) const {
     return getBoundsCheckOffset(getOffsetExpr(pointer));
   }
-  ref<Expr> getBoundsCheckPointer(ref<Expr> pointer, unsigned bytes) const {
+  ref<Expr> getBoundsCheckPointer(const ref<Expr> &pointer,
+                                  unsigned bytes) const {
     return getBoundsCheckOffset(getOffsetExpr(pointer), bytes);
   }
 
-  ref<Expr> getBoundsCheckOffset(ref<Expr> offset) const {
+  ref<Expr> getBoundsCheckOffset(const ref<Expr> &offset) const {
     if (size==0) {
       return EqExpr::create(offset, 
                             ConstantExpr::alloc(0, Context::get().getPointerWidth()));
@@ -135,7 +136,8 @@ public:
       return UltExpr::create(offset, getSizeExpr());
     }
   }
-  ref<Expr> getBoundsCheckOffset(ref<Expr> offset, unsigned bytes) const {
+  ref<Expr> getBoundsCheckOffset(const ref<Expr> &offset,
+                                 unsigned bytes) const {
     if (bytes<=size) {
       return UltExpr::create(offset, 
                              ConstantExpr::alloc(size - bytes + 1, 
@@ -217,13 +219,13 @@ public:
   // make contents all concrete and random
   void initializeToRandom();
 
-  ref<Expr> read(ref<Expr> offset, Expr::Width width) const;
+  ref<Expr> read(const ref<Expr> &offset, Expr::Width width) const;
   ref<Expr> read(unsigned offset, Expr::Width width) const;
   ref<Expr> read8(unsigned offset) const;
 
   // return bytes written.
-  void write(unsigned offset, ref<Expr> value);
-  void write(ref<Expr> offset, ref<Expr> value);
+  void write(unsigned offset, const ref<Expr> &value);
+  void write(const ref<Expr> &offset, const ref<Expr> &value);
 
   void write8(unsigned offset, uint8_t value);
   void write16(unsigned offset, uint16_t value);
@@ -245,11 +247,11 @@ private:
 
   void makeSymbolic();
 
-  ref<Expr> read8(ref<Expr> offset) const;
-  void write8(unsigned offset, ref<Expr> value);
-  void write8(ref<Expr> offset, ref<Expr> value);
+  ref<Expr> read8(const ref<Expr> &offset) const;
+  void write8(unsigned offset, const ref<Expr> &value);
+  void write8(const ref<Expr> &offset, const ref<Expr> &value);
 
-  void fastRangeCheckOffset(ref<Expr> offset, unsigned *base_r, 
+  void fastRangeCheckOffset(const ref<Expr> &offset, unsigned *base_r,
                             unsigned *size_r) const;
   void flushRangeForRead(unsigned rangeBase, unsigned rangeSize) const;
   void flushRangeForWrite(unsigned rangeBase, unsigned rangeSize);

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -231,11 +231,11 @@ bool SpecialFunctionHandler::handle(ExecutionState &state,
 /****/
 
 // reads a concrete string from memory
-std::string 
-SpecialFunctionHandler::readStringAtAddress(ExecutionState &state, 
-                                            ref<Expr> addressExpr) {
+std::string
+SpecialFunctionHandler::readStringAtAddress(ExecutionState &state,
+                                            const ref<Expr> &_addressExpr) {
   ObjectPair op;
-  addressExpr = executor.toUnique(state, addressExpr);
+  ref<Expr> addressExpr = executor.toUnique(state, _addressExpr);
   if (!isa<ConstantExpr>(addressExpr)) {
     executor.terminateStateOnError(
         state, "Symbolic string pointer passed to one of the klee_ functions",

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -93,8 +93,9 @@ namespace klee {
 
     /* Convenience routines */
 
-    std::string readStringAtAddress(ExecutionState &state, ref<Expr> address);
-    
+    std::string readStringAtAddress(ExecutionState &state,
+                                    const ref<Expr> &address);
+
     /* Handlers */
 
 #define HANDLER(name) void name(ExecutionState &state, \

--- a/lib/Expr/AssignmentGenerator.h
+++ b/lib/Expr/AssignmentGenerator.h
@@ -34,9 +34,9 @@ private:
                                        Assignment *&a, Expr::Width width,
                                        bool sign);
 
-  static bool isReadExprAtOffset(ref<Expr> e, const ReadExpr *base,
-                                 ref<Expr> offset);
-  static ReadExpr *hasOrderedReads(ref<Expr> e);
+  static bool isReadExprAtOffset(const ref<Expr> &e, const ReadExpr *base,
+                                 const ref<Expr> &offset);
+  static ReadExpr *hasOrderedReads(const ref<Expr> &e);
 
   static ref<Expr> createSubExpr(const ref<Expr> &l, ref<Expr> &r);
   static ref<Expr> createAddExpr(const ref<Expr> &l, ref<Expr> &r);

--- a/lib/Expr/Constraints.cpp
+++ b/lib/Expr/Constraints.cpp
@@ -35,7 +35,8 @@ private:
   ref<Expr> src, dst;
 
 public:
-  ExprReplaceVisitor(ref<Expr> _src, ref<Expr> _dst) : src(_src), dst(_dst) {}
+  ExprReplaceVisitor(ref<Expr> _src, ref<Expr> _dst)
+      : src(std::move(_src)), dst(std::move(_dst)) {}
 
   Action visitExpr(const Expr &e) {
     if (e == *src.get()) {
@@ -95,11 +96,11 @@ bool ConstraintManager::rewriteConstraints(ExprVisitor &visitor) {
   return changed;
 }
 
-void ConstraintManager::simplifyForValidConstraint(ref<Expr> e) {
-  // XXX 
+void ConstraintManager::simplifyForValidConstraint(const ref<Expr> &e) {
+  // XXX
 }
 
-ref<Expr> ConstraintManager::simplifyExpr(ref<Expr> e) const {
+ref<Expr> ConstraintManager::simplifyExpr(const ref<Expr> &e) const {
   if (isa<ConstantExpr>(e))
     return e;
 
@@ -124,7 +125,7 @@ ref<Expr> ConstraintManager::simplifyExpr(ref<Expr> e) const {
   return ExprReplaceVisitor2(equalities).visit(e);
 }
 
-void ConstraintManager::addConstraintInternal(ref<Expr> e) {
+void ConstraintManager::addConstraintInternal(const ref<Expr> &e) {
   // rewrite any known equalities and split Ands into different conjuncts
 
   switch (e->getKind()) {
@@ -164,7 +165,6 @@ void ConstraintManager::addConstraintInternal(ref<Expr> e) {
   }
 }
 
-void ConstraintManager::addConstraint(ref<Expr> e) {
-  e = simplifyExpr(e);
-  addConstraintInternal(e);
+void ConstraintManager::addConstraint(const ref<Expr> &e) {
+  addConstraintInternal(simplifyExpr(e));
 }

--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -312,11 +312,11 @@ void Expr::printWidth(llvm::raw_ostream &os, Width width) {
   }
 }
 
-ref<Expr> Expr::createImplies(ref<Expr> hyp, ref<Expr> conc) {
+ref<Expr> Expr::createImplies(const ref<Expr> &hyp, const ref<Expr> &conc) {
   return OrExpr::create(Expr::createIsZero(hyp), conc);
 }
 
-ref<Expr> Expr::createIsZero(ref<Expr> e) {
+ref<Expr> Expr::createIsZero(const ref<Expr> &e) {
   return EqExpr::create(e, ConstantExpr::create(0, e->getWidth()));
 }
 
@@ -493,7 +493,7 @@ ref<ConstantExpr> ConstantExpr::Sge(const ref<ConstantExpr> &RHS) {
 
 /***/
 
-ref<Expr>  NotOptimizedExpr::create(ref<Expr> src) {
+ref<Expr> NotOptimizedExpr::create(const ref<Expr> &src) {
   return NotOptimizedExpr::alloc(src);
 }
 
@@ -530,7 +530,7 @@ unsigned Array::computeHash() {
 }
 /***/
 
-ref<Expr> ReadExpr::create(const UpdateList &ul, ref<Expr> index) {
+ref<Expr> ReadExpr::create(const UpdateList &ul, const ref<Expr> &index) {
   // rollback update nodes if possible
 
   // Iterate through the update list from the most recent to the
@@ -584,7 +584,8 @@ int ReadExpr::compareContents(const Expr &b) const {
   return updates.compare(static_cast<const ReadExpr&>(b).updates);
 }
 
-ref<Expr> SelectExpr::create(ref<Expr> c, ref<Expr> t, ref<Expr> f) {
+ref<Expr> SelectExpr::create(const ref<Expr> &c, const ref<Expr> &t,
+                             const ref<Expr> &f) {
   Expr::Width kt = t->getWidth();
 
   assert(c->getWidth()==Bool && "type mismatch");
@@ -667,7 +668,7 @@ ref<Expr> ConcatExpr::create8(const ref<Expr> &kid1, const ref<Expr> &kid2,
 
 /***/
 
-ref<Expr> ExtractExpr::create(ref<Expr> expr, unsigned off, Width w) {
+ref<Expr> ExtractExpr::create(const ref<Expr> &expr, unsigned off, Width w) {
   unsigned kw = expr->getWidth();
   assert(w > 0 && off + w <= kw && "invalid extract");
   

--- a/lib/Expr/ExprPPrinter.cpp
+++ b/lib/Expr/ExprPPrinter.cpp
@@ -72,23 +72,22 @@ private:
 
   /// shouldPrintWidth - Predicate for whether this expression should
   /// be printed with its width.
-  bool shouldPrintWidth(ref<Expr> e) {
+  bool shouldPrintWidth(const ref<Expr> &e) const {
     if (PCAllWidths)
       return true;
     return e->getWidth() != Expr::Bool;
   }
 
-  bool isVerySimple(const ref<Expr> &e) { 
+  bool isVerySimple(const ref<Expr> &e) const {
     return isa<ConstantExpr>(e) || bindings.find(e)!=bindings.end();
   }
 
-  bool isVerySimpleUpdate(const UpdateNode *un) {
+  bool isVerySimpleUpdate(const UpdateNode *un) const {
     return !un || updateBindings.find(un)!=updateBindings.end();
   }
 
-
   // document me!
-  bool isSimple(const ref<Expr> &e) { 
+  bool isSimple(const ref<Expr> &e) const {
     if (isVerySimple(e)) {
       return true;
     } else if (const ReadExpr *re = dyn_cast<ReadExpr>(e)) {
@@ -103,13 +102,13 @@ private:
     }
   }
 
-  bool hasSimpleKids(const Expr *ep) {
-      for (unsigned i=0; i<ep->getNumKids(); i++)
-        if (!isSimple(ep->getKid(i)))
-          return false;
-      return true;
+  bool hasSimpleKids(const Expr *ep) const {
+    for (unsigned i = 0; i < ep->getNumKids(); i++)
+      if (!isSimple(ep->getKid(i)))
+        return false;
+    return true;
   }
-  
+
   void scanUpdate(const UpdateNode *un) {
     // FIXME: This needs to be non-recursive.
     if (un) {
@@ -199,7 +198,7 @@ private:
     PC << " @ " << updates.root->name;
   }
 
-  void printWidth(PrintContext &PC, ref<Expr> e) {
+  void printWidth(PrintContext &PC, const ref<Expr> &e) {
     if (!shouldPrintWidth(e))
       return;
 
@@ -212,7 +211,6 @@ private:
     PC << e->getWidth();
   }
 
-  
   bool isReadExprAtOffset(ref<Expr> e, const ReadExpr *base, ref<Expr> offset) {
     const ReadExpr *re = dyn_cast<ReadExpr>(e.get());
       

--- a/lib/Expr/ExprUtil.cpp
+++ b/lib/Expr/ExprUtil.cpp
@@ -16,9 +16,8 @@
 
 using namespace klee;
 
-void klee::findReads(ref<Expr> e, 
-                     bool visitUpdates,
-                     std::vector< ref<ReadExpr> > &results) {
+void klee::findReads(const ref<Expr> &e, bool visitUpdates,
+                     std::vector<ref<ReadExpr>> &results) {
   // Invariant: \forall_{i \in stack} !i.isConstant() && i \in visited 
   std::vector< ref<Expr> > stack;
   ExprHashSet visited;
@@ -129,8 +128,8 @@ void klee::findSymbolicObjects(InputIterator begin,
     of.visit(*begin);
 }
 
-void klee::findSymbolicObjects(ref<Expr> e,
-                               std::vector<const Array*> &results) {
+void klee::findSymbolicObjects(const ref<Expr> &e,
+                               std::vector<const Array *> &results) {
   findSymbolicObjects(&e, &e+1, results);
 }
 

--- a/lib/Solver/CachingSolver.cpp
+++ b/lib/Solver/CachingSolver.cpp
@@ -22,7 +22,7 @@ using namespace klee;
 
 class CachingSolver : public SolverImpl {
 private:
-  ref<Expr> canonicalizeQuery(ref<Expr> originalQuery,
+  ref<Expr> canonicalizeQuery(const ref<Expr> &originalQuery,
                               bool &negationUsed);
 
   void cacheInsert(const Query& query,
@@ -33,7 +33,7 @@ private:
   
   struct CacheEntry {
     CacheEntry(const ConstraintManager &c, ref<Expr> q)
-      : constraints(c), query(q) {}
+        : constraints(c), query(std::move(q)) {}
 
     CacheEntry(const CacheEntry &ce)
       : constraints(ce.constraints), query(ce.query) {}
@@ -91,7 +91,7 @@ public:
 /** @returns the canonical version of the given query.  The reference
     negationUsed is set to true if the original query was negated in
     the canonicalization process. */
-ref<Expr> CachingSolver::canonicalizeQuery(ref<Expr> originalQuery,
+ref<Expr> CachingSolver::canonicalizeQuery(const ref<Expr> &originalQuery,
                                            bool &negationUsed) {
   ref<Expr> negatedQuery = Expr::createIsZero(originalQuery);
 


### PR DESCRIPTION
KLEE can sometimes be slower when executing concrete - one reason is that is has not been optimised for it, this PR tries to reduce the overhead a bit. It reduces KLEE's execution time by 56% for the example given in #1255 .

This PR consists of:
* reducing the overhead of `ref<Expr>` at several places - this avoids incrementing/decrementing the reference counter in the first place
* directly writing and reading to/from memory objects if the access and the object is only concrete
* last, fast out-of-bounds check if address is concrete

Although it elevates the problem a bit, one of the reason `lli` is faster are the way `mem*` operations are handled.
KLEE lowers them to calls to the intrinsic library, which does those operations byte-by-byte.
And each byte needs the whole chain of lookup object - access object, while SSE can do the whole vector operations magic.
In this case, maybe we should think about handling more cases in KLEE again, this might be also faster for the symbolic case.