### PR TITLE
Fixed silent concretization and refactored the code handling --max-static-*pct

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -363,6 +363,12 @@ cl::opt<double> MaxStaticCPSolvePct(
              "instructions (default=1.0 (always))"),
     cl::cat(TerminationCat));
 
+cl::opt<std::string> MaxStaticPctCheckDelay(
+    "max-static-pct-check-delay",
+    cl::desc("Time after which the --max-static-*-pct checks are enforced (default=60s)"),
+    cl::init("60s"),
+    cl::cat(TerminationCat));
+
 cl::opt<std::string> TimerInterval(
     "timer-interval",
     cl::desc("Minimum interval to check timers. "
@@ -480,6 +486,8 @@ Executor::Executor(LLVMContext &ctx, const InterpreterOptions &opts,
 
   this->solver = new TimingSolver(solver, EqualitySubstitution);
   memory = new MemoryManager(&arrayCache);
+
+  maxStaticPctCheckDelay = time::Span{MaxStaticPctCheckDelay};
 
   initializeSearchOptions();
 
@@ -967,7 +975,9 @@ ref<Expr> Executor::maxStaticPctChecks(ExecutionState &current,
       MaxStaticCPForkPct == 1. && MaxStaticCPSolvePct == 1.)
     return condition;
 
-  if (statsTracker->elapsed() <= time::seconds(60))
+  // these checks are performed only after MaxStaticPctCheckDelay time has
+  // passed since execution started
+  if (statsTracker->elapsed() <= maxStaticPctCheckDelay)
     return condition;
 
   StatisticManager &sm = *theStatisticManager;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -982,18 +982,28 @@ ref<Expr> Executor::maxStaticPctChecks(ExecutionState &current,
 
   StatisticManager &sm = *theStatisticManager;
   CallPathNode *cpn = current.stack.back().callPathNode;
-  if ((MaxStaticForkPct < 1. &&
-       sm.getIndexedValue(stats::forks, sm.getIndex()) >
-           stats::forks * MaxStaticForkPct) ||
-      (MaxStaticCPForkPct < 1. && cpn &&
-       (cpn->statistics.getValue(stats::forks) >
-        stats::forks * MaxStaticCPForkPct)) ||
+
+  bool reached_max_fork_limit =
+      (MaxStaticForkPct < 1. &&
+       (sm.getIndexedValue(stats::forks, sm.getIndex()) >
+        stats::forks * MaxStaticForkPct));
+
+  bool reached_max_cp_fork_limit = (MaxStaticCPForkPct < 1. && cpn &&
+                                    (cpn->statistics.getValue(stats::forks) >
+                                     stats::forks * MaxStaticCPForkPct));
+
+  bool reached_max_solver_limit =
       (MaxStaticSolvePct < 1 &&
-       sm.getIndexedValue(stats::solverTime, sm.getIndex()) >
-           stats::solverTime * MaxStaticSolvePct) ||
+       (sm.getIndexedValue(stats::solverTime, sm.getIndex()) >
+        stats::solverTime * MaxStaticSolvePct));
+
+  bool reached_max_cp_solver_limit =
       (MaxStaticCPForkPct < 1. && cpn &&
        (cpn->statistics.getValue(stats::solverTime) >
-        stats::solverTime * MaxStaticCPSolvePct))) {
+        stats::solverTime * MaxStaticCPSolvePct));
+
+  if (reached_max_fork_limit || reached_max_cp_fork_limit ||
+      reached_max_solver_limit || reached_max_cp_solver_limit) {
     ref<klee::ConstantExpr> value;
     bool success = solver->getValue(current.constraints, condition, value,
                                     current.queryMetaData);

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -999,6 +999,13 @@ ref<Expr> Executor::maxStaticPctChecks(ExecutionState &current,
                                     current.queryMetaData);
     assert(success && "FIXME: Unhandled solver failure");
     (void)success;
+
+    std::string msg("skipping fork and concretizing condition (MaxStatic*Pct "
+                    "limit reached) at ");
+    llvm::raw_string_ostream os(msg);
+    os << current.prevPC->getSourceLocation();
+    klee_warning_once(0, "%s", os.str().c_str());
+
     addConstraint(current, EqExpr::create(value, condition));
     condition = value;
   }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -958,6 +958,43 @@ void Executor::branch(ExecutionState &state,
       addConstraint(*result[i], conditions[i]);
 }
 
+ref<Expr> Executor::maxStaticPctChecks(ExecutionState &current,
+                                       ref<Expr> condition) {
+  if (isa<klee::ConstantExpr>(condition))
+    return condition;
+
+  if (MaxStaticForkPct == 1. && MaxStaticSolvePct == 1. &&
+      MaxStaticCPForkPct == 1. && MaxStaticCPSolvePct == 1.)
+    return condition;
+
+  if (statsTracker->elapsed() <= time::seconds(60))
+    return condition;
+
+  StatisticManager &sm = *theStatisticManager;
+  CallPathNode *cpn = current.stack.back().callPathNode;
+  if ((MaxStaticForkPct < 1. &&
+       sm.getIndexedValue(stats::forks, sm.getIndex()) >
+           stats::forks * MaxStaticForkPct) ||
+      (MaxStaticCPForkPct < 1. && cpn &&
+       (cpn->statistics.getValue(stats::forks) >
+        stats::forks * MaxStaticCPForkPct)) ||
+      (MaxStaticSolvePct < 1 &&
+       sm.getIndexedValue(stats::solverTime, sm.getIndex()) >
+           stats::solverTime * MaxStaticSolvePct) ||
+      (MaxStaticCPForkPct < 1. && cpn &&
+       (cpn->statistics.getValue(stats::solverTime) >
+        stats::solverTime * MaxStaticCPSolvePct))) {
+    ref<klee::ConstantExpr> value;
+    bool success = solver->getValue(current.constraints, condition, value,
+                                    current.queryMetaData);
+    assert(success && "FIXME: Unhandled solver failure");
+    (void)success;
+    addConstraint(current, EqExpr::create(value, condition));
+    condition = value;
+  }
+  return condition;
+}
+
 Executor::StatePair 
 Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
   Solver::Validity res;
@@ -965,33 +1002,8 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
     seedMap.find(&current);
   bool isSeeding = it != seedMap.end();
 
-  if (!isSeeding && !isa<ConstantExpr>(condition) && 
-      (MaxStaticForkPct!=1. || MaxStaticSolvePct != 1. ||
-       MaxStaticCPForkPct!=1. || MaxStaticCPSolvePct != 1.) &&
-      statsTracker->elapsed() > time::seconds(60)) {
-    StatisticManager &sm = *theStatisticManager;
-    CallPathNode *cpn = current.stack.back().callPathNode;
-    if ((MaxStaticForkPct<1. &&
-         sm.getIndexedValue(stats::forks, sm.getIndex()) > 
-         stats::forks*MaxStaticForkPct) ||
-        (MaxStaticCPForkPct<1. &&
-         cpn && (cpn->statistics.getValue(stats::forks) > 
-                 stats::forks*MaxStaticCPForkPct)) ||
-        (MaxStaticSolvePct<1 &&
-         sm.getIndexedValue(stats::solverTime, sm.getIndex()) > 
-         stats::solverTime*MaxStaticSolvePct) ||
-        (MaxStaticCPForkPct<1. &&
-         cpn && (cpn->statistics.getValue(stats::solverTime) > 
-                 stats::solverTime*MaxStaticCPSolvePct))) {
-      ref<ConstantExpr> value;
-      bool success = solver->getValue(current.constraints, condition, value,
-                                      current.queryMetaData);
-      assert(success && "FIXME: Unhandled solver failure");
-      (void) success;
-      addConstraint(current, EqExpr::create(value, condition));
-      condition = value;
-    }
-  }
+  if (!isSeeding)
+    condition = maxStaticPctChecks(current, condition);
 
   time::Span timeout = coreSolverTimeout;
   if (isSeeding)

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -363,10 +363,10 @@ cl::opt<double> MaxStaticCPSolvePct(
              "instructions (default=1.0 (always))"),
     cl::cat(TerminationCat));
 
-cl::opt<std::string> MaxStaticPctCheckDelay(
+cl::opt<unsigned> MaxStaticPctCheckDelay(
     "max-static-pct-check-delay",
-    cl::desc("Time after which the --max-static-*-pct checks are enforced (default=60s)"),
-    cl::init("60s"),
+    cl::desc("Number of forks after which the --max-static-*-pct checks are enforced (default=1000)"),
+    cl::init(1000),
     cl::cat(TerminationCat));
 
 cl::opt<std::string> TimerInterval(
@@ -486,8 +486,6 @@ Executor::Executor(LLVMContext &ctx, const InterpreterOptions &opts,
 
   this->solver = new TimingSolver(solver, EqualitySubstitution);
   memory = new MemoryManager(&arrayCache);
-
-  maxStaticPctCheckDelay = time::Span{MaxStaticPctCheckDelay};
 
   initializeSearchOptions();
 
@@ -975,9 +973,9 @@ ref<Expr> Executor::maxStaticPctChecks(ExecutionState &current,
       MaxStaticCPForkPct == 1. && MaxStaticCPSolvePct == 1.)
     return condition;
 
-  // these checks are performed only after MaxStaticPctCheckDelay time has
-  // passed since execution started
-  if (statsTracker->elapsed() <= maxStaticPctCheckDelay)
+  // These checks are performed only after at least MaxStaticPctCheckDelay forks
+  // have been performed since execution started
+  if (stats::forks < MaxStaticPctCheckDelay)
     return condition;
 
   StatisticManager &sm = *theStatisticManager;

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -353,6 +353,10 @@ private:
   // current state, and one of the states may be null.
   StatePair fork(ExecutionState &current, ref<Expr> condition, bool isInternal);
 
+  // If the MaxStatic*Pct limits have been reached, concretize the condition and
+  // return it. Otherwise, return the unmodified condition.
+  ref<Expr> maxStaticPctChecks(ExecutionState &current, ref<Expr> condition);
+
   /// Add the given (boolean) condition as a constraint on state. This
   /// function is a wrapper around the state's addConstraint function
   /// which also manages propagation of implied values,

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -203,9 +203,6 @@ private:
   /// Maximum time to allow for a single instruction.
   time::Span maxInstructionTime;
 
-  /// Time after which the --max-static-*-pct checks are enforced
-  time::Span maxStaticPctCheckDelay;
-
   /// Assumes ownership of the created array objects
   ArrayCache arrayCache;
 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -203,6 +203,9 @@ private:
   /// Maximum time to allow for a single instruction.
   time::Span maxInstructionTime;
 
+  /// Time after which the --max-static-*-pct checks are enforced
+  time::Span maxStaticPctCheckDelay;
+
   /// Assumes ownership of the created array objects
   ArrayCache arrayCache;
 

--- a/test/Feature/MaxStaticForkPct.c
+++ b/test/Feature/MaxStaticForkPct.c
@@ -1,0 +1,43 @@
+// RUN: %clang %s -emit-llvm %O0opt -c -g -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -max-static-fork-pct=0.2 -max-static-pct-check-delay=0s --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-pt2 %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -max-static-fork-pct=0.5 -max-static-pct-check-delay=0s --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-pt5 %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -max-static-fork-pct=0.8 -max-static-pct-check-delay=0s --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-pt8 %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -max-static-cpfork-pct=0.5 -max-static-pct-check-delay=0s --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-cppt5 %s
+
+#include "klee/klee.h"
+#include <stdio.h>
+
+int main() {
+#define N 4
+  int x[10], i;
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+  if (x[0])
+      printf("x[0] ");
+  else printf("NOT x[0] ");
+
+  if (x[1])
+  // CHECK-pt2: skipping fork and concretizing condition (MaxStatic*Pct limit reached)
+  // CHECK-cppt5: skipping fork and concretizing condition (MaxStatic*Pct limit reached)
+      printf("x[1] ");
+  else printf("NOT x[1] ");
+
+  for (i = 2; i < 10; i++) {
+    if (x[i])
+    // CHECK-pt5: skipping fork and concretizing condition (MaxStatic*Pct limit reached)
+    // CHECK-pt8: skipping fork and concretizing condition (MaxStatic*Pct limit reached)
+      printf("x[%d] ", i);
+    else printf("NOT x[%d] ", i);
+  }
+
+  // CHECK-pt2: completed paths = 4
+  // CHECK-pt5: completed paths = 8
+  // CHECK-pt8: completed paths = 17
+
+  // CHECK-cppt5: completed paths = 2
+  return 0;
+}

--- a/test/Feature/MaxStaticForkPct.c
+++ b/test/Feature/MaxStaticForkPct.c
@@ -1,12 +1,12 @@
 // RUN: %clang %s -emit-llvm %O0opt -c -g -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee -max-static-fork-pct=0.2 -max-static-pct-check-delay=0s --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-pt2 %s
+// RUN: %klee -max-static-fork-pct=0.2 -max-static-pct-check-delay=1 --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-pt2 %s
 // RUN: rm -rf %t.klee-out
-// RUN: %klee -max-static-fork-pct=0.5 -max-static-pct-check-delay=0s --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-pt5 %s
+// RUN: %klee -max-static-fork-pct=0.5 -max-static-pct-check-delay=1 --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-pt5 %s
 // RUN: rm -rf %t.klee-out
-// RUN: %klee -max-static-fork-pct=0.8 -max-static-pct-check-delay=0s --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-pt8 %s
+// RUN: %klee -max-static-fork-pct=0.8 -max-static-pct-check-delay=1 --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-pt8 %s
 // RUN: rm -rf %t.klee-out
-// RUN: %klee -max-static-cpfork-pct=0.5 -max-static-pct-check-delay=0s --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-cppt5 %s
+// RUN: %klee -max-static-cpfork-pct=0.5 -max-static-pct-check-delay=1 --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck --check-prefix=CHECK-cppt5 %s
 
 #include "klee/klee.h"
 #include <stdio.h>


### PR DESCRIPTION
This PR does the following:
1. fixes the silent concretization reported in #526 
2. refactors the code handling --max-static-*pct into a separate function thus partially addressing #527 
3. adds a new --max-static-pcc-heck-delay to replace the hardcoded time delay after these checks are enforced
4. adds a test case for these arguments, as the code was not tested by the current test suite


Thank you for contributing to KLEE.  We are looking forward to reviewing your PR.  However, given the small number of active reviewers and our limited time, it might take a while to do so.  We aim to get back to each PR within one month, and often do so within one week. 

To help expedite the review please ensure the following, by adding an "x" for each completed item:

- [x] The PR addresses a single issue.  In other words, if some parts of a PR could form another independent PR, you should break this PR into multiple smaller PRs.
- [x] There are no unnecessary commits. For instance, commits that fix issues with a previous commit in this PR are unnecessary and should be removed (you can find [documentation on squashing commits here](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#squash-your-changes)).
- [x] Larger PRs are divided into a logical sequence of commits.
- [x] Each commit has a meaningful message documenting what it does.
- [x] The code is commented.  In particular, newly added classes and functions should be documented.
- [x] The patch is formatted via  [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (see also [git-clang-format](https://raw.githubusercontent.com/llvm/llvm-project/master/clang/tools/clang-format/git-clang-format) for Git integration).  Please only format the patch itself and code surrounding the patch, not entire files.  Divergences from clang-formatting are only rarely accepted, and only if they clearly improve code readability.
- [x] Add test cases exercising the code you added or modified.  We expect [system and/or unit test cases](https://klee.github.io/docs/developers-guide/#regression-testing-framework) for all non-trivial changes.  After you submit your PR, you will be able to see a [Codecov report](https://docs.codecov.io/docs/pull-request-comments) telling you which parts of your patch are not covered by the regression test suite.  You will also be able to see if the Github Actions CI and Cirrus CI tests have passed.  If they don't, you should examine the failures and address them before the PR can be reviewed. 
- [x] Spellcheck all messages added to the codebase, all comments, as well as commit messages.
