### PR TITLE
Stub definition of __cxa_thread_atexit_impl

### DIFF
--- a/runtime/klee-libc/__cxa_atexit.c
+++ b/runtime/klee-libc/__cxa_atexit.c
@@ -47,3 +47,8 @@ int __cxa_atexit(void (*fn)(void*),
   return 0;
 }
 
+// This variant is part of more recent glibc versions and
+// is required by the Rust standard library
+int __cxa_thread_atexit_impl(void (*fn)(void*), void *arg, void *dso_handle) {
+  return __cxa_atexit(fn, arg, dso_handle);
+}

--- a/test/Runtime/klee-libc/cxa_thread_atexit_impl.c
+++ b/test/Runtime/klee-libc/cxa_thread_atexit_impl.c
@@ -1,0 +1,20 @@
+// RUN: %clang %s -emit-llvm %O0opt -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error --libc=klee %t1.bc
+
+// just make sure __cxa_thread_atexit_impl works ok
+
+#include <assert.h>
+
+extern int __cxa_thread_atexit_impl(void (*)(void*), void*, void *);
+
+static int x; // a global whose address we can take
+
+void boo(void *h) {
+  assert(h == (void*)&x);
+}
+
+int main() {
+  __cxa_thread_atexit_impl(boo, (void*)&x, (void*)0);
+  return 0;
+}


### PR DESCRIPTION
This function is usually a weak symbol but, in KLEE, this behaves like a call
to an unknown function and chaos ensues.
Worse, it happens just as the program is cleanly shutting itself down,
so programs that are cleanly exiting crash with the wrong message.