### PR TITLE
[Module] Disable asm lifting for memory fences with return values

### DIFF
--- a/lib/Module/RaiseAsm.cpp
+++ b/lib/Module/RaiseAsm.cpp
@@ -10,14 +10,15 @@
 #include "Passes.h"
 #include "klee/Config/Version.h"
 #include "klee/Support/ErrorHandling.h"
+
+#include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InlineAsm.h"
-#include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Instructions.h"
-
-#include "llvm/Support/raw_ostream.h"
+#include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/TargetRegistry.h"
+#include "llvm/Support/raw_ostream.h"
 #if LLVM_VERSION_CODE >= LLVM_VERSION(6, 0)
 #include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
@@ -63,7 +64,8 @@ bool RaiseAsmPass::runOnInstruction(Module &M, Instruction *I) {
        triple.getOS() == llvm::Triple::Darwin ||
        triple.getOS() == llvm::Triple::FreeBSD)) {
 
-    if (ia->getAsmString() == "" && ia->hasSideEffects()) {
+    if (ia->getAsmString() == "" && ia->hasSideEffects() &&
+        ia->getFunctionType()->getReturnType()->isVoidTy()) {
       IRBuilder<> Builder(I);
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 9)
       Builder.CreateFence(llvm::AtomicOrdering::SequentiallyConsistent);

--- a/test/Feature/asm_lifting.ll
+++ b/test/Feature/asm_lifting.ll
@@ -1,0 +1,27 @@
+; RUN: llvm-as %s -f -o %t1.bc
+; RUN: rm -rf %t.klee-out
+; RUN: %klee --output-dir=%t.klee-out --optimize=false %t1.bc
+; RUN: FileCheck %s --input-file=%t.klee-out/assembly.ll
+
+define i32 @asm_free() nounwind {
+entry:
+  call void asm sideeffect "", "~{memory},~{dirflag},~{fpsr},~{flags}"()
+  ; Make sure simple memory barrier is lifted
+  ; CHECK-NOT: call void asm sideeffect "", "~{memory},~{dirflag},~{fpsr},~{flags}"()
+  ret i32 0
+}
+
+define i32 @unlifted_asm() nounwind {
+entry:
+  %0 = alloca [47 x i8], align 16
+  %1 = getelementptr inbounds [47 x i8], [47 x i8]* %0, i64 0, i64 0
+  ; Make sure memory barrier with function arguments is kept
+  %2 = call i8* asm sideeffect "", "=r,0,~{memory},~{dirflag},~{fpsr},~{flags}"(i8* nonnull %1)
+  ; CHECK: %2 = call i8* asm sideeffect "", "=r,0,~{memory},~{dirflag},~{fpsr},~{flags}"(i8* nonnull %1)
+  ret i32 0
+}
+
+define i32 @main() nounwind {
+entry:
+  ret i32 0
+}


### PR DESCRIPTION
ASM memory barriers with operands might be used to propagate values as result of their operation.
This is currently not supported.

Tighten condition to not lift those optimisations.

Fixes #1252