### PR TITLE
fix fabs intrinsic, implement fneg instruction

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2465,6 +2465,20 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Floating point instructions
 
+#if LLVM_VERSION_CODE >= LLVM_VERSION(8, 0)
+  case Instruction::FNeg: {
+    ref<ConstantExpr> arg =
+        toConstant(state, eval(ki, 0, state).value, "floating point");
+    if (!fpWidthToSemantics(arg->getWidth()))
+      return terminateStateOnExecError(state, "Unsupported FNeg operation");
+
+    llvm::APFloat Res(*fpWidthToSemantics(arg->getWidth()), arg->getAPValue());
+    Res = llvm::neg(Res);
+    bindLocal(ki, state, ConstantExpr::alloc(Res.bitcastToAPInt()));
+    break;
+  }
+#endif
+
   case Instruction::FAdd: {
     ref<ConstantExpr> left = toConstant(state, eval(ki, 0, state).value,
                                         "floating point");

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1420,7 +1420,7 @@ void Executor::executeCall(ExecutionState &state, KInstruction *ki, Function *f,
       break;
     case Intrinsic::fabs: {
       ref<ConstantExpr> arg =
-          toConstant(state, eval(ki, 0, state).value, "floating point");
+          toConstant(state, arguments[0], "floating point");
       if (!fpWidthToSemantics(arg->getWidth()))
         return terminateStateOnExecError(
             state, "Unsupported intrinsic llvm.fabs call");

--- a/test/Feature/FNeg.ll
+++ b/test/Feature/FNeg.ll
@@ -1,0 +1,19 @@
+; REQUIRES: geq-llvm-8.0
+; RUN: %llvmas %s -o %t.bc
+; RUN: rm -rf %t.klee-out
+; RUN: %klee -exit-on-error -output-dir=%t.klee-out -optimize=false %t.bc
+
+define i32 @main() {
+  %1 = fneg double 2.000000e-01
+  %2 = fcmp oeq double %1, -2.000000e-01
+  br i1 %2, label %success, label %fail
+
+success:
+  ret i32 0
+
+fail:
+  call void @abort()
+  unreachable
+}
+
+declare void @abort() noreturn nounwind

--- a/test/regression/2020-01-14-fabs-compare.c
+++ b/test/regression/2020-01-14-fabs-compare.c
@@ -1,0 +1,16 @@
+// RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --exit-on-error --output-dir=%t.klee-out %t.bc
+
+#include <math.h>
+#include <assert.h>
+
+int main(void) {
+  long double a = 0.25;
+  long double b = -a;
+
+  long double b_abs = fabsl(b);
+
+  assert(a == b_abs);
+  return 0;
+}


### PR DESCRIPTION
The first commit is a fix by @dlaprell for an issue he found in the `fabs` intrinsic implementation a while ago, along with a regression test. However, the test fails starting with LLVM 10, because floating point negation is now using the [fneg](https://releases.llvm.org/8.0.0/docs/LangRef.html#fneg-instruction) instruction introduced with LLVM 8 (instead of using `fsub`). The second commit therefore implements `fneg`, together with a test.