### PR TITLE
C++ / Exception Handling Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,7 +562,7 @@ else()
 endif()
 
 ################################################################################
-# KLEE libcxx support
+# KLEE libc++ support
 ################################################################################
 option(ENABLE_KLEE_LIBCXX "Enable libc++ for klee" OFF)
 if (ENABLE_KLEE_LIBCXX)

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -288,10 +288,12 @@ cl::list<Executor::TerminateReason> ExitOnErrorType(
         clEnumValN(Executor::ReportError, "ReportError",
                    "klee_report_error called"),
         clEnumValN(Executor::User, "User", "Wrong klee_* functions invocation"),
+#ifdef SUPPORT_KLEE_EH_CXX
         clEnumValN(Executor::UncaughtException, "UncaughtException",
                    "Exception was not caught"),
         clEnumValN(Executor::UnexpectedException, "UnexpectedException",
                    "An unexpected exception was thrown"),
+#endif
         clEnumValN(Executor::Unhandled, "Unhandled",
                    "Unhandled instruction hit") KLEE_LLVM_CL_VAL_END),
     cl::ZeroOrMore,
@@ -441,8 +443,10 @@ const char *Executor::TerminateReasonNames[] = {
   [ ReadOnly ] = "readonly",
   [ ReportError ] = "reporterror",
   [ User ] = "user",
+#ifdef SUPPORT_KLEE_EH_CXX
   [ UncaughtException ] = "uncaught_exception",
   [ UnexpectedException ] = "unexpected_exception",
+#endif
   [ Unhandled ] = "xxx",
 };
 
@@ -1743,10 +1747,12 @@ void Executor::executeCall(ExecutionState &state, KInstruction *ki, Function *f,
       break;
     }
 
+#ifdef SUPPORT_KLEE_EH_CXX
     case Intrinsic::eh_typeid_for: {
       bindLocal(ki, state, getEhTypeidFor(arguments.at(0)));
       break;
     }
+#endif
 
     case Intrinsic::vaend:
       // va_end is a noop for the interpreter.
@@ -2026,6 +2032,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
         ++state.pc;
       }
 
+#ifdef SUPPORT_KLEE_EH_CXX
       if (ri->getFunction()->getName() == "_klee_eh_cxx_personality") {
         assert(dyn_cast<ConstantExpr>(result) &&
                "result from personality fn must be a concrete value");
@@ -2059,6 +2066,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
         // never return normally from the personality fn
         break;
       }
+#endif // SUPPORT_KLEE_EH_CXX
 
       if (!isVoidReturn) {
         Type *t = caller->getType();
@@ -3152,6 +3160,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     terminateStateOnExecError(state, "Unexpected ShuffleVector instruction");
     break;
 
+#ifdef SUPPORT_KLEE_EH_CXX
   case Instruction::Resume: {
     auto *cui = dyn_cast_or_null<CleanupPhaseUnwindingInformation>(
         state.unwindingInformation.get());
@@ -3230,6 +3239,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     break;
   }
+#endif // SUPPORT_KLEE_EH_CXX
 
   case Instruction::AtomicRMW:
     terminateStateOnExecError(state, "Unexpected Atomic instruction, should be "

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1772,14 +1772,8 @@ void Executor::executeCall(ExecutionState &state, KInstruction *ki, Function *f,
       return;
     }
 
-    // __cxa_throw & _rethrow are already handled in their
-    // SpecialFunctionHandlers and have already been redirected to their unwind
-    // destinations, so we must not transfer them to their regular targets.
     if (InvokeInst *ii = dyn_cast<InvokeInst>(i)) {
-      if (f->getName() != std::string("__cxa_throw") &&
-          f->getName() != std::string("__cxa_rethrow")) {
-        transferToBasicBlock(ii->getNormalDest(), i->getParent(), state);
-      }
+      transferToBasicBlock(ii->getNormalDest(), i->getParent(), state);
     }
   } else {
     // Check if maximum stack size was reached.

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -110,8 +110,10 @@ public:
     ReadOnly,
     ReportError,
     User,
+#ifdef SUPPORT_KLEE_EH_CXX
     UncaughtException,
     UnexpectedException,
+#endif
     Unhandled,
   };
 

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -18,6 +18,7 @@
 #include "StatsTracker.h"
 #include "TimingSolver.h"
 
+#include "klee/Config/config.h"
 #include "klee/Module/KInstruction.h"
 #include "klee/Module/KModule.h"
 #include "klee/Solver/SolverCmdLine.h"
@@ -115,7 +116,11 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("malloc", handleMalloc, true),
   add("memalign", handleMemalign, true),
   add("realloc", handleRealloc, true),
+
+#ifdef SUPPORT_KLEE_EH_CXX
   add("_klee_eh_Unwind_RaiseException_impl", handleEhUnwindRaiseExceptionImpl, false),
+  add("klee_eh_typeid_for", handleEhTypeid, true),
+#endif
 
   // operator delete[](void*)
   add("_ZdaPv", handleDeleteArray, false),
@@ -140,7 +145,6 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("__ubsan_handle_sub_overflow", handleSubOverflow, false),
   add("__ubsan_handle_mul_overflow", handleMulOverflow, false),
   add("__ubsan_handle_divrem_overflow", handleDivRemOverflow, false),
-  add("klee_eh_typeid_for", handleEhTypeid, true),
 
 #undef addDNR
 #undef add
@@ -458,6 +462,7 @@ void SpecialFunctionHandler::handleMemalign(ExecutionState &state,
                         alignment);
 }
 
