### PR TITLE
Feature: implement single memory object resolution for symbolic addre…

### DIFF
--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -235,6 +235,10 @@ public:
   /// @brief Disables forking for this state. Set by user code
   bool forkDisabled;
 
+  /// @brief Mapping symbolic address expressions to concrete base addresses
+  typedef std::map<ref<Expr>, ref<ConstantExpr>> base_addrs_t;
+  base_addrs_t base_addrs;
+
 public:
   #ifdef KLEE_UNITTEST
   // provide this function only in the context of unittests

--- a/test/Feature/SingleObjectResolution.c
+++ b/test/Feature/SingleObjectResolution.c
@@ -1,0 +1,51 @@
+// RUN: %clang %s -g -emit-llvm %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --posix-runtime --libc=uclibc --output-dir=%t.klee-out --single-object-resolution %t.bc > %t.log 2>&1
+// RUN: FileCheck %s -input-file=%t.log
+
+#include "klee/klee.h"
+#include <stdlib.h>
+
+struct A {
+  long long int y;
+  long long int y2;
+  int z;
+};
+
+struct B {
+  long long int x;
+  struct A y[20];
+  struct A *y1;
+  struct A *y2;
+  int z;
+};
+
+int foo(int *pointer) {
+  //printf("pointer is called\n");
+  int *ptr = pointer + 123;
+  return *ptr;
+}
+
+int main(int argc, char *argv[]) {
+
+  int x;
+  struct B b;
+
+  // create a lot of memory objects
+  int *ptrs[1024];
+  for (int i = 0; i < 1024; i++) {
+    ptrs[i] = malloc(23);
+  }
+
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+  b.y1 = malloc(20 * sizeof(struct A));
+
+  // dereference of a pointer within a struct
+  int *tmp = &b.y1[x].z;
+
+  // CHECK: KLEE: ERROR: test/Feature/SingleObjectResolution.c:26: memory error: out of bound pointer
+  // CHECK: KLEE: done: completed paths = 2
+  // CHECK: KLEE: done: generated tests = 2
+  return foo(tmp);
+}


### PR DESCRIPTION
…sses.

    This feature implements tracking of and resolution of memory objects in the presence of
    symbolic addresses.
    For example, an expression like the following:
    int x;
    klee_make_symbolic(&x, sizeof(x), "x");

    int* tmp = &b.y[x].z;

    For a concrete array object "y", which is a member of struct "b", a symbolic offset "x" would normally 
    be resolved to any matching memory object - including the ones outside of the object "b".
    This behaviour is consistent with symbex approach of exploring all execution paths.
    However, from the point of view of security testing, we would only be interested to know if we are still
    in-bounds or there is a buffer overflow.

    The implemented feature creates and tracks (via the GEP instruction) the mapping between the current
    symbolic offset and the base object it refers to: in our example we are able to tell that the reference
    should happen within the object "b" (as the array "y" is inside the same memory blob). 
    As a result, we are able to minimize the symbolic exploration to only two paths: one within the bounds of "b", 
    the other with a buffer overflow bug.

    The feature is turned on via the single-object-resolution command line flag.

    A new test case was implemented to illustrate how the feature works.

Thank you for contributing to KLEE.  We are looking forward to reviewing your PR.  However, given the small number of active reviewers and our limited time, it might take a while to do so.  We aim to get back to each PR within one month, and often do so within one week. 

To help expedite the review please ensure the following, by adding an "x" for each completed item:

- [x] The PR addresses a single issue.  In other words, if some parts of a PR could form another independent PR, you should break this PR into multiple smaller PRs.
- [x] There are no unnecessary commits. For instance, commits that fix issues with a previous commit in this PR are unnecessary and should be removed (you can find [documentation on squashing commits here](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#squash-your-changes)).
- [x] Larger PRs are divided into a logical sequence of commits.
- [x] Each commit has a meaningful message documenting what it does.
- [x] The code is commented.  In particular, newly added classes and functions should be documented.
- [x] The patch is formatted via  [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (see also [git-clang-format](https://raw.githubusercontent.com/llvm/llvm-project/master/clang/tools/clang-format/git-clang-format) for Git integration).  Please only format the patch itself and code surrounding the patch, not entire files.  Divergences from clang-formatting are only rarely accepted, and only if they clearly improve code readability.
- [x] Add test cases exercising the code you added or modified.  We expect [system and/or unit test cases](https://klee.github.io/docs/developers-guide/#regression-testing-framework) for all non-trivial changes.  After you submit your PR, you will be able to see a [Codecov report](https://docs.codecov.io/docs/pull-request-comments) telling you which parts of your patch are not covered by the regression test suite.  You will also be able to see if the Github Actions CI and Cirrus CI tests have passed.  If they don't, you should examine the failures and address them before the PR can be reviewed. 
- [x] Spellcheck all messages added to the codebase, all comments, as well as commit messages.
