### PR TITLE
test/Feature/FunctionAlias.c: Add missing `CHECK-UNKNOWN` prefix

### DIFF
--- a/test/Feature/FunctionAlias.c
+++ b/test/Feature/FunctionAlias.c
@@ -38,6 +38,8 @@
 
 // CHECK-TYPE-MISMATCH: KLEE: WARNING: function-alias: @{{[a-z0-9]+}} could not be replaced with @{{[a-z0-9]+}}
 
+// CHECK-UNKNOWN: KLEE: ERROR: function-alias: replacement function @unknownfunction could not be found
+
 // CHECK-SUCCESS: KLEE: function-alias: replaced @twoints with @twointsmul
 
 // CHECK-REGEX-NO-MATCH: KLEE: ERROR: function-alias: no (replacable) match for 'xxx.*' found


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
This test started to fail on LLVM 13 because `FileCheck` switched the default setting regarding the allowance of unused prefixes.  This is now considered to be a fatal error.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
