### PR TITLE
runtime/POSIX: fix failures with glibc-2.33

### DIFF
--- a/runtime/POSIX/fd_64.c
+++ b/runtime/POSIX/fd_64.c
@@ -73,6 +73,16 @@ int openat(int fd, const char *pathname, int flags, ...) {
   return __fd_openat(fd, pathname, flags, mode);
 }
 
+/* removed in glibc 2.33 */
+#ifdef __REDIRECT_NTH
+extern int __REDIRECT_NTH(__fxstat, (int __ver, int __fildes,
+                          struct stat *__stat_buf), __fxstat64);
+extern int __REDIRECT_NTH(__xstat, (int __ver, const char *__filename,
+                          struct stat *__stat_buf), __xstat64);
+extern int __REDIRECT_NTH(__lxstat, (int __ver, const char *__filename,
+                          struct stat *__stat_buf), __lxstat64);
+#endif
+
 off64_t lseek(int fd, off64_t offset, int whence) {
   return __fd_lseek(fd, offset, whence);
 }


### PR DESCRIPTION
commit 8ed005daf0ab of glibc-2.33 (Remove stat wrapper functions, move them to exported symbols) removed renames of `__fxstat`, `__xstat`, and `__lxstat` to `__fxstat64`, `__xstat64`, and `__lxstat64`, respectively.

But we relied on the renames to build `fd_64.c` properly. With glibc 2.33, we now see link failures of the POSIX runtime:
```
error: Linking globals named '__xstat': symbol multiply defined!
```
Rename the functions using `__REDIRECT_NTH` in the code as `__USE_FILE_OFFSET64` case (which we define at the top of the file by `#define _FILE_OFFSET_BITS 64`) did exactly that.

Fixes #1384.
