### PR TITLE
klee-stats: add (readable) csv format (--table-format=readable-csv/csv)

### DIFF
--- a/test/Feature/KleeStatsCsv.test
+++ b/test/Feature/KleeStatsCsv.test
@@ -1,0 +1,8 @@
+RUN: %klee-stats --table-format=csv %S/klee-stats/run | FileCheck --check-prefix=CHECK-CSV %s
+RUN: %klee-stats --table-format=readable-csv %S/klee-stats/run | FileCheck --check-prefix=CHECK-READABLECSV %s
+
+CHECK-CSV: Path,Instrs,Time(s),ICov(%),BCov(%),ICount,TSolver(%)
+CHECK-CSV: klee-stats/run,3,0.00,100.00,100.00,3,0.00
+
+CHECK-READABLECSV: Path          ,  Instrs,  Time(s),  ICov(%),  BCov(%),  ICount,  TSolver(%)
+CHECK-READABLECSV: klee-stats/run,       3,     0.00,   100.00,   100.00,       3,        0.00

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -372,13 +372,8 @@ def write_table(args, data, dirs, pr):
     table = final_table
 
     # Output table
-    if args.tableFormat != 'klee':
-        print(tabulate(
-            table, headers='keys',
-            tablefmt=args.tableFormat,
-            floatfmt='.{p}f'.format(p=2),
-            numalign='right', stralign='center'))
-    else:
+    # - KLEE standard format
+    if args.tableFormat == 'klee':
         stream = tabulate(
             table, headers='keys',
             tablefmt=KleeTable,
@@ -390,6 +385,27 @@ def write_table(args, data, dirs, pr):
             stream.insert(-2, stream[-1])
             stream = '\n'.join(stream)
         print(stream)
+    # - (readable) csv
+    elif args.tableFormat in ['csv', 'readable-csv']:
+        CsvTable = TableFormat(
+            lineabove = None, linebelowheader = None,
+            linebetweenrows = None, linebelow = None,
+            headerrow = DataRow('', ',', ''),
+            datarow = DataRow('', ',', ''),
+            padding = 0, with_header_hide = None)
+        print(tabulate(
+            table, headers='keys',
+            tablefmt=CsvTable,
+            floatfmt='.{p}f'.format(p=2),
+            numalign='decimal' if args.tableFormat == 'readable-csv' else None,
+            stralign='left' if args.tableFormat == 'readable-csv' else None))
+    # - user-defined
+    else:
+        print(tabulate(
+            table, headers='keys',
+            tablefmt=args.tableFormat,
+            floatfmt='.{p}f'.format(p=2),
+            numalign='right', stralign='center'))
 
 
 def main():
@@ -413,22 +429,22 @@ def main():
 
     if tabulate_available:
         parser.add_argument('--table-format',
-                              choices=['klee'] + list(_table_formats.keys()),
-                              dest='tableFormat', default='klee',
-                              help='Table format for the summary.')
+                            choices=['klee', 'csv', 'readable-csv'] + list(_table_formats.keys()),
+                            dest='tableFormat', default='klee',
+                            help='Table format for the summary.')
 
     parser.add_argument('--to-csv',
-                          action='store_true', dest='toCsv',
-                          help='Output stats as comma-separated values (CSV)')
+                        action='store_true', dest='toCsv',
+                        help='Output run.stats data as comma-separated values (CSV)')
     parser.add_argument('--grafana',
-                          action='store_true', dest='grafana',
-                          help='Start a grafana web server')
+                        action='store_true', dest='grafana',
+                        help='Start a grafana web server')
     parser.add_argument('--grafana-host', dest='grafana_host',
-                          help='IP address grafana web server should listen to',
-                          default="127.0.0.1")
+                        help='IP address grafana web server should listen to',
+                        default="127.0.0.1")
     parser.add_argument('--grafana-port', dest='grafana_port', type=int,
-                          help='Port grafana web server should listen to',
-                          default=5000)
+                        help='Port grafana web server should listen to',
+                        default=5000)
 
     # argument group for controlling output verboseness
     pControl = parser.add_mutually_exclusive_group(required=False)


### PR DESCRIPTION
While working on #1294 I realised that we only dump a single `run.stats` file via `--to-csv`. As it is often required to use the data in figures, spreadsheets etc. I've added two more table modes: `csv` and `rcsv` (readable/aligned csv). Both are based on tabulate. `csv` could be implemented without tabulate but for simplicity I re-used the code for `rcsv`.

- [x] The PR addresses a single issue.  In other words, if some parts of a PR could form another independent PR, you should break this PR into multiple smaller PRs.
- [x] There are no unnecessary commits. For instance, commits that fix issues with a previous commit in this PR are unnecessary and should be removed (you can find [documentation on squashing commits here](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#squash-your-changes)).
- [x] Larger PRs are divided into a logical sequence of commits.
- [x] Each commit has a meaningful message documenting what it does.
- [x] The code is commented.  In particular, newly added classes and functions should be documented.
- [ ] The patch is formatted via  [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (see also [git-clang-format](https://raw.githubusercontent.com/llvm/llvm-project/master/clang/tools/clang-format/git-clang-format) for Git integration).  Please only format the patch itself and code surrounding the patch, not entire files.  Divergences from clang-formatting are only rarely accepted, and only if they clearly improve code readability.
- [ ] Add test cases exercising the code you added or modified.  We expect [system and/or unit test cases](https://klee.github.io/docs/developers-guide/#regression-testing-framework) for all non-trivial changes.  After you submit your PR, you will be able to see a [Codecov report](https://docs.codecov.io/docs/pull-request-comments) telling you which parts of your patch are not covered by the regression test suite.  You will also be able to see if the Travis CI and Cirrus CI tests have passed.  If they don't, you should examine the failures and address them before the PR can be reviewed. 
- [x] Spellcheck all messages added to the codebase, all comments, as well as commit messages.
