### PR TITLE
Handle global variables

### DIFF
--- a/lib/Module/ModuleUtil.cpp
+++ b/lib/Module/ModuleUtil.cpp
@@ -280,22 +280,22 @@ Function *klee::getDirectCallTarget(
 #endif
         v = ga->getAliasee();
       } else {
-        v = NULL;
+        v = nullptr;
       }
     } else if (llvm::ConstantExpr *ce = dyn_cast<llvm::ConstantExpr>(v)) {
       viaConstantExpr = true;
       v = ce->getOperand(0)->stripPointerCasts();
     } else {
-      v = NULL;
+      v = nullptr;
     }
-  } while (v != NULL);
+  } while (v != nullptr);
 
   // NOTE: This assert may fire, it isn't necessarily a problem and
   // can be disabled, I just wanted to know when and if it happened.
   (void) viaConstantExpr;
   assert((!viaConstantExpr) &&
          "FIXME: Unresolved direct target for a constant expression");
-  return NULL;
+  return nullptr;
 }
 
 static bool valueIsOnlyCalled(const Value *v) {

--- a/lib/Module/ModuleUtil.cpp
+++ b/lib/Module/ModuleUtil.cpp
@@ -263,7 +263,14 @@ Function *klee::getDirectCallTarget(
   // Walk through aliases and bitcasts to try to find
   // the function being called.
   do {
-    if (Function *f = dyn_cast<Function>(v)) {
+    if (isa<llvm::GlobalVariable>(v)) {
+      // We don't care how we got this GlobalVariable
+      viaConstantExpr = false;
+
+      // Global variables won't be a direct call target. Instead, their
+      // value need to be read and is handled as indirect call target.
+      v = nullptr;
+    } else if (Function *f = dyn_cast<Function>(v)) {
       return f;
     } else if (llvm::GlobalAlias *ga = dyn_cast<GlobalAlias>(v)) {
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 9)

--- a/test/Feature/GlobalVariable.ll
+++ b/test/Feature/GlobalVariable.ll
@@ -1,0 +1,28 @@
+; RUN: llvm-as %s -f -o %t1.bc
+; RUN: rm -rf %t.klee-out
+; Run KLEE and expect it to error out but not crash
+; RUN: not %klee --output-dir=%t.klee-out --optimize=false %t1.bc 2> %t2
+; Check that it could not find an initializer for the external_function global
+; RUN: FileCheck %s --input-file %t2
+; CHECK: ERROR: Unable to load symbol(external_function) while initializing globals
+
+@external_function = extern_weak global i8
+@bar = internal thread_local global <{ [56 x i8] }> zeroinitializer, align 32
+@handle = global i8* null, align 8
+
+define internal void @foo(i8* nocapture) {
+entry:
+    ret void
+}
+
+define i32 @main(i32 %argc, i8** nocapture %argv) nounwind readnone {
+entry:
+  br i1 icmp ne (i8* @external_function, i8* null), label %bbtrue, label %bbfalse
+
+bbtrue:
+  %0 = tail call i32 bitcast (i8* @external_function to i32 (void (i8*)*, i8*, i8*)*)(void (i8*)* nonnull @foo, i8* getelementptr inbounds (<{ [56 x i8] }>, <{ [56 x i8] }>* @bar, i64 0, i32 0, i64 0), i8* bitcast (i8** @handle to i8*))
+  ret i32 0
+
+bbfalse:
+  ret i32 1
+}


### PR DESCRIPTION
Global variables were not handled correctly while validating direct call targets.
This lead to crashes of KLEE.

This PR adds this case to handle direct call targets.