+#ifdef SUPPORT_KLEE_EH_CXX
 void SpecialFunctionHandler::handleEhUnwindRaiseExceptionImpl(
     ExecutionState &state, KInstruction *target,
     std::vector<ref<Expr>> &arguments) {
@@ -495,6 +500,7 @@ void SpecialFunctionHandler::handleEhTypeid(ExecutionState &state,
 
   executor.bindLocal(target, state, executor.getEhTypeidFor(arguments[0]));
 }
+#endif // SUPPORT_KLEE_EH_CXX
 
 void SpecialFunctionHandler::handleAssume(ExecutionState &state,
                             KInstruction *target,

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -10,6 +10,8 @@
 #ifndef KLEE_SPECIALFUNCTIONHANDLER_H
 #define KLEE_SPECIALFUNCTIONHANDLER_H
 
+#include "klee/Config/config.h"
+
 #include <iterator>
 #include <map>
 #include <vector>
@@ -109,8 +111,12 @@ namespace klee {
     HANDLER(handleDefineFixedObject);
     HANDLER(handleDelete);    
     HANDLER(handleDeleteArray);
-    HANDLER(handleExit);
+#ifdef SUPPORT_KLEE_EH_CXX
+    HANDLER(handleEhUnwindRaiseExceptionImpl);
+    HANDLER(handleEhTypeid);
+#endif
     HANDLER(handleErrnoLocation);
+    HANDLER(handleExit);
     HANDLER(handleFree);
     HANDLER(handleGetErrno);
     HANDLER(handleGetObjSize);
@@ -119,8 +125,6 @@ namespace klee {
     HANDLER(handleMakeSymbolic);
     HANDLER(handleMalloc);
     HANDLER(handleMemalign);
-    HANDLER(handleEhUnwindRaiseExceptionImpl);
-    HANDLER(handleEhTypeid);
     HANDLER(handleMarkGlobal);
     HANDLER(handleOpenMerge);
     HANDLER(handleCloseMerge);

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -364,6 +364,9 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
 #if LLVM_VERSION_CODE >= LLVM_VERSION(7, 0)
       case Intrinsic::dbg_label:
 #endif
+#ifndef SUPPORT_KLEE_EH_CXX
+      case Intrinsic::eh_typeid_for:
+#endif
       case Intrinsic::exp2:
       case Intrinsic::exp:
       case Intrinsic::expect:
@@ -399,10 +402,12 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         dirty = true;
         break;
 
+#ifdef SUPPORT_KLEE_EH_CXX
       case Intrinsic::eh_typeid_for: {
         // Don't lower this, we need it for exception handling
         break;
       }
+#endif
 
         // Warn about any unrecognized intrinsics.
       default: {

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -196,7 +196,7 @@ if config.enable_uclibc:
 if config.enable_posix_runtime:
   config.available_features.add('posix-runtime')
 
-# LibC++ runtime feature
+# libc++ runtime feature
 if config.enable_libcxx:
   config.available_features.add('libcxx')
 

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1305,6 +1305,9 @@ int main(int argc, char **argv, char **envp) {
                         loadedModules, errorMsg))
       klee_error("error loading libklee-eh-cxx '%s': %s", EhCxxPath.c_str(),
                  errorMsg.c_str());
+    klee_message("NOTE: Enabled runtime support for C++ exceptions");
+#else
+    klee_message("NOTE: KLEE was not compiled with support for C++ exceptions");
 #endif
 #endif
   }

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1287,15 +1287,15 @@ int main(int argc, char **argv, char **envp) {
 
   if (Libcxx) {
 #ifndef SUPPORT_KLEE_LIBCXX
-    klee_error("KLEE was not compiled with Libcxx support");
+    klee_error("KLEE was not compiled with libc++ support");
 #else
     SmallString<128> LibcxxBC(Opts.LibraryDir);
     llvm::sys::path::append(LibcxxBC, KLEE_LIBCXX_BC_NAME);
     if (!klee::loadFile(LibcxxBC.c_str(), mainModule->getContext(), loadedModules,
                         errorMsg))
-      klee_error("error loading libcxx '%s': %s", LibcxxBC.c_str(),
+      klee_error("error loading libc++ '%s': %s", LibcxxBC.c_str(),
                  errorMsg.c_str());
-    klee_message("NOTE: Using libcxx : %s", LibcxxBC.c_str());
+    klee_message("NOTE: Using libc++ : %s", LibcxxBC.c_str());
 #ifdef SUPPORT_KLEE_EH_CXX
     SmallString<128> EhCxxPath(Opts.LibraryDir);
     llvm::sys::path::append(EhCxxPath, "libkleeeh-cxx" + opt_suffix + ".bca");

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -782,8 +782,10 @@ static const char *modelledExternals[] = {
   "klee_warning",
   "klee_warning_once",
   "klee_stack_trace",
+#ifdef SUPPORT_KLEE_EH_CXX
   "_klee_eh_Unwind_RaiseException_impl",
   "klee_eh_typeid_for",
+#endif
   "llvm.dbg.declare",
   "llvm.dbg.value",
   "llvm.va_start",


### PR DESCRIPTION
This PR (mainly) restores KLEE's old behavior in case that Exception Handling is disabled (LLVM version < 8, no libc++abi headers available, CMake variable disabled). In addition, some more renaming, messages at startup informing whether EH support is available and removing a special case that was only required by an earlier (never merged) version of C++ EH support.

***
- [X] The PR addresses a single issue.
- [x] There are no unnecessary commits.
- [x] Larger PRs are divided into a logical sequence of commits.
- [x] Each commit has a meaningful message documenting what it does.
- [ ] The code is commented.
- [X] The patch is formatted via  [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (see also [git-clang-format](https://raw.githubusercontent.com/llvm/llvm-project/master/clang/tools/clang-format/git-clang-format) for Git integration).
- [ ] Add test cases exercising the code you added or modified. 
- [X] Spellcheck all messages added to the codebase, all comments, as well as commit messages.