### PR TITLE
klee-replay: Fix `-Wformat-truncation` warning

### DIFF
--- a/tools/klee-replay/file-creator.c
+++ b/tools/klee-replay/file-creator.c
@@ -49,10 +49,15 @@ static void check_file(int index, exe_disk_file_t *dfile);
 static int create_link(const char *fname,
                        exe_disk_file_t *dfile,
                        const char *tmpdir) {
-  char buf[64];
+  char buf[PATH_MAX];
   struct stat64 *s = dfile->stat;
 
-  snprintf(buf, sizeof(buf), "%s.lnk", fname);
+  // make sure that the .lnk suffix is not truncated
+  if (snprintf(buf, sizeof buf, "%s.lnk", fname) >= PATH_MAX) {
+    fputs("create_link: fname is too long for additional .lnk suffix", stderr);
+    return -1;
+  }
+
   s->st_mode = (s->st_mode & ~S_IFMT) | S_IFREG;
   create_file(-1, buf, dfile, tmpdir);
 


### PR DESCRIPTION
## Summary: 

Increase the size of the buffer to `PATH_MAX` in `create_link` as that is the maximal possible length of `fname` and check whether output truncation occurred.

Fixes:
```
tools/klee-replay/file-creator.c: In function 'create_file':
tools/klee-replay/file-creator.c:55:31: warning: '%s' directive output may be truncated writing up to 4095 bytes into a region of size 64 [-Wformat-truncation=]
   55 |   snprintf(buf, sizeof(buf), "%s.lnk", fname);
      |                               ^~
......
  344 |   target = tmpname;
      |            ~~~~~~~
In file included from /usr/include/stdio.h:866,
                 from tools/klee-replay/file-creator.c:16:
/usr/include/bits/stdio2.h:70:10: note: '__snprintf_chk' output between 5 and 4100 bytes into a destination of size 64
   70 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   71 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [ ] There are test cases for the code you added or modified OR no such test cases are required.
