### PR TITLE
refactoring ExecutionState::merge

### DIFF
--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -311,11 +311,9 @@ bool ExecutionState::merge(const ExecutionState &b) {
   }
 
   constraints = ConstraintSet();
-
-  ConstraintManager m(constraints);
   for (const auto &constraint : commonConstraints)
-    m.addConstraint(constraint);
-  m.addConstraint(OrExpr::create(inA, inB));
+    addConstraint(constraint);
+  addConstraint(OrExpr::create(inA, inB));
 
   return true;
 }


### PR DESCRIPTION
## Summary: 
Refactoring `ExecutionState::merge` to be more consistent with the rest of the code.
Using here `ExecutionState::addConstraint` instead of the underlying `ConstraintManager::addConstraint`.