### PR TITLE
Replace llvm::CallSite with llvm::CallBase (LLVM 11 1/2)

### DIFF
--- a/include/klee/Support/ModuleUtil.h
+++ b/include/klee/Support/ModuleUtil.h
@@ -12,7 +12,11 @@
 
 #include "klee/Config/Version.h"
 
+#if LLVM_VERSION_CODE >= LLVM_VERSION(8, 0)
+#include "llvm/IR/InstrTypes.h"
+#else
 #include "llvm/IR/CallSite.h"
+#endif
 #include "llvm/IR/Module.h"
 
 #include <memory>
@@ -41,9 +45,16 @@ linkModules(std::vector<std::unique_ptr<llvm::Module>> &modules,
 /// another possibility).
 ///
 /// If `moduleIsFullyLinked` is set to true it will be assumed that the
-///  module containing the `llvm::CallSite` is fully linked. This assumption
-///  allows resolution of functions that are marked as overridable.
-llvm::Function *getDirectCallTarget(llvm::CallSite, bool moduleIsFullyLinked);
+///  module containing the `llvm::CallSite` (`llvm::CallBase` on LLVM 8+)
+///  is fully linked. This assumption allows resolution of functions
+///  that are marked as overridable.
+llvm::Function *getDirectCallTarget(
+#if LLVM_VERSION_CODE >= LLVM_VERSION(8, 0)
+    const llvm::CallBase &cb,
+#else
+    const llvm::CallSite &cs,
+#endif
+    bool moduleIsFullyLinked);
 
 /// Return true iff the given Function value is used in something
 /// other than a direct call (or a constant expression that

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -55,7 +55,9 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/BasicBlock.h"
+#if LLVM_VERSION_CODE < LLVM_VERSION(8, 0)
 #include "llvm/IR/CallSite.h"
+#endif
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Function.h"
@@ -1570,13 +1572,17 @@ void Executor::executeCall(ExecutionState &state, KInstruction *ki, Function *f,
       uint64_t offsets[callingArgs]; // offsets of variadic arguments
       uint64_t argWidth;             // width of current variadic argument
 
-      CallSite cs(i);
+#if LLVM_VERSION_CODE >= LLVM_VERSION(8, 0)
+      const CallBase &cs = cast<CallBase>(*i);
+#else
+      const CallSite cs(i);
+#endif
       for (unsigned k = funcArgs; k < callingArgs; k++) {
         if (cs.isByValArgument(k)) {
 #if LLVM_VERSION_CODE >= LLVM_VERSION(9, 0)
           Type *t = cs.getParamByValType(k);
 #else
-          auto arg = cs.getArgument(k);
+          auto arg = cs.getArgOperand(k);
           Type *t = arg->getType();
           assert(t->isPointerTy());
           t = t->getPointerElementType();
@@ -1770,8 +1776,13 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
           Expr::Width to = getWidthForLLVMType(t);
             
           if (from != to) {
-            CallSite cs = (isa<InvokeInst>(caller) ? CallSite(cast<InvokeInst>(caller)) : 
-                           CallSite(cast<CallInst>(caller)));
+#if LLVM_VERSION_CODE >= LLVM_VERSION(8, 0)
+            const CallBase &cs = cast<CallBase>(*caller);
+#else
+            const CallSite cs(isa<InvokeInst>(caller)
+                                  ? CallSite(cast<InvokeInst>(caller))
+                                  : CallSite(cast<CallInst>(caller)));
+#endif
 
             // XXX need to check other param attrs ?
 #if LLVM_VERSION_CODE >= LLVM_VERSION(5, 0)
@@ -2036,7 +2047,12 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     // Ignore debug intrinsic calls
     if (isa<DbgInfoIntrinsic>(i))
       break;
-    CallSite cs(i);
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(8, 0)
+    const CallBase &cs = cast<CallBase>(*i);
+#else
+    const CallSite cs(i);
+#endif
 
     unsigned numArgs = cs.arg_size();
     Value *fp = cs.getCalledValue();
@@ -4138,10 +4154,14 @@ size_t Executor::getAllocationAlignment(const llvm::Value *allocSite) const {
     type = AI->getAllocatedType();
   } else if (isa<InvokeInst>(allocSite) || isa<CallInst>(allocSite)) {
     // FIXME: Model the semantics of the call to use the right alignment
+#if LLVM_VERSION_CODE >= LLVM_VERSION(8, 0)
+    const CallBase &cs = cast<CallBase>(*allocSite);
+#else
     llvm::Value *allocSiteNonConst = const_cast<llvm::Value *>(allocSite);
-    const CallSite cs = (isa<InvokeInst>(allocSiteNonConst)
-                             ? CallSite(cast<InvokeInst>(allocSiteNonConst))
-                             : CallSite(cast<CallInst>(allocSiteNonConst)));
+    const CallSite cs(isa<InvokeInst>(allocSiteNonConst)
+                          ? CallSite(cast<InvokeInst>(allocSiteNonConst))
+                          : CallSite(cast<CallInst>(allocSiteNonConst)));
+#endif
     llvm::Function *fn =
         klee::getDirectCallTarget(cs, /*moduleIsFullyLinked=*/true);
     if (fn)

--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -26,7 +26,6 @@
 #include "klee/Support/ModuleUtil.h"
 #include "klee/System/Time.h"
 
-#include "llvm/IR/CallSite.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"


### PR DESCRIPTION
This is in preparation for LLVM 11 support as the `llvm:CallSite` class has been removed.
There is quite a lot of changes so I decided to split this PR in two parts.

