### PR TITLE
test/Concrete: Use Python 3 in `ConcreteTest.py` explicitly

### DIFF
--- a/test/Concrete/ConcreteTest.py
+++ b/test/Concrete/ConcreteTest.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import argparse
 import os
 import platform
@@ -33,7 +32,6 @@ def testFile(name, klee_path, lli_path):
     lli_cmd = [lli_path, '-force-interpreter=true', exeFile]
     print("EXECUTING: %s" % (lli_cmd,))
 
-    # Decode is for python 3.x
     lliOut = subprocess.check_output(lli_cmd).decode()
     print('-- lli output --\n%s--\n' % (lliOut,))
 
@@ -45,7 +43,6 @@ def testFile(name, klee_path, lli_path):
     print("EXECUTING: %s" % (klee_cmd,))
     sys.stdout.flush()
 
-    # Decode is for python 3.x
     kleeOut = subprocess.check_output(klee_cmd).decode()
     print('-- klee output --\n%s--\n' % (kleeOut,))
         


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Some Linux distributions, e.g. Fedora, do not install the unversioned Python binary by default and Python 2 has been dead for more than a year.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
