### PR TITLE
Fixed a crash in the operation of 128-bit variables in the sse instruction set of the x86/x64 architecture

### DIFF
--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -39,10 +39,8 @@ char IntrinsicCleanerPass::ID;
 bool IntrinsicCleanerPass::runOnModule(Module &M) {
   bool dirty = false;
   for (Module::iterator f = M.begin(), fe = M.end(); f != fe; ++f)
-    for (Function::iterator b = f->begin(), be = f->end(); b != be; ++b){
-      std::string name = f->getName();
+    for (Function::iterator b = f->begin(), be = f->end(); b != be; ++b)
       dirty |= runOnBasicBlock(*b, M);
-    }
     
   if (Function *Declare = M.getFunction("llvm.trap")) {
     Declare->eraseFromParent();
@@ -294,13 +292,11 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
             result = builder.CreateSub(op1, op2);
             overflow = builder.CreateICmpULT(op1, op2); // a < b  =>  a - b < 0
             saturated = createConstantVector(ctx,op1,0);
-            //saturated = ConstantInt::get(ctx, APInt(bw, 0));
             break;
           case Intrinsic::uadd_sat:
             result = builder.CreateAdd(op1, op2);
             overflow = builder.CreateICmpULT(result, op1); // a + b < a
             saturated = createConstantVector(ctx,op1,1);
-            //saturated = ConstantInt::get(ctx, APInt::getMaxValue(bw));
             break;
           case Intrinsic::ssub_sat:
           case Intrinsic::sadd_sat: {
@@ -322,21 +318,6 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
             } else { 
               saturated = builder.CreateSelect(sign2, pConstantMin, pConstantMax);
             } 
-/*          
-            ConstantInt *zero = ConstantInt::get(ctx, APInt(bw, 0));
-            ConstantInt *smin = ConstantInt::get(ctx, APInt::getSignedMinValue(bw));
-            ConstantInt *smax = ConstantInt::get(ctx, APInt::getSignedMaxValue(bw));
-
-            Value *sign1 = builder.CreateICmpSLT(op1, zero);
-            Value *sign2 = builder.CreateICmpSLT(op2, zero);
-            Value *signR = builder.CreateICmpSLT(result, zero);
-
-            if (ii->getIntrinsicID() == Intrinsic::ssub_sat) {
-              saturated = builder.CreateSelect(sign2, smax, smin);
-            } else {
-              saturated = builder.CreateSelect(sign2, smin, smax);
-            }
-*/
             // The sign of the result differs from the sign of the first operand
             overflow = builder.CreateXor(sign1, signR);
             if (ii->getIntrinsicID() == Intrinsic::ssub_sat) {

--- a/lib/Module/Passes.h
+++ b/lib/Module/Passes.h
@@ -61,7 +61,7 @@ class IntrinsicCleanerPass : public llvm::ModulePass {
   llvm::IntrinsicLowering *IL;
 
   bool runOnBasicBlock(llvm::BasicBlock &b, llvm::Module &M);
-
+  llvm::Constant* createConstantVector(llvm::LLVMContext& ctx, llvm::Value* pConstantVector, unsigned mode);
 public:
   IntrinsicCleanerPass(const llvm::DataLayout &TD)
       : llvm::ModulePass(ID), DataLayout(TD),


### PR DESCRIPTION
## Summary: 
When using llvm9, in the IntrinsicCleanerPass function, handle the bug that the usub_sat, uadd_sat, ssub_sat and sadd_sat instructions crash

Testcase:
#include <stdio.h>
#include <stdlib.h>
#include <immintrin.h>
void adds8x16_sat() { 
	__m128i round_8x16b,y_0_8x16b;
	y_0_8x16b = _mm_adds_epi16(round_8x16b, y_0_8x16b); 	//bug1
}
void subs8x16_sat() { 
	__m128i round_8x16b,y_0_8x16b;
	y_0_8x16b = _mm_subs_epi16(round_8x16b, y_0_8x16b); 	//bug2
}
void uadd8x16_sat() { 
	__m128i round_8x16b,y_0_8x16b;
	y_0_8x16b = _mm_adds_epu8(round_8x16b, y_0_8x16b); 	//bug3
}
void usubs8x16_sat() { 
	__m128i round_8x16b,y_0_8x16b;
	y_0_8x16b = _mm_subs_epu8(round_8x16b, y_0_8x16b); 	//bug4
}
int main(int argc, char* argv[]) { 
	adds8x16_sat();
	subs8x16_sat();
	add8x16_sat();
	sub8x16_sat();
	return 0;
}	

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
