### PR TITLE
Fix path stats for disabled state dumping

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ task:
   deps_script:
     - sed -i.bak -e 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
     - env ASSUME_ALWAYS_YES=yes pkg update -f
-    - env ASSUME_ALWAYS_YES=yes pkg install -y llvm90 gmake z3 cmake pkgconf google-perftools python3 python37 py37-sqlite3 py37-tabulate
+    - env ASSUME_ALWAYS_YES=yes pkg install -y llvm90 gmake z3 cmake pkgconf google-perftools python3 py38-sqlite3 py38-tabulate
   build_script:
     - mkdir build
     - cd build

--- a/include/klee/Core/Interpreter.h
+++ b/include/klee/Core/Interpreter.h
@@ -40,7 +40,8 @@ public:
   virtual std::string getOutputFilename(const std::string &filename) = 0;
   virtual std::unique_ptr<llvm::raw_fd_ostream> openOutputFile(const std::string &filename) = 0;
 
-  virtual void incPathsExplored() = 0;
+  virtual void incPathsCompleted() = 0;
+  virtual void incPathsExplored(std::uint32_t num = 1) = 0;
 
   virtual void processTestCase(const ExecutionState &state,
                                const char *err,

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3436,8 +3436,10 @@ bool Executor::checkMemoryUsage() {
 }
 
 void Executor::doDumpStates() {
-  if (!DumpStatesOnHalt || states.empty())
+  if (!DumpStatesOnHalt || states.empty()) {
+    interpreterHandler->incPathsExplored(states.size());
     return;
+  }
 
   klee_message("halting execution, dumping remaining states");
   for (const auto &state : states)
@@ -3638,6 +3640,7 @@ void Executor::terminateStateOnExit(ExecutionState &state) {
   if (!OnlyOutputStatesCoveringNew || state.coveredNew || 
       (AlwaysOutputSeeds && seedMap.count(&state)))
     interpreterHandler->processTestCase(state, 0, 0);
+  interpreterHandler->incPathsCompleted();
   terminateState(state);
 }
 

--- a/test/CXX/symex/libc++/uncaught_exception.cpp
+++ b/test/CXX/symex/libc++/uncaught_exception.cpp
@@ -11,4 +11,5 @@ int main() {
 }
 
 // CHECK: KLEE: ERROR:
-// CHECK: KLEE: done: completed paths = 1
+// CHECK: KLEE: done: completed paths = 0
+// CHECK: KLEE: done: partially completed paths = 1

--- a/test/Feature/SilentKleeAssume.c
+++ b/test/Feature/SilentKleeAssume.c
@@ -26,5 +26,6 @@ int main() {
 
 // CHECK-SILENT-KLEE-ASSUME: KLEE: output directory is "{{.+}}"
 // CHECK-SILENT-KLEE-ASSUME: KLEE: done: total instructions = {{[0-9]+}}
-// CHECK-SILENT-KLEE-ASSUME: KLEE: done: completed paths = 2
+// CHECK-SILENT-KLEE-ASSUME: KLEE: done: completed paths = 1
+// CHECK-SILENT-KLEE-ASSUME: KLEE: done: partially completed paths = 1
 // CHECK-SILENT-KLEE-ASSUME: KLEE: done: generated tests = 1

--- a/test/Feature/consecutive_divide_by_zero.c
+++ b/test/Feature/consecutive_divide_by_zero.c
@@ -25,7 +25,8 @@ int main() {
   // CHECK: consecutive_divide_by_zero.c:[[@LINE+1]]: divide by zero
   unsigned int result2 = b / d2;
 
-  // CHECK: completed paths = 3
+  // CHECK: completed paths = 1
+  // CHECK: partially completed paths = 2
   // CHECK: generated tests = 3
   return 0;
 }

--- a/test/Feature/srem.c
+++ b/test/Feature/srem.c
@@ -39,5 +39,6 @@ int main(int argc, char** argv)
     // CHECK: srem.c:[[@LINE+1]]: ASSERTION FAIL
     assert(-1 % y == -1);
 
-    // CHECK: KLEE: done: completed paths = 5
+    // CHECK: KLEE: done: completed paths = 2
+    // CHECK: KLEE: done: partially completed paths = 3
 }

--- a/test/Intrinsics/Missing.ll
+++ b/test/Intrinsics/Missing.ll
@@ -11,7 +11,8 @@
 ; CHECK: KLEE: WARNING: unimplemented intrinsic: llvm.minnum.f32
 
 ; Check that Executor explores all paths
-; CHECK: KLEE: done: completed paths = 3
+; CHECK: KLEE: done: completed paths = 1
+; CHECK: KLEE: done: partially completed paths = 2
 ; CHECK: KLEE: done: generated tests = 2
 
 

--- a/test/regression/2020-02-24-count-paths-nodump.c
+++ b/test/regression/2020-02-24-count-paths-nodump.c
@@ -1,0 +1,14 @@
+// ASAN fails because KLEE does not cleanup states with -dump-states-on-halt=false
+// REQUIRES: not-asan
+// RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -dump-states-on-halt=false -max-instructions=1 -output-dir=%t.klee-out %t.bc 2>&1 | FileCheck %s
+
+int main(int argc, char **argv) {
+  // just do something
+  int i = 42;
+  ++i;
+}
+
+// CHECK: KLEE: done: completed paths = 0
+// CHECK: KLEE: done: partially completed paths = 1


### PR DESCRIPTION
Originally part of #1343:

Although I don't like the misleading output of "completed paths", it should also count states when we do not dump states at the end. You can observe it with current upstream KLEE:

`klee -dump-states-on-halt=false -max-instructions=1 program.bc`

outputs:

`KLEE: done: completed paths = 0`

This fix adds `states.size()` to that counter.

**Edit:**

As discussed below this PR now splits the path summary into "completed" and "partially completed" paths.

---

Thank you for contributing to KLEE.  We are looking forward to reviewing your PR.  However, given the small number of active reviewers and our limited time, it might take a while to do so.  We aim to get back to each PR within one month, and often do so within one week. 

To help expedite the review please ensure the following, by adding an "x" for each completed item:

- [x] The PR addresses a single issue.  In other words, if some parts of a PR could form another independent PR, you should break this PR into multiple smaller PRs.
- [x] There are no unnecessary commits. For instance, commits that fix issues with a previous commit in this PR are unnecessary and should be removed (you can find [documentation on squashing commits here](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#squash-your-changes)).
- [x] Larger PRs are divided into a logical sequence of commits.
- [x] Each commit has a meaningful message documenting what it does.
- [x] The code is commented.  In particular, newly added classes and functions should be documented.
- [x] The patch is formatted via  [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (see also [git-clang-format](https://raw.githubusercontent.com/llvm/llvm-project/master/clang/tools/clang-format/git-clang-format) for Git integration).  Please only format the patch itself and code surrounding the patch, not entire files.  Divergences from clang-formatting are only rarely accepted, and only if they clearly improve code readability.
- [x] Add test cases exercising the code you added or modified.  We expect [system and/or unit test cases](https://klee.github.io/docs/developers-guide/#regression-testing-framework) for all non-trivial changes.  After you submit your PR, you will be able to see a [Codecov report](https://docs.codecov.io/docs/pull-request-comments) telling you which parts of your patch are not covered by the regression test suite.  You will also be able to see if the Github Actions CI and Cirrus CI tests have passed.  If they don't, you should examine the failures and address them before the PR can be reviewed. 
- [x] Spellcheck all messages added to the codebase, all comments, as well as commit messages.
