### PR TITLE
Silence vptr-Sanitizer Report in Executor

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3315,14 +3315,15 @@ void Executor::computeOffsets(KGEPInstruction *kgepi, TypeIt ib, TypeIt ie) {
 }
 
 void Executor::bindInstructionConstants(KInstruction *KI) {
-  KGEPInstruction *kgepi = static_cast<KGEPInstruction*>(KI);
-
   if (GetElementPtrInst *gepi = dyn_cast<GetElementPtrInst>(KI->inst)) {
+    KGEPInstruction *kgepi = static_cast<KGEPInstruction *>(KI);
     computeOffsets(kgepi, gep_type_begin(gepi), gep_type_end(gepi));
   } else if (InsertValueInst *ivi = dyn_cast<InsertValueInst>(KI->inst)) {
+    KGEPInstruction *kgepi = static_cast<KGEPInstruction *>(KI);
     computeOffsets(kgepi, iv_type_begin(ivi), iv_type_end(ivi));
     assert(kgepi->indices.empty() && "InsertValue constant offset expected");
   } else if (ExtractValueInst *evi = dyn_cast<ExtractValueInst>(KI->inst)) {
+    KGEPInstruction *kgepi = static_cast<KGEPInstruction *>(KI);
     computeOffsets(kgepi, ev_type_begin(evi), ev_type_end(evi));
     assert(kgepi->indices.empty() && "ExtractValue constant offset expected");
   }


### PR DESCRIPTION
This PR gets rid of the following `-fsanitize=vptr` (of [UBSan](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html), requiring RTTI) message:
```
lib/Core/Executor.cpp:3318:28: runtime error: downcast of address 0x604000418b90 which does not point to an object of type 'KGEPInstruction'
0x604000418b90: note: object is of type 'klee::KInstruction'
 17 00 00 43  90 e9 49 03 00 00 00 00  b8 77 16 00 80 60 00 00  90 12 82 00 30 60 00 00  30 47 12 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'klee::KInstruction'
```

As the pointer never gets used after a wrong cast, this is rather an annoyance than an actual error.

***
- [X] The PR addresses a single issue.
- [X] There are no unnecessary commits.
- [ ] Larger PRs are divided into a logical sequence of commits.
- [X] Each commit has a meaningful message documenting what it does.
- [ ] The code is commented.
- [X] The patch is formatted via  [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (see also [git-clang-format](https://raw.githubusercontent.com/llvm/llvm-project/master/clang/tools/clang-format/git-clang-format) for Git integration).
- [ ] Add test cases exercising the code you added or modified. 
- [X] Spellcheck all messages added to the codebase, all comments, as well as commit messages.