### PR TITLE
Layout the PTree in a more cache friendly way

### DIFF
--- a/lib/Core/PTree.cpp
+++ b/lib/Core/PTree.cpp
@@ -44,17 +44,17 @@ void PTree::attach(PTreeNode *node, ExecutionState *leftState, ExecutionState *r
   node->left = PTreeNodePtr(new PTreeNode(node, leftState));
   // The current node inherits the tag
   uint8_t currentNodeTag = root.getInt();
-  if (node->parent)
-    currentNodeTag = node->parent->left.getPointer() == node
-                         ? node->parent->left.getInt()
-                         : node->parent->right.getInt();
+  if (node->parent.getPointer())
+    currentNodeTag = node->parent.getPointer()->left.getPointer() == node
+                         ? node->parent.getPointer()->left.getInt()
+                         : node->parent.getPointer()->right.getInt();
   node->right = PTreeNodePtr(new PTreeNode(node, rightState), currentNodeTag);
 }
 
 void PTree::remove(PTreeNode *n) {
   assert(!n->left.getPointer() && !n->right.getPointer());
   do {
-    PTreeNode *p = n->parent;
+    PTreeNode *p = n->parent.getPointer();
     if (p) {
       if (n == p->left.getPointer()) {
         p->left = PTreeNodePtr(nullptr);

--- a/lib/Core/PTree.h
+++ b/lib/Core/PTree.h
@@ -25,9 +25,15 @@ namespace klee {
   constexpr int PtrBitCount = 3;
   using PTreeNodePtr = llvm::PointerIntPair<PTreeNode *, PtrBitCount, uint8_t>;
 
+  /* Used to implement van Embde Boas partitioning of the PTree for good cache effiecency.
+     The integer part stores the number of other PTreeNodes in this chunk of memory. For example
+     2 means there is space for 2 other nodes.
+  */
+  using PTreeParentPtr = PTreeNodePtr;
+
   class PTreeNode {
   public:
-    PTreeNode *parent = nullptr;
+    PTreeParentPtr parent{nullptr, 0};
 
     PTreeNodePtr left; 
     PTreeNodePtr right;

--- a/lib/Core/PTree.h
+++ b/lib/Core/PTree.h
@@ -41,6 +41,7 @@ namespace klee {
 
     PTreeNode(const PTreeNode&) = delete;
     PTreeNode(PTreeNode *parent, ExecutionState *state);
+    PTreeNode(PTreeNode *parent, uint8_t, ExecutionState *state);
     ~PTreeNode() = default;
   };
 

--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -293,7 +293,7 @@ void RandomPathSearcher::update(ExecutionState *current,
                                 const std::vector<ExecutionState *> &removedStates) {
   // insert states
   for (auto es : addedStates) {
-    PTreeNode *pnode = es->ptreeNode, *parent = pnode->parent;
+    PTreeNode *pnode = es->ptreeNode, *parent = pnode->parent.getPointer();
     PTreeNodePtr *childPtr;
 
     childPtr = parent ? ((parent->left.getPointer() == pnode) ? &parent->left
@@ -303,7 +303,7 @@ void RandomPathSearcher::update(ExecutionState *current,
       childPtr->setInt(childPtr->getInt() | idBitMask);
       pnode = parent;
       if (pnode)
-        parent = pnode->parent;
+        parent = pnode->parent.getPointer();
 
       childPtr = parent
                      ? ((parent->left.getPointer() == pnode) ? &parent->left
@@ -314,7 +314,7 @@ void RandomPathSearcher::update(ExecutionState *current,
 
   // remove states
   for (auto es : removedStates) {
-    PTreeNode *pnode = es->ptreeNode, *parent = pnode->parent;
+    PTreeNode *pnode = es->ptreeNode, *parent = pnode->parent.getPointer();
 
     while (pnode && !IS_OUR_NODE_VALID(pnode->left) &&
            !IS_OUR_NODE_VALID(pnode->right)) {
@@ -326,7 +326,7 @@ void RandomPathSearcher::update(ExecutionState *current,
       childPtr->setInt(childPtr->getInt() & ~idBitMask);
       pnode = parent;
       if (pnode)
-        parent = pnode->parent;
+        parent = pnode->parent.getPointer();
     }
   }
 }


### PR DESCRIPTION
Most of the time in the RandomPathSearcher is spent on loading the PTreeNodes, so it makes sense to lay them out better. I've also done a small end to end test on `tail.bc`.  I've taken the algorithm from https://jiahai-feng.github.io/posts/cache-oblivious-algorithms/ and http://erikdemaine.org/papers/BRICS2002/paper.pdf (Figure 4)

```
./klee --search=random-path --write-no-tests -libc=uclibc -posix-runtime  -ptree-chunk=7 -max-instructions=25232069 -use-forked-solver=0 -rewrite-equalities=0 tail.bc -sym-arg 2 -sym-arg 2 -sym-stdin 1
```

This run has about 25% of solver time and the rest of arguments are making sure tail runs as fast as possible so that the RandomPathSearcher takes a large proprotion of execution time (about 13%).


Here are the results:

```

Subtree size | Chunk size | Time (s) | Memory (MB)
-- | -- | -- | --
+--------------+------------+----------+-------------+
| Subtree size | Chunk size | Time (s) | Memory (MB) |
+--------------+------------+----------+-------------+
| (upstream) 1 |          0 |    62.68 |         535 |
| 3            |          1 |    59.13 |         533 |
| 7            |          2 |    58.53 |         537 |
| 15           |          3 |    57.94 |         537 |
| 31           |          4 |    58.75 |         541 |
| 63           |          5 |    58.59 |         547 |
| 127          |          6 |    57.69 |         550 |
| 255          |          7 |    59.98 |         572 |
+--------------+------------+----------+-------------+
```
So this PR, shaves off 2-3s in a 60s run. THe flamegraph also shows that RP searcher only takes about 7% of the execution time.

I'm not sure what's a good way of picking Subtree size. `3` is the safe choice that gets most of the benefit, but it seems like we could go to 7-15 without too much space waste.  Currently I also have this controlable via command line option, but it might make sense to make it compile time.
```