### PR TITLE
With KLEE's libc, this test is not guaranteed to call the static dest…

### DIFF
--- a/test/CXX/StaticDestructor.cpp
+++ b/test/CXX/StaticDestructor.cpp
@@ -1,21 +1,20 @@
-// don't optimize this, llvm likes to turn the *p into unreachable
+// REQUIRES: uclibc
 
 // RUN: %clangxx %s -emit-llvm -g %O0opt -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --optimize=false --libc=klee --write-no-tests %t1.bc 2> %t1.log
+// RUN: %klee --output-dir=%t.klee-out --libc=uclibc %t1.bc 2> %t1.log
 // RUN: FileCheck --input-file %t1.log %s
 
 #include <cassert>
 
 class Test {
-  int *p;
+  int x;
 
 public:
-  Test() : p(0) {}
+  Test() : x(13) {}
   ~Test() {
-    assert(!p);
-    // CHECK: :[[@LINE+1]]: memory error
-    assert(*p == 10); // crash here
+    // CHECK: :[[@LINE+1]]: divide by zero
+    x = x / (x - 13);
   }
 };
 


### PR DESCRIPTION
…ructors (observed on macOS). Also made the test less fragile with respect to optimizations.