### PR TITLE
Correctly update symbolic variables that have been changed externally

### DIFF
--- a/lib/Core/AddressSpace.cpp
+++ b/lib/Core/AddressSpace.cpp
@@ -336,13 +336,33 @@ bool AddressSpace::copyInConcretes() {
 bool AddressSpace::copyInConcrete(const MemoryObject *mo, const ObjectState *os,
                                   uint64_t src_address) {
   auto address = reinterpret_cast<std::uint8_t*>(src_address);
-  if (memcmp(address, os->concreteStore, mo->size) != 0) {
-    if (os->readOnly) {
-      return false;
-    } else {
-      ObjectState *wos = getWriteable(mo, os);
-      memcpy(wos->concreteStore, address, mo->size);
-    }
+
+  // Don't do anything if the underlying representation has not been changed
+  // externally.
+  if (std::memcmp(address, os->concreteStore, mo->size) == 0)
+    return true;
+
+  // External object representation has been changed
+
+  // Return `false` if the object is marked as read-only
+  if (os->readOnly)
+    return false;
+
+  ObjectState *wos = getWriteable(mo, os);
+  // Check if the object is fully concrete object. If so, use the fast
+  // path and `memcpy` the new values from the external object to the internal
+  // representation
+  if (!wos->unflushedMask) {
+    std::memcpy(wos->concreteStore, address, mo->size);
+    return true;
+  }
+
+  // The object is partially symbolic, it needs to be updated byte-by-byte
+  // via object state's `write` function
+  for (size_t i = 0, ie = mo->size; i < ie; ++i) {
+    u_int8_t external_byte_value = *(address + i);
+    if (external_byte_value != wos->concreteStore[i])
+      wos->write8(i, external_byte_value);
   }
   return true;
 }

--- a/lib/Core/AddressSpace.h
+++ b/lib/Core/AddressSpace.h
@@ -138,18 +138,22 @@ namespace klee {
     /// potentially copied) if the memory values are different from
     /// the current concrete values.
     ///
-    /// \retval true The copy succeeded. 
-    /// \retval false The copy failed because a read-only object was modified.
-    bool copyInConcretes();
+    /// \param concretize fully concretize the object representation if changed
+    /// externally
+    /// \return true if copy succeeded, otherwise false (e.g. try to modify
+    /// read-only object)
+    bool copyInConcretes(bool concretize);
 
     /// Updates the memory object with the raw memory from the address
     ///
     /// @param mo The MemoryObject to update
     /// @param os The associated memory state containing the actual data
     /// @param src_address the address to copy from
+    /// @param concretize fully concretize the object representation if changed
+    /// externally
     /// @return
     bool copyInConcrete(const MemoryObject *mo, const ObjectState *os,
-                        uint64_t src_address);
+                        uint64_t src_address, bool concretize);
   };
 } // End klee namespace
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4126,7 +4126,8 @@ void Executor::callExternalFunction(ExecutionState &state, KInstruction *target,
     return;
   }
 
-  if (!state.addressSpace.copyInConcretes()) {
+  if (!state.addressSpace.copyInConcretes(ExternalCalls ==
+                                          ExternalCallPolicy::All)) {
     terminateStateOnExecError(state, "external modified read-only object",
                               StateTerminationType::External);
     return;
@@ -4143,7 +4144,8 @@ void Executor::callExternalFunction(ExecutionState &state, KInstruction *target,
   // Update errno memory object with the errno value from the call
   int error = externalDispatcher->getLastErrno();
   state.addressSpace.copyInConcrete(result.first, result.second,
-                                    (uint64_t)&error);
+                                    (uint64_t)&error,
+                                    ExternalCalls == ExternalCallPolicy::All);
 #endif
 
   Type *resultType = target->inst->getType();

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -94,6 +94,7 @@ class Executor : public Interpreter {
   friend class SpecialFunctionHandler;
   friend class StatsTracker;
   friend class MergeHandler;
+  friend class ObjectState;
   friend klee::Searcher *klee::constructUserSearcher(Executor &executor);
 
 public:

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -199,7 +199,7 @@ const UpdateList &ObjectState::getUpdates() const {
 void ObjectState::flushToConcreteStore(TimingSolver *solver,
                                        const ExecutionState &state) const {
   for (unsigned i = 0; i < size; i++) {
-    if (isByteKnownSymbolic(i)) {
+    if (!isByteConcrete(i)) {
       ref<ConstantExpr> ce;
       bool success = solver->getValue(state.constraints, read8(i), ce,
                                       state.queryMetaData);

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -29,6 +29,7 @@ namespace klee {
 class ArrayCache;
 class BitArray;
 class ExecutionState;
+class Executor;
 class MemoryManager;
 class Solver;
 
@@ -233,12 +234,15 @@ public:
   void write64(unsigned offset, uint64_t value);
   void print() const;
 
-  /*
-    Looks at all the symbolic bytes of this object, gets a value for them
-    from the solver and puts them in the concreteStore.
-  */
-  void flushToConcreteStore(TimingSolver *solver,
-                            const ExecutionState &state) const;
+  /// Generate concrete values for each symbolic byte of the object and put them
+  /// in the concrete store.
+  ///
+  /// \param executor
+  /// \param state
+  /// \param concretize if true, constraints for concretised bytes are added if
+  /// necessary
+  void flushToConcreteStore(Executor &executor, ExecutionState &state,
+                            bool concretize);
 
 private:
   const UpdateList &getUpdates() const;

--- a/test/Feature/ConcretizeSymbolicExternals.c
+++ b/test/Feature/ConcretizeSymbolicExternals.c
@@ -1,0 +1,35 @@
+// Check for calling external functions using symbolic parameters.
+// Externals calls might modify memory objects that have been previously fully symbolic.
+// The constant modifications should be propagated back.
+// RUN: %clang %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out -external-calls=all %t.bc > %t.log
+// RUN: FileCheck -input-file=%t.log %s
+// REQUIRES: not-darwin
+#include "klee/klee.h"
+#include <stdio.h>
+
+int main() {
+
+  int a;
+  int b;
+  int c;
+
+  // Symbolize argument that gets concretized by the external call
+  klee_make_symbolic(&a, sizeof(a), "a");
+  klee_make_symbolic(&b, sizeof(b), "b");
+  klee_make_symbolic(&c, sizeof(c), "c");
+  if (a == 2 && b == 3) {
+    // Constrain fully symbolic `a` and `b` to concrete values
+
+    // Although a and b are not character vectors, explicitly constraining them to `2` and `3`
+    // leads to the most significant bits of the int (e.g. bit 8 to 31 of 32bit) set to `\0`.
+    // This leads to an actual null-termination of the character vector, which makes it safe
+    // to use by an external function.
+    printf("%s%s%n\n", (char *)&a, (char *)&b, &c);
+    printf("after: a = %d b = %d c = %d\n", a, b, c);
+    //CHECK: after: a = 2 b = 3 c = 2
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Before, external changes to symbolic variables have not been propagated
back to their internal representation.

Do a byte-by-byte comparison and potential update if required.

The test case is based on the example provided by Mingyi Liu from the
mailing list.

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
