### PR TITLE
Use more precise version check for selecting swapoff() signature.

### DIFF
--- a/runtime/POSIX/FreeBSD.h
+++ b/runtime/POSIX/FreeBSD.h
@@ -1,6 +1,8 @@
 #ifndef KLEE_FREEBSD_H
 #define KLEE_FREEBSD_H
 
+#include <sys/param.h>
+
 // termios maps
 #define TCGETS  TIOCGETA
 #define TCSETS  TIOCSETA

--- a/runtime/POSIX/stubs.c
+++ b/runtime/POSIX/stubs.c
@@ -432,7 +432,7 @@ int swapon(const char *path) {
 #ifndef __FreeBSD__
 int swapoff(const char *path) __attribute__((weak));
 int swapoff(const char *path) {
-#elif __FreeBSD__ < 13
+#elif __FreeBSD_version < 1300523
 int swapoff(const char *path) __attribute__((weak));
 int swapoff(const char *path) {
 #else


### PR DESCRIPTION
An improvement over #1451 