### PR TITLE
ktest-tool: --extract: warn if object can't be found

### DIFF
--- a/tools/ktest-tool/ktest-tool
+++ b/tools/ktest-tool/ktest-tool
@@ -115,6 +115,7 @@ class KTest:
         return sio.getvalue()
 
     def extract(self, object_names, trim_zeros):
+        extracted_objects = set()
         for name, data in self.objects:
             if name not in object_names:
                 continue
@@ -123,6 +124,12 @@ class KTest:
             blob = data.rstrip(b'\x00') if trim_zeros else data
             f.write(blob)
             f.close()
+            extracted_objects.add(name)
+        missing_objects = list(object_names - extracted_objects)
+        missing_objects.sort()
+        if missing_objects:
+            sys.exit(f'Could not find object{"s"[:len(missing_objects)^1]}: {", ".join(missing_objects)}')
+
 
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

`ktest-tool` silently exits when an object for `--extract` can't be found. It now prints a warning message and exits with error code `1`, e.g.:

Before:
```Bash
> ktest-tool --extract Z --extract A-data test000096.ktest        
```
After:
```Bash
> ktest-tool --extract Z --extract A-data test000096.ktest        
Could not find object: Z
```
or:
```Bash
> ktest-tool --extract Z --extract A-data --extract B-data --extract C-Data test000096.ktest
Could not find objects: B-data, C-Data, Z
```

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
