### PR TITLE
klee-stats: order remaining columns alphabetically

### DIFF
--- a/test/Feature/KleeStatsColumns.test
+++ b/test/Feature/KleeStatsColumns.test
@@ -1,5 +1,5 @@
 RUN: %klee-stats --print-all %S/klee-stats/missing_column %S/klee-stats/run %S/klee-stats/additional_column | FileCheck %s
 
-CHECK: {{^}}| missing_column  |        |{{.*}}|             |{{$}}
-CHECK: {{^}}|       run       |       3|{{.*}}|             |{{$}}
-CHECK: {{^}}|additional_column|       3|{{.*}}|         4711|{{$}}
+CHECK: {{^}}| missing_column  |        |{{.*}}|             |{{.*}}|{{$}}
+CHECK: {{^}}|       run       |       3|{{.*}}|             |{{.*}}|{{$}}
+CHECK: {{^}}|additional_column|       3|{{.*}}|         4711|{{.*}}|{{$}}

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -363,6 +363,7 @@ def write_table(args, data, dirs, pr):
         if l_name in available_headers:
             headers.append(l_name)
             available_headers.remove(l_name)
+    available_headers.sort()
     headers += available_headers
 
     # Make sure we keep the correct order of the column entries


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

Currently `klee-stats --print-all` prints the last columns in varying order. With this fix we keep the same order every time to make it easier to join .csv files.

