### PR TITLE
Do not use stat64 directly in gen-random-bout

### DIFF
--- a/tools/gen-random-bout/gen-random-bout.cpp
+++ b/tools/gen-random-bout/gen-random-bout.cpp
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define _FILE_OFFSET_BITS 64
+
 #include <assert.h>
 #include <fcntl.h>
 #include <limits.h>
@@ -21,10 +23,6 @@
 
 #include "klee/ADT/KTest.h"
 
-#if defined(__FreeBSD__) || defined(__minix)
-#define stat64 stat
-#define fstat64 fstat
-#endif
 
 #define SMALL_BUFFER_SIZE 64 // To hold "arg<N>" string, temporary
                              // filename, etc.
@@ -95,7 +93,7 @@ static void push_range(KTest *b, const char *name, unsigned value) {
   push_obj(b, name, 4, (unsigned char *)&value);
 }
 
-void create_stat(size_t size, struct stat64 *s) {
+void create_stat(size_t size, struct stat *s) {
   char filename_template[] = "/tmp/klee-gen-random-bout-XXXXXX";
   char *filename;
   int fd;
@@ -120,7 +118,7 @@ void create_stat(size_t size, struct stat64 *s) {
     error_exit("%s:%d: Error writing %s\n", __FILE__, __LINE__, filename);
   }
 
-  fstat64(fd, s);
+  fstat(fd, s);
 
   close(fd);
 
@@ -242,7 +240,7 @@ int main(int argc, char *argv[]) {
     char filename[] = "A-data";
     char file_stat[] = "A-data-stat";
     unsigned nbytes;
-    struct stat64 s;
+    struct stat s;
 
     if (i >= MAX_FILE_SIZES) {
       fprintf(stderr, "%s:%d: Maximum number of file sizes exceeded (%d)\n",
@@ -257,26 +255,26 @@ int main(int argc, char *argv[]) {
     create_stat(nbytes, &s);
 
     push_random_obj(&b, filename, nbytes, nbytes);
-    push_obj(&b, file_stat, sizeof(struct stat64), (unsigned char *)&s);
+    push_obj(&b, file_stat, sizeof(struct stat), (unsigned char *)&s);
   }
 
   if (stdin_size) {
-    struct stat64 s;
+    struct stat s;
 
     // Using disk file works well with klee-replay.
     create_stat(stdin_size, &s);
 
     push_random_obj(&b, "stdin", stdin_size, stdin_size);
-    push_obj(&b, "stdin-stat", sizeof(struct stat64), (unsigned char *)&s);
+    push_obj(&b, "stdin-stat", sizeof(struct stat), (unsigned char *)&s);
   }
   if (sym_stdout) {
-    struct stat64 s;
+    struct stat s;
 
     // Using disk file works well with klee-replay.
     create_stat(1024, &s);
 
     push_random_obj(&b, "stdout", 1024, 1024);
-    push_obj(&b, "stdout-stat", sizeof(struct stat64), (unsigned char *)&s);
+    push_obj(&b, "stdout-stat", sizeof(struct stat), (unsigned char *)&s);
   }
   push_range(&b, "model_version", 1);
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
There is no need to use stat64 explicitly in gen-random-bout.  This also eliminates some warnings on e.g., macOS.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
