### PR TITLE
Revert to FreeBSD 12.1-STABLE (13.0-CURRENT has started running into …

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ task:
   freebsd_instance:
     matrix:
       - image_family: freebsd-11-3-snap
-      - image_family: freebsd-13-0-snap
+      - image_family: freebsd-12-1-snap
   deps_script:
     - sed -i.bak -e 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
     - env ASSUME_ALWAYS_YES=yes pkg bootstrap -f


### PR DESCRIPTION
…issues)

The issue with 13.0-CURRENT is:
```
Newer FreeBSD version for package py37-pyfasta:
To ignore this error set IGNORE_OSVERSION=yes
- package: 1300099
- running kernel: 1300097
Ignore the mismatch and continue? [Y/n]: pkg: repository FreeBSD contains packages for wrong OS version: FreeBSD:13:amd64
```