### PR TITLE
cmake: do not create symlinks to `klee-uclibc` and `klee-libcxx`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,22 +539,13 @@ if (ENABLE_KLEE_UCLIBC)
   endif()
   message(STATUS "Found klee-uclibc library: \"${KLEE_UCLIBC_C_BCA}\"")
 
-  # Make a symlink to KLEE_UCLIBC_C_BCA so KLEE can find it where it
-  # is expected.
-  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+  # Copy KLEE_UCLIBC_C_BCA so KLEE can find it where it is expected.
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy
     "${KLEE_UCLIBC_C_BCA}"
     "${KLEE_RUNTIME_DIRECTORY}/${KLEE_UCLIBC_BCA_NAME}"
   )
   list(APPEND KLEE_COMPONENT_CXX_DEFINES
     -DKLEE_UCLIBC_BCA_NAME=\"${KLEE_UCLIBC_BCA_NAME}\")
-
-  # Add klee-uclibc to the install target. We install the original
-  # file rather than the symlink because CMake would just copy the symlink
-  # rather than the file.
-  install(FILES "${KLEE_UCLIBC_C_BCA}"
-    DESTINATION "${KLEE_INSTALL_RUNTIME_DIR}"
-    RENAME "${KLEE_UCLIBC_BCA_NAME}"
-    )
 
 else()
   message(STATUS "klee-uclibc support disabled")
@@ -605,23 +596,14 @@ if (ENABLE_KLEE_LIBCXX)
   endif()
   message(STATUS "Found libc++ library: \"${KLEE_LIBCXX_BC_PATH}\"")
 
-  # Make a symlink to KLEE_LIBCXX_BC_PATH so KLEE can find it where it
-  # is expected.
+  # Copy KLEE_LIBCXX_BC_PATH so KLEE can find it where it is expected.
   file(MAKE_DIRECTORY "${KLEE_RUNTIME_DIRECTORY}")
-  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy
     "${KLEE_LIBCXX_BC_PATH}"
     "${KLEE_RUNTIME_DIRECTORY}/${KLEE_LIBCXX_BC_NAME}"
   )
   list(APPEND KLEE_COMPONENT_CXX_DEFINES
     -DKLEE_LIBCXX_BC_NAME=\"${KLEE_LIBCXX_BC_NAME}\")
-
-  # Add libc++ to the install target. We install the original
-  # file rather than the symlink because CMake would just copy the symlink
-  # rather than the file.
-  install(FILES "${KLEE_LIBCXX_BC_PATH}"
-    DESTINATION "${KLEE_INSTALL_RUNTIME_DIR}"
-    RENAME "${KLEE_LIBCXX_BC_NAME}"
-    )
 
 else()
   message(STATUS "libc++ support disabled")


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Before this change, we created a symlink to the given library in their expected
location and then installed the original library.  This was problematic as the
install directives are performed the order they are encountered during the
configure step and the installation of directory containing the symlink was
processed after the installation of the original library.  Therefore, the
original libraries were installed but were subsequently overwritten by the
symlinks.

This commit changes the behaviour so that we create hard links in the expected
location and install them together with the rest of the KLEE runtime as was
originally intended.

> There are test cases for the code you added or modified OR no such test cases are required.

I found this issue when I was adding uClibc to KLEE package in Fedora and I can confirm that this commit fixes it.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
