### PR TITLE
Tweak LLVM version string parser: support rust

### DIFF
--- a/cmake/find_llvm.cmake
+++ b/cmake/find_llvm.cmake
@@ -72,7 +72,7 @@ else()
   # Get LLVM version
   _run_llvm_config(LLVM_PACKAGE_VERSION "--version")
   # Try x.y.z patern
-  set(_llvm_version_regex "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(svn|git)?$")
+  set(_llvm_version_regex "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(svn|git|-rust-dev)?$")
   if ("${LLVM_PACKAGE_VERSION}" MATCHES "${_llvm_version_regex}")
     string(REGEX REPLACE
       "${_llvm_version_regex}"


### PR DESCRIPTION
This change allows KLEE to be configured to use the LLVM version
that comes with the Rust compiler instead of a standard version.

e.g., one might configure with

-DLLVM_CONFIG_BINARY=${RUST_SRC}/build/x86_64-unknown-linux-gnu/llvm/bin/llvm-config

For which typical output might be

    10.0.1-rust-dev