### PR TITLE
retire some build system legacy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,6 @@ set(PACKAGE_URL "\"https://klee.github.io\"")
 
 ################################################################################
 # Sanity check - Disallow building in source.
-# Otherwise we would overwrite the Makefiles of the old build system.
 ################################################################################
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   message(FATAL_ERROR "In source builds are not allowed. You should invoke "
@@ -745,16 +744,6 @@ add_subdirectory(tools)
 ################################################################################
 option(ENABLE_UNIT_TESTS "Enable unit tests" OFF)
 option(ENABLE_SYSTEM_TESTS "Enable system tests" ON)
-
-# This provides a migration path for older build directories that have this
-# variable set in their cache. Leaving it behind could lead to confusion so
-# removing it is probably a good idea.
-# TODO: Remove this eventually (probably next release or something).
-if (DEFINED ENABLE_TESTS)
-  message(WARNING "You have the \"ENABLE_TESTS\" variable is your CMake cache."
-    "This variable no longer has any meaning so removing it from your cache")
-  unset(ENABLE_TESTS CACHE)
-endif()
 
 if (ENABLE_UNIT_TESTS OR ENABLE_SYSTEM_TESTS)
   message(STATUS "Testing is enabled")

--- a/README-CMake.md
+++ b/README-CMake.md
@@ -97,8 +97,6 @@ cmake -DCMAKE_BUILD_TYPE=Release /path/to/klee/src
    `USE_CMAKE_FIND_PACKAGE_LLVM` is `TRUE`. This can be used to tell CMake where
    it can find LLVM outside of standard directories.
 
-* `MAKE_BINARY` (STRING) - Path to `make` binary used to build KLEE's runtime.
-
 * `metaSMT_DIR` (STRING) - Provides a hint to CMake, where the metaSMT constraint
   solver can be found.  This should be an absolute path to a directory
   containing the file `metaSMTConfig.cmake`.


### PR DESCRIPTION
This PR removes some legacy from the build system:
- a comment mentioning "the old build system"
- `ENABLE_TESTS` variable, marked for removal in #569
- a mention of `MAKE_BINARY` (which was removed in #1250) in `README-CMake.md`

***
- [ ] The PR addresses a single issue.
- [X] There are no unnecessary commits.
- [ ] Larger PRs are divided into a logical sequence of commits.
- [ ] Each commit has a meaningful message documenting what it does.
- [ ] The code is commented.
- [ ] The patch is formatted via  [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (see also [git-clang-format](https://raw.githubusercontent.com/llvm/llvm-project/master/clang/tools/clang-format/git-clang-format) for Git integration).
- [ ] Add test cases exercising the code you added or modified. 
- [X] Spellcheck all messages added to the codebase, all comments, as well as commit messages.