### PR TITLE
Add cmake custom target `uninstall`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -814,3 +814,19 @@ endif()
 # Miscellaneous install
 ################################################################################
 install(FILES include/klee/klee.h DESTINATION include/klee)
+
+################################################################################
+# Uninstall rule
+################################################################################
+configure_file(
+  "${PROJECT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+  "${CMAKE_BINARY_DIR}/cmake_uninstall.cmake"
+	@ONLY
+)
+
+add_custom_target(uninstall
+  COMMAND
+  "${CMAKE_COMMAND}" -P "${CMAKE_BINARY_DIR}/cmake_uninstall.cmake"
+  COMMENT "Uninstalling..."
+  VERBATIM
+)

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,24 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: "
+          "@CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  set(file_path "$ENV{DESTDIR}${file}")
+  message(STATUS "Uninstalling ${file_path}")
+  if(IS_SYMLINK "${file_path}" OR EXISTS "${file_path}")
+    # We could use ``file(REMOVE ...)`` here but then we wouldn't
+    # know if the removal failed.
+    execute_process(COMMAND
+      "@CMAKE_COMMAND@" "-E" "remove" "${file_path}"
+      RESULT_VARIABLE rm_retval
+    )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing \"${file_path}\"")
+    endif()
+  else()
+    message(STATUS "File \"${file_path}\" does not exist.")
+  endif()
+endforeach()


### PR DESCRIPTION
`make uninstall` is enabled.
Without this, uninstalling was done manually with `rm` command.

```sh
sudo make uninstall
```

> [100%] Uninstalling...
> -- Uninstalling /usr/local/include/klee/klee.h
> -- Uninstalling /usr/local/lib/klee/runtime/libkleeRuntimeFreestanding64_Release.bca
> ...
> [100%] Built target uninstall

I referred Z3 and STP build system to add this feature, each of which supports `make uninstall`. One thing I failed is to remove the progress number above. (That doesn't appear for Z3 and STP...) However after digging in cmake documentation, I concluded that it is too time-consuming.


- [x] The PR addresses a single issue.  In other words, if some parts of a PR could form another independent PR, you should break this PR into multiple smaller PRs.
- [x] There are no unnecessary commits. For instance, commits that fix issues with a previous commit in this PR are unnecessary and should be removed (you can find [documentation on squashing commits here](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#squash-your-changes)).
- [x] Larger PRs are divided into a logical sequence of commits.
- [x] Each commit has a meaningful message documenting what it does.
- [x] The code is commented.  In particular, newly added classes and functions should be documented.
- [ ] The patch is formatted via  [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (see also [git-clang-format](https://raw.githubusercontent.com/llvm/llvm-project/master/clang/tools/clang-format/git-clang-format) for Git integration).  Please only format the patch itself and code surrounding the patch, not entire files.  Divergences from clang-formatting are only rarely accepted, and only if they clearly improve code readability.
- [ ] Add test cases exercising the code you added or modified.  We expect [system and/or unit test cases](https://klee.github.io/docs/developers-guide/#regression-testing-framework) for all non-trivial changes.  After you submit your PR, you will be able to see a [Codecov report](https://docs.codecov.io/docs/pull-request-comments) telling you which parts of your patch are not covered by the regression test suite.  You will also be able to see if the Github Actions CI and Cirrus CI tests have passed.  If they don't, you should examine the failures and address them before the PR can be reviewed. 
- [x] Spellcheck all messages added to the codebase, all comments, as well as commit messages.
