### PR TITLE
Fix crash of KLEE on preferCex() function on some code

### DIFF
--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -103,6 +103,7 @@ ExecutionState::ExecutionState(const ExecutionState& state):
     symPathOS(state.symPathOS),
     coveredLines(state.coveredLines),
     symbolics(state.symbolics),
+    cexPreferences(state.cexPreferences),
     arrayNames(state.arrayNames),
     openMergeStack(state.openMergeStack),
     steppedInstructions(state.steppedInstructions),
@@ -357,4 +358,8 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
 void ExecutionState::addConstraint(ref<Expr> e) {
   ConstraintManager c(constraints);
   c.addConstraint(e);
+}
+
+void ExecutionState::addCexPreference(const ref<Expr> &cond) {
+  cexPreferences = cexPreferences.insert(cond);
 }

--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -13,6 +13,7 @@
 #include "AddressSpace.h"
 #include "MergeHandler.h"
 
+#include "klee/ADT/ImmutableSet.h"
 #include "klee/ADT/TreeStream.h"
 #include "klee/Expr/Constraints.h"
 #include "klee/Expr/Expr.h"
@@ -207,6 +208,10 @@ public:
   // FIXME: Move to a shared list structure (not critical).
   std::vector<std::pair<ref<const MemoryObject>, const Array *>> symbolics;
 
+  /// @brief A set of boolean expressions
+  /// the user has requested be true of a counterexample.
+  ImmutableSet<ref<Expr>> cexPreferences;
+
   /// @brief Set of used array names for this state.  Used to avoid collisions.
   std::set<std::string> arrayNames;
 
@@ -259,6 +264,7 @@ public:
   void addSymbolic(const MemoryObject *mo, const Array *array);
 
   void addConstraint(ref<Expr> e);
+  void addCexPreference(const ref<Expr> &cond);
 
   bool merge(const ExecutionState &b);
   void dumpStack(llvm::raw_ostream &out) const;

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -64,12 +64,6 @@ public:
   /// should be either the allocating instruction or the global object
   /// it was allocated for (or whatever else makes sense).
   const llvm::Value *allocSite;
-  
-  /// A list of boolean expressions the user has requested be true of
-  /// a counterexample. Mutable since we play a little fast and loose
-  /// with allowing it to be added to during execution (although
-  /// should sensibly be only at creation time).
-  mutable std::vector< ref<Expr> > cexPreferences;
 
   // DO NOT IMPLEMENT
   MemoryObject(const MemoryObject &b);

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -549,13 +549,7 @@ void SpecialFunctionHandler::handlePreferCex(ExecutionState &state,
   if (cond->getWidth() != Expr::Bool)
     cond = NeExpr::create(cond, ConstantExpr::alloc(0, cond->getWidth()));
 
-  Executor::ExactResolutionList rl;
-  executor.resolveExact(state, arguments[0], rl, "prefex_cex");
-  
-  assert(rl.size() == 1 &&
-         "prefer_cex target must resolve to precisely one object");
-
-  rl[0].first.first->cexPreferences.push_back(cond);
+  state.addCexPreference(cond);
 }
 
 void SpecialFunctionHandler::handlePosixPreferCex(ExecutionState &state,

--- a/test/Replay/libkleeruntest/replay_cex_after_assumed_malloc.c
+++ b/test/Replay/libkleeruntest/replay_cex_after_assumed_malloc.c
@@ -1,0 +1,25 @@
+// RUN: %clang %s -S -emit-llvm -g -c -o %t.ll
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out %t.ll
+// KLEE just must not fail
+#include "klee/klee.h"
+
+int main() {
+  char i;
+  char *p;
+  char *q;
+  klee_make_symbolic(&i, sizeof(i), "i");
+  klee_make_symbolic(&p, sizeof(p), "p");
+
+  if (i) {}
+
+  q = malloc(sizeof (char));
+  klee_assume(p == q);
+  klee_make_symbolic(p, sizeof (char), "p[0]");
+
+  char condition = (*p);
+  if (*p) condition = 1;
+  klee_prefer_cex(&i, condition);
+  if (i+5) {}
+  return 0;
+}

--- a/test/Replay/libkleeruntest/replay_cex_incorrect_result.c
+++ b/test/Replay/libkleeruntest/replay_cex_incorrect_result.c
@@ -1,0 +1,51 @@
+// RUN: %clang %s -S -emit-llvm -g -c -o %t.ll
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --search=dfs --output-dir=%t.klee-out %t.ll
+
+// This should produce four test cases.
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: test -f %t.klee-out/test000002.ktest
+// RUN: test -f %t.klee-out/test000003.ktest
+// RUN: test -f %t.klee-out/test000004.ktest
+// RUN: test ! -f %t.klee-out/test000005.ktest
+
+// Now try to replay with libkleeRuntest
+// RUN: %cc -DPRINT_VALUE %s %libkleeruntest -Wl,-rpath %libkleeruntestdir -o %t_runner
+
+// RUN: env KTEST_FILE=%t.klee-out/test000001.ktest %t_runner 2>&1 | FileCheck -check-prefix=CHECK_1 %s
+// RUN: env KTEST_FILE=%t.klee-out/test000002.ktest %t_runner 2>&1 | FileCheck -check-prefix=CHECK_2 %s
+// RUN: env KTEST_FILE=%t.klee-out/test000003.ktest %t_runner 2>&1 | FileCheck -check-prefix=CHECK_3 %s
+// RUN: env KTEST_FILE=%t.klee-out/test000004.ktest %t_runner 2>&1 | FileCheck -check-prefix=CHECK_4 %s
+
+#include <klee/klee.h>
+#include <stdio.h>
+
+void f0(void) {}
+void f1(void) {}
+void f2(void) {}
+void f3(void) {}
+
+int main() {
+  int x = klee_range(0, 256, "x");
+
+  if (x == 17) {
+    f0();
+    // CHECK_4: x=17
+  } else if (x == 32) {
+    f1();
+    // CHECK_3: x=32
+  } else if (x == 99) {
+    f2();
+    // CHECK_2: x=99
+  } else {
+    klee_prefer_cex(&x, x == 0);
+    f3();
+    // CHECK_1: x=0
+  }
+
+#ifdef PRINT_VALUE
+  printf("x=%d\n", x);
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
## Summary: 
There is some problem with handling preferCex. Sometimes addresses initialized in some state, but Klee try to read them from another state. Sometimes it causes the segfault.  
The file which create this error is also attached to pull-request as new system-test.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.

Also after this cnahge first parameter of preferCex has no effect and now it is only for compability.

