### PR TITLE
Fixed a crash in the operation of 128-bit variables in the sse instruction set of the x86/x64 architecture

### DIFF
--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -41,7 +41,7 @@ bool IntrinsicCleanerPass::runOnModule(Module &M) {
   for (Module::iterator f = M.begin(), fe = M.end(); f != fe; ++f)
     for (Function::iterator b = f->begin(), be = f->end(); b != be; ++b)
       dirty |= runOnBasicBlock(*b, M);
-    
+  
   if (Function *Declare = M.getFunction("llvm.trap")) {
     Declare->eraseFromParent();
     dirty = true;
@@ -265,10 +265,6 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         ii->eraseFromParent();
         dirty = true;
         break;
-
-        //Value *op1;
-        //Type * type = op1->getType()->getVectorElementType();
-
       }
 #if LLVM_VERSION_CODE >= LLVM_VERSION(8, 0)
       case Intrinsic::sadd_sat:
@@ -276,17 +272,13 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
       case Intrinsic::uadd_sat:
       case Intrinsic::usub_sat: {
         IRBuilder<> builder(ii);
-
         Value *op1 = ii->getArgOperand(0);
         Value *op2 = ii->getArgOperand(1);
-
         unsigned int bw = op1->getType()->getPrimitiveSizeInBits();
         assert(bw == op2->getType()->getPrimitiveSizeInBits());
-        
         Value *overflow = nullptr;
         Value *result = nullptr;
         Value *saturated = nullptr;
-
         switch(ii->getIntrinsicID()) {
           case Intrinsic::usub_sat:
             result = builder.CreateSub(op1, op2);

--- a/lib/Module/Passes.h
+++ b/lib/Module/Passes.h
@@ -61,7 +61,7 @@ class IntrinsicCleanerPass : public llvm::ModulePass {
   llvm::IntrinsicLowering *IL;
 
   bool runOnBasicBlock(llvm::BasicBlock &b, llvm::Module &M);
-
+  llvm::Constant* createConstantVector(llvm::LLVMContext& ctx, llvm::Value* pConstantVector, unsigned mode);
 public:
   IntrinsicCleanerPass(const llvm::DataLayout &TD)
       : llvm::ModulePass(ID), DataLayout(TD),


### PR DESCRIPTION
## Summary: 
When using llvm9, in the IntrinsicCleanerPass function, handle the bug that the usub_sat, uadd_sat, ssub_sat and sadd_sat instructions crash.

Code change description:
1. Fixed the crash when the two parameter types did not match when calling the CreateICmpSLT function and the crash when the element types did not match when calling the CreateSelect function.
2. Added the createConstantVector function to create a ConstantVector. The bit width and number of elements created depend on the input pConstantVector, and the mode parameter is used to limit the value of the element.

Testcase:
#include <stdio.h>
#include <stdlib.h>
#include <immintrin.h>
void adds8x16_sat() {
__m128i round_8x16b,y_0_8x16b;
y_0_8x16b = _mm_adds_epi16(round_8x16b, y_0_8x16b); //bug1
}
void subs8x16_sat() {
__m128i round_8x16b,y_0_8x16b;
y_0_8x16b = _mm_subs_epi16(round_8x16b, y_0_8x16b); //bug2
}
void uadd8x16_sat() {
__m128i round_8x16b,y_0_8x16b;
y_0_8x16b = _mm_adds_epu8(round_8x16b, y_0_8x16b); //bug3
}
void usubs8x16_sat() {
__m128i round_8x16b,y_0_8x16b;
y_0_8x16b = _mm_subs_epu8(round_8x16b, y_0_8x16b); //bug4
}
int main(int argc, char* argv[]) {
adds8x16_sat();
subs8x16_sat();
add8x16_sat();
sub8x16_sat();
return 0;
}

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
