### PR TITLE
cmake: Fix CMP0026 policy deprecation warning

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,21 +135,17 @@ add_subdirectory(Concrete)
 ###############################################################################
 
 # Find path to libkleeRuntest target for `lit.site.cfg`.
-# FIXME: This is not the right way to get the location of the target we have to
-# set CMP0026 to old.
-# This will likely break if using a multi-configuration generator.
-if (POLICY CMP0026)
-  # HACK: Allow reading `LOCATION` property.
-  cmake_policy(SET CMP0026 OLD)
-endif()
-get_property(LIB_KLEE_RUN_TEST_PATH
-  TARGET kleeRuntest
-  PROPERTY LOCATION
-)
+set(LIB_KLEE_RUN_TEST_PATH $<TARGET_FILE:kleeRuntest>)
 
 configure_file(lit.site.cfg.in
-  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.imd
   @ONLY
+)
+
+# Evaluate all generator expressions inserted during the configure step.
+file(GENERATE
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
+  INPUT  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.imd
 )
 
 add_custom_target(systemtests


### PR DESCRIPTION
## Summary: 

CMake 3.19+ started to issue warnings if this policy is set to OLD:
```
CMake Deprecation Warning at test/CMakeLists.txt:143 (cmake_policy):
  The OLD behavior for policy CMP0026 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
```
This PR tries to fix that.
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->




## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
