### PR TITLE
Assert that all tools in tests in CI are invoked through their corresponding macros 

### DIFF
--- a/scripts/build/run-tests.sh
+++ b/scripts/build/run-tests.sh
@@ -37,6 +37,12 @@ run_tests() {
   # TODO change to pinpoint specific directory
   cd "${build_dir}"
 
+  # Remove klee from PATH
+  export PATH=${PATH%":/home/klee/klee_build/bin"}
+  if which klee; then
+    return 1 # should not happen
+  fi
+
   ###############################################################################
   # Unit tests
   ###############################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,6 +71,9 @@ if (NOT EXISTS "${LLVM_TOOLS_BINARY_DIR}/not")
   set(DOWNLOAD_NOT_SOURCE TRUE)
 endif()
 
+# Do not build FileCheck and not to ${KLEE_TOOLS_DIR} as it will not be in lit's PATH.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${KLEE_TOOLS_DIR}/testtools)
+
 if (DOWNLOAD_FILECHECK_SOURCE)
   if (${LLVM_VERSION_MAJOR} GREATER 3)
     set(FILECHECK_SRC_URL "https://raw.githubusercontent.com/llvm/llvm-project/release/${LLVM_VERSION_MAJOR}.x/llvm/utils/FileCheck/FileCheck.cpp")

--- a/test/CXX/LandingPad.cpp
+++ b/test/CXX/LandingPad.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx %s -emit-llvm -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: klee --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck %s
 
 // CHECK: Using zero size array fix for landingpad instruction filter
 

--- a/test/Expr/Parser/Concat64.kquery
+++ b/test/Expr/Parser/Concat64.kquery
@@ -1,4 +1,4 @@
-# RUN: kleaver --print-ast %s
+# RUN: %kleaver --print-ast %s
 
 array arr1[8] : w32 -> w8 = symbolic
 (query [(Eq 0

--- a/test/Feature/PreferCex.c
+++ b/test/Feature/PreferCex.c
@@ -1,7 +1,7 @@
 // RUN: %clang %s -emit-llvm %O0opt -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --exit-on-error %t1.bc
-// RUN: ktest-tool %t.klee-out/test000001.ktest | FileCheck %s
+// RUN: %ktest-tool %t.klee-out/test000001.ktest | FileCheck %s
 
 #include <assert.h>
 #include <stdlib.h>

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -35,21 +35,21 @@ klee_src_root = getattr(config, 'klee_src_root', None)
 if klee_obj_root is not None:
   config.test_exec_root = os.path.join(klee_obj_root, 'test')
 
-# Tweak the PATH to include the tool dir.
-if klee_obj_root is not None:
+  # Check KLEE tools directory
   klee_tools_dir = getattr(config, 'klee_tools_dir', None)
   if not klee_tools_dir:
     lit_config.fatal('No KLEE tools dir set!')
 
-  # Check LLVM tool directory
+  # Check LLVM tools directory
   llvm_tools_dir = getattr(config, 'llvm_tools_dir', None)
   if not llvm_tools_dir:
-    lit_config.fatal('No LLVM tool directory set!')
+    lit_config.fatal('No LLVM tools directory set!')
 
+  # Add LLVM tools and FileCheck with not to PATH
   path = os.path.pathsep.join(
     (
+      os.path.join(klee_tools_dir, "testtools"),
       llvm_tools_dir,
-      klee_tools_dir,
       config.environment['PATH']
     )
   )

--- a/test/regression/2014-09-13-debug-info.c
+++ b/test/regression/2014-09-13-debug-info.c
@@ -8,8 +8,7 @@
 // one with the prefered CEX. We verify this by using ktest-tool to dump the
 // values, and then checking the output.
 //
-// RUN: /bin/sh -c "ktest-tool %t.klee-out/*.ktest" > %t.data-values
-// RUN: FileCheck < %t.data-values %s
+// RUN: %ktest-tool %t.klee-out/*.ktest | FileCheck %s
 
 // CHECK-DAG: object 0: int : 0
 // CHECK-DAG: object 0: int : 17


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
It may happen that some older instance of `klee` is already present in `PATH`.  All tests that call plain `klee` instead of `%klee` may use it and then unexpectedly fail.

This PR will make all tests that rely on KLEE tools being explicitly in `PATH` fail in the CI.  From now on, only LLVM tools, `FileCheck` and `not` will be in `lit`'s `PATH`.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