Before (headers with 5 runs on the same directories):
```Bash
|              Path              |    Instrs|  Time(s)|  TUser(s)|  ICov(%)|  BCov(%)|  ICount|  TSolver(s)|  TSolver(%)|  States|  AvgStates|  Mem(MB)|  Queries|  AvgQC|  Tcex(s)|  Tcex(%)|  Tfork(s)|  Tfork(%)|  TResolve(s)|  TResolve(%)|  QCexCMisses|  QCexCHits|  NumQueryConstructs|  QueryTime|  maxState|  maxMem|  RelUserTime|  TimedOutQueries|  avgMem|  ArrayHashTime|  MadviseCalls|  PartialBranches|  NumBranches|  InhibitedForks|  NumAllocs|  AllQueries|  QueryCacheHits|  CoveredInstructions|  QueryCacheMisses|  MaxRSS|  ExternalCalls|  FullBranches|  KilledStates|  UncoveredInstructions|
|              Path              |    Instrs|  Time(s)|  TUser(s)|  ICov(%)|  BCov(%)|  ICount|  TSolver(s)|  TSolver(%)|  States|  AvgStates|  Mem(MB)|  Queries|  AvgQC|  Tcex(s)|  Tcex(%)|  Tfork(s)|  Tfork(%)|  TResolve(s)|  TResolve(%)|  QCexCMisses|  QCexCHits|  ArrayHashTime|  NumQueryConstructs|  RelUserTime|  PartialBranches|  ExternalCalls|  TimedOutQueries|  avgMem|  QueryTime|  CoveredInstructions|  KilledStates|  MadviseCalls|  maxState|  NumBranches|  MaxRSS|  FullBranches|  QueryCacheMisses|  InhibitedForks|  NumAllocs|  QueryCacheHits|  UncoveredInstructions|  maxMem|  AllQueries|
|              Path              |    Instrs|  Time(s)|  TUser(s)|  ICov(%)|  BCov(%)|  ICount|  TSolver(s)|  TSolver(%)|  States|  AvgStates|  Mem(MB)|  Queries|  AvgQC|  Tcex(s)|  Tcex(%)|  Tfork(s)|  Tfork(%)|  TResolve(s)|  TResolve(%)|  QCexCMisses|  QCexCHits|  CoveredInstructions|  maxState|  ExternalCalls|  maxMem|  UncoveredInstructions|  QueryCacheHits|  AllQueries|  NumQueryConstructs|  TimedOutQueries|  FullBranches|  KilledStates|  avgMem|  NumBranches|  ArrayHashTime|  RelUserTime|  QueryTime|  PartialBranches|  QueryCacheMisses|  InhibitedForks|  MadviseCalls|  NumAllocs|  MaxRSS|
|              Path              |    Instrs|  Time(s)|  TUser(s)|  ICov(%)|  BCov(%)|  ICount|  TSolver(s)|  TSolver(%)|  States|  AvgStates|  Mem(MB)|  Queries|  AvgQC|  Tcex(s)|  Tcex(%)|  Tfork(s)|  Tfork(%)|  TResolve(s)|  TResolve(%)|  QCexCMisses|  QCexCHits|  NumAllocs|  InhibitedForks|  MadviseCalls|  TimedOutQueries|  NumBranches|  PartialBranches|  ExternalCalls|  UncoveredInstructions|  KilledStates|  QueryCacheHits|  maxState|  CoveredInstructions|  QueryTime|  maxMem|  MaxRSS|  ArrayHashTime|  RelUserTime|  AllQueries|  NumQueryConstructs|  FullBranches|  avgMem|  QueryCacheMisses|
|              Path              |    Instrs|  Time(s)|  TUser(s)|  ICov(%)|  BCov(%)|  ICount|  TSolver(s)|  TSolver(%)|  States|  AvgStates|  Mem(MB)|  Queries|  AvgQC|  Tcex(s)|  Tcex(%)|  Tfork(s)|  Tfork(%)|  TResolve(s)|  TResolve(%)|  QCexCMisses|  QCexCHits|  PartialBranches|  ExternalCalls|  CoveredInstructions|  KilledStates|  QueryTime|  avgMem|  NumBranches|  AllQueries|  MadviseCalls|  maxState|  FullBranches|  InhibitedForks|  ArrayHashTime|  NumAllocs|  maxMem|  QueryCacheHits|  MaxRSS|  QueryCacheMisses|  TimedOutQueries|  NumQueryConstructs|  UncoveredInstructions|  RelUserTime|
```
After:
```Bash
|              Path              |    Instrs|  Time(s)|  TUser(s)|  ICov(%)|  BCov(%)|  ICount|  TSolver(s)|  TSolver(%)|  States|  AvgStates|  Mem(MB)|  Queries|  AvgQC|  Tcex(s)|  Tcex(%)|  Tfork(s)|  Tfork(%)|  TResolve(s)|  TResolve(%)|  QCexCMisses|  QCexCHits|  AllQueries|  ArrayHashTime|  CoveredInstructions|  ExternalCalls|  FullBranches|  InhibitedForks|  KilledStates|  MadviseCalls|  MaxRSS|  NumAllocs|  NumBranches|  NumQueryConstructs|  PartialBranches|  QueryCacheHits|  QueryCacheMisses|  QueryTime|  RelUserTime|  TimedOutQueries|  UncoveredInstructions|  avgMem|  maxMem|  maxState|
|              Path              |    Instrs|  Time(s)|  TUser(s)|  ICov(%)|  BCov(%)|  ICount|  TSolver(s)|  TSolver(%)|  States|  AvgStates|  Mem(MB)|  Queries|  AvgQC|  Tcex(s)|  Tcex(%)|  Tfork(s)|  Tfork(%)|  TResolve(s)|  TResolve(%)|  QCexCMisses|  QCexCHits|  AllQueries|  ArrayHashTime|  CoveredInstructions|  ExternalCalls|  FullBranches|  InhibitedForks|  KilledStates|  MadviseCalls|  MaxRSS|  NumAllocs|  NumBranches|  NumQueryConstructs|  PartialBranches|  QueryCacheHits|  QueryCacheMisses|  QueryTime|  RelUserTime|  TimedOutQueries|  UncoveredInstructions|  avgMem|  maxMem|  maxState|
|              Path              |    Instrs|  Time(s)|  TUser(s)|  ICov(%)|  BCov(%)|  ICount|  TSolver(s)|  TSolver(%)|  States|  AvgStates|  Mem(MB)|  Queries|  AvgQC|  Tcex(s)|  Tcex(%)|  Tfork(s)|  Tfork(%)|  TResolve(s)|  TResolve(%)|  QCexCMisses|  QCexCHits|  AllQueries|  ArrayHashTime|  CoveredInstructions|  ExternalCalls|  FullBranches|  InhibitedForks|  KilledStates|  MadviseCalls|  MaxRSS|  NumAllocs|  NumBranches|  NumQueryConstructs|  PartialBranches|  QueryCacheHits|  QueryCacheMisses|  QueryTime|  RelUserTime|  TimedOutQueries|  UncoveredInstructions|  avgMem|  maxMem|  maxState|
|              Path              |    Instrs|  Time(s)|  TUser(s)|  ICov(%)|  BCov(%)|  ICount|  TSolver(s)|  TSolver(%)|  States|  AvgStates|  Mem(MB)|  Queries|  AvgQC|  Tcex(s)|  Tcex(%)|  Tfork(s)|  Tfork(%)|  TResolve(s)|  TResolve(%)|  QCexCMisses|  QCexCHits|  AllQueries|  ArrayHashTime|  CoveredInstructions|  ExternalCalls|  FullBranches|  InhibitedForks|  KilledStates|  MadviseCalls|  MaxRSS|  NumAllocs|  NumBranches|  NumQueryConstructs|  PartialBranches|  QueryCacheHits|  QueryCacheMisses|  QueryTime|  RelUserTime|  TimedOutQueries|  UncoveredInstructions|  avgMem|  maxMem|  maxState|
|              Path              |    Instrs|  Time(s)|  TUser(s)|  ICov(%)|  BCov(%)|  ICount|  TSolver(s)|  TSolver(%)|  States|  AvgStates|  Mem(MB)|  Queries|  AvgQC|  Tcex(s)|  Tcex(%)|  Tfork(s)|  Tfork(%)|  TResolve(s)|  TResolve(%)|  QCexCMisses|  QCexCHits|  AllQueries|  ArrayHashTime|  CoveredInstructions|  ExternalCalls|  FullBranches|  InhibitedForks|  KilledStates|  MadviseCalls|  MaxRSS|  NumAllocs|  NumBranches|  NumQueryConstructs|  PartialBranches|  QueryCacheHits|  QueryCacheMisses|  QueryTime|  RelUserTime|  TimedOutQueries|  UncoveredInstructions|  avgMem|  maxMem|  maxState|
```

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
