### PR TITLE
Fix travis mac build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,13 +139,14 @@ addons:
   apt:
     packages:
       - docker-ce
+  homebrew:
+    packages:
+      - bash
 cache:
   ccache: true
   apt: true
   directories:
     - $HOME/Library/Caches/Homebrew
-before_install:
-   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export HOMEBREW_NO_INSTALL_CLEANUP=1 && brew update && brew install --verbose --debug bash; fi
 
 script:
     # Build KLEE and run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,8 +145,6 @@ addons:
 cache:
   ccache: true
   apt: true
-  directories:
-    - $HOME/Library/Caches/Homebrew
 
 script:
     # Build KLEE and run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,8 @@ addons:
       - docker-ce
   homebrew:
     packages:
-      - bash
+    - bash
+    update: true
 cache:
   ccache: true
   apt: true


### PR DESCRIPTION
Potential fix for the build issue for the Mac platform.

Mainly, it's switching to the travis-provided means of handling brew packages.
Beside that, older infrastructure parts are removed that are not needed in this context.