### PR TITLE
Fix codecov upload

### DIFF
--- a/scripts/build/run-tests.sh
+++ b/scripts/build/run-tests.sh
@@ -91,7 +91,7 @@ function upload_coverage() {
   file="$1"
   tags="$2"
   cd /home/klee/klee_src
-  bash <(curl -s https://codecov.io/bash) -X gcov -R /tmp/klee_src/ -y .codecov.yml -f /home/klee/klee_build/coverage_all.info."${file}" -F "$tags"
+  bash <(curl -s https://codecov.io/bash) -X gcov -R /tmp/klee_src/ -f /home/klee/klee_build/coverage_all.info."${file}" -F "$tags"
 }
 
 function run_docker() {


### PR DESCRIPTION
Argument `-y` has been removed from the upload script.
https://github.com/codecov/codecov-bash/commit/c2f935a0dd0590d20296e95a759782e32b311b34

But `.codecov.yml` is now supported