### PR TITLE
Install git as a requirement for codecov

### DIFF
--- a/scripts/build/p-klee-linux-ubuntu.inc
+++ b/scripts/build/p-klee-linux-ubuntu.inc
@@ -35,7 +35,7 @@ install_build_dependencies_klee() {
   )
 
   if [[ $(to_bool "${COVERAGE}") -eq 1 ]]; then
-    dependencies+=(lcov curl)
+    dependencies+=(lcov curl git)
   fi
 
   apt -y --no-install-recommends install "${dependencies[@]}"


### PR DESCRIPTION
Codecov depends on git to detect the SHA sum of the repository.
Install as a dependency.

Warning message from codecov:
```
2021-09-13T08:59:56.7220068Z   _____          _
2021-09-13T08:59:56.7220767Z  / ____|        | |
2021-09-13T08:59:56.7221266Z | |     ___   __| | ___  ___ _____   __
2021-09-13T08:59:56.7221738Z | |    / _ \ / _` |/ _ \/ __/ _ \ \ / /
2021-09-13T08:59:56.7222216Z | |___| (_) | (_| |  __/ (_| (_) \ V /
2021-09-13T08:59:56.7222716Z  \_____\___/ \__,_|\___|\___\___/ \_/
2021-09-13T08:59:56.7224450Z                               Bash-1.0.6
2021-09-13T08:59:56.7225219Z 
2021-09-13T08:59:56.7225641Z 
2021-09-13T08:59:56.7231885Z [0;33m==>[0m git not installed, testing for mercurial
2021-09-13T08:59:56.7242361Z [0;31m==>[0m git nor mercurial are installed. Uploader may fail or have unintended consequences
```

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
