### PR TITLE
Fix Runtime CFLAGS

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -34,17 +34,17 @@ foreach (bc_architecture ${bc_architectures})
 
         # Set specific compiler flags depending on the optimization
         if (bc_optimization STREQUAL "Release")
-            list(APPEND local_flags -O2 -DNDebug)
+            list(APPEND local_flags -O2 -DNDEBUG)
         elseif (bc_optimization STREQUAL "Release+Debug")
-            list(APPEND local_flags -O2 -g -DNDebug)
+            list(APPEND local_flags -O2 -g -D_DEBUG -DNDEBUG)
         elseif (bc_optimization STREQUAL "Release+Asserts")
-            list(APPEND local_flags -O2 -g)
+            list(APPEND local_flags -O2)
         elseif (bc_optimization STREQUAL "Release+Debug+Asserts")
-            list(APPEND local_flags -O2 -g)
+            list(APPEND local_flags -O2 -g -D_DEBUG)
         elseif (bc_optimization STREQUAL "Debug")
-            list(APPEND local_flags -g -DNDebug)
+            list(APPEND local_flags -g -D_DEBUG -DNDEBUG)
         elseif (bc_optimization STREQUAL "Debug+Asserts")
-            list(APPEND local_flags -g)
+            list(APPEND local_flags -g -D_DEBUG)
         else()
             message(FATAL_ERROR
                     "Optimization (\"${bc_optimization}\") for runtime library unknown.")
@@ -59,13 +59,12 @@ message(STATUS "LIB_BC_SUFFIX: ${LIB_BC_SUFFIX}")
 message(STATUS "KLEE_RUNTIME_DIRECTORY: ${KLEE_RUNTIME_DIRECTORY}")
 
 # Add additional setups if needed, e.g.
-# `list(APPEND LIB_BC_SUFFIX MY_SPECIAL_CONFIG)`
+# `list(APPEND LIB_BC_SUFFIX 64_MY_SPECIAL_CONFIG)`
 
-# Following define the specific flags: LIB_BC_FLAGS_*SUFFIX_FROM_ABOVE*
-set(LIB_BC_FLAGS_64)
-set(LIB_BC_FLAGS_32
-        -m32
-        )
+# Following define the specific flags: LIB_BC_FLAGS_*SUFFIX_FROM_ABOVE*, e.g.
+# ```set(LIB_BC_FLAGS_64_MY_SPECIAL_CONFIG
+#         -DSOME_DEFINE
+# )``
 
 # Common for all library configurations
 # Since the runtime now contains fortified libc functions, it is
@@ -74,8 +73,6 @@ set(LIB_BC_FLAGS_32
 set(COMMON_CC_FLAGS
         "-I${CMAKE_SOURCE_DIR}/include"
         "-I${CMAKE_BINARY_DIR}/include"
-        -g
-        -D_DEBUG
         -D_FORTIFY_SOURCE=0
         -D_GNU_SOURCE
         -D__STDC_LIMIT_MACROS


### PR DESCRIPTION
With this PR I fix various issues with the `CFLAGS` used for various runtime build types (introduced by #1250)

- `-DNDebug` -> `-DNDEBUG`: the latter is specified by the C standard, and a quick test with clang found that its preprocessor is case sensitive
- different flags for `Release{+Debug,}+Asserts`: before, both had the same flags
- `-g` is no longer part of common flags: i.e. it is no longer set for Release builds (before: Debug builds just had `-g -g`, while Release had `-g`)
- `-D_DEBUG` is now only set for debug builds
- removed unused `LIB_BC_FLAGS_{32,64}`: `-m32` is already added a few lines above
- added example, architecture prefix for specific flags: currently, there is no way to select a runtime that does not have an architecture prefix

***
- [X] The PR addresses a single issue.
- [X] There are no unnecessary commits.
- [X] Larger PRs are divided into a logical sequence of commits.
- [X] Each commit has a meaningful message documenting what it does.
- [ ] The code is commented.
- [ ] The patch is formatted via  [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (see also [git-clang-format](https://raw.githubusercontent.com/llvm/llvm-project/master/clang/tools/clang-format/git-clang-format) for Git integration).
- [ ] Add test cases exercising the code you added or modified. 
- [X] Spellcheck all messages added to the codebase, all comments, as well as commit messages.