### PR TITLE
Improve Google Test Integration and Version Support (for Unit Testing)

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -43,15 +43,14 @@ function(add_vanilla_googletest_subdirectory directory)
   add_subdirectory(${directory} "${CMAKE_CURRENT_BINARY_DIR}/gtest_build")
 endfunction()
 
-if (TARGET gtest AND TARGET gtest_main)
-  # try to reuse LLVM's targets
+if (TARGET gtest)
+  # try to reuse LLVM's 'gtest' target
 
-  message(WARNING "LLVM exports 'gtest' and 'gtest_main' targets (for Google "
-    "Test), so KLEE cannot create them. By default, KLEE will reuse "
-    "LLVM's 'gtest' and 'gtest_main' targets if they are available. This is, "
-    "however, only recommended if LLVM and KLEE were build with the same "
-    "compiler and linker flags to prevent any compatibility issues.\n"
-    "To prevent CMake from reusing the targets or to use a different version "
+  message(WARNING "LLVM exports its 'gtest' CMake target (for Google Test), so"
+    "KLEE cannot create its own. Thus, KLEE will reuse the existing one. This"
+    "is, however, only recommended if LLVM and KLEE were built using the same"
+    "compiler and linker flags (to prevent compatibility issues).\n"
+    "To prevent CMake from reusing the target or to use a different version "
     "of Google Test, try either of the following:\n"
     "- Point LLVM_DIR to the directory containing the `LLVMConfig.cmake` file "
     "of an installed copy of LLVM instead of a build tree.\n"
@@ -60,17 +59,16 @@ if (TARGET gtest AND TARGET gtest_main)
     "target to the build tree.")
 
   if (GTEST_SRC_DIR)
-    message(FATAL_ERROR "Cannot use GTEST_SRC_DIR when targets 'gtest' and "
-      "'gtest_main' are already defined.\n"
+    message(FATAL_ERROR "Cannot use GTEST_SRC_DIR when target 'gtest' is"
+      "already defined.\n"
       "Either reuse LLVM's Google Test setup by not setting GTEST_SRC_DIR or "
-      "choose one of the options to prevent LLVM from exporting these targets.")
+      "choose one of the options to prevent LLVM from exporting this target.")
   endif()
 
-  # check if it's really LLVM that exports them
+  # check if it's really LLVM that exports the 'gtest' target
   list(FIND LLVM_EXPORTED_TARGETS "gtest" _GTEST_INDEX)
-  list(FIND LLVM_EXPORTED_TARGETS "test_main" _GTEST_MAIN_INDEX)
-  if (${_GTEST_INDEX} GREATER -1 AND ${_GTEST_MAIN_INDEX})
-    message(STATUS "Google Test: Reusing LLVM's 'gtest' and 'gtest_main' targets.")
+  if (${_GTEST_INDEX} GREATER -1)
+    message(STATUS "Google Test: Reusing LLVM's 'gtest' target.")
     # in this case, only include directory has to be set
     if (LLVM_BUILD_MAIN_SRC_DIR)
       set(GTEST_INCLUDE_DIR
@@ -81,11 +79,11 @@ if (TARGET gtest AND TARGET gtest_main)
       )
     endif()
   else()
-    message(FATAL_ERROR "Reusing Google Test targets from LLVM failed:"
-      "LLVM_EXPORTED_TARGETS does not contain 'gtest' or 'gtest_main'.")
+    message(FATAL_ERROR "Reusing Google Test (target) from LLVM failed:"
+      "LLVM_EXPORTED_TARGETS does not contain 'gtest'.")
   endif()
 else()
-  # LLVM's targets are not reused
+  # LLVM's 'gtest' target is not reused
 
   if (NOT GTEST_SRC_DIR)
     if (USE_CMAKE_FIND_PACKAGE_LLVM AND LLVM_BUILD_MAIN_SRC_DIR)
@@ -107,7 +105,6 @@ else()
 
       # add includes for LLVM's modifications
       target_include_directories(gtest BEFORE PRIVATE ${LLVM_INCLUDE_DIRS})
-      target_include_directories(gtest_main BEFORE PRIVATE ${LLVM_INCLUDE_DIRS})
     else()
       # try to find Google Test, as GTEST_SRC_DIR is not manually specified
       find_path(GTEST_SRC_DIR
@@ -125,7 +122,7 @@ else()
     endif()
   endif()
 
-  if (NOT (TARGET gtest AND TARGET gtest_main))
+  if (NOT TARGET gtest)
     # building from GTEST_SRC_DIR, not from LLVM's utils directory
     find_path(GTEST_INCLUDE_DIR
       "gtest/gtest.h"
@@ -156,9 +153,7 @@ else()
 
   # build Google Test with KLEE's defines and compile flags
   target_compile_definitions(gtest PRIVATE ${KLEE_COMPONENT_CXX_DEFINES})
-  target_compile_definitions(gtest_main PRIVATE ${KLEE_COMPONENT_CXX_DEFINES})
   target_compile_options(gtest PRIVATE ${KLEE_COMPONENT_CXX_FLAGS})
-  target_compile_options(gtest_main PRIVATE ${KLEE_COMPONENT_CXX_FLAGS})
 endif()
 
 
@@ -177,11 +172,20 @@ if (NOT IS_DIRECTORY "${GTEST_INCLUDE_DIR}")
 endif()
 message(STATUS "GTEST_INCLUDE_DIR: ${GTEST_INCLUDE_DIR}")
 
+add_library(unittest_main)
+target_sources(unittest_main PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/TestMain.cpp")
+target_link_libraries(unittest_main PUBLIC gtest)
+target_include_directories(unittest_main
+  PUBLIC
+  ${GTEST_INCLUDE_DIR}
+  ${KLEE_COMPONENT_EXTRA_INCLUDE_DIRS}
+)
+target_compile_definitions(unittest_main PUBLIC ${KLEE_COMPONENT_CXX_DEFINES})
+target_compile_options(unittest_main PUBLIC ${KLEE_COMPONENT_CXX_FLAGS})
+
 function(add_klee_unit_test target_name)
   add_executable(${target_name} ${ARGN})
-  target_link_libraries(${target_name} PRIVATE gtest_main)
-  target_include_directories(${target_name} BEFORE PRIVATE "${GTEST_INCLUDE_DIR}")
-  target_include_directories(${target_name} BEFORE PRIVATE ${KLEE_COMPONENT_EXTRA_INCLUDE_DIRS})
+  target_link_libraries(${target_name} PRIVATE unittest_main)
   set_target_properties(${target_name}
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/unittests/"

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -96,6 +96,7 @@ else()
 
       HINTS
       "${GTEST_SRC_DIR}/include"
+      "${GTEST_SRC_DIR}/googletest/include"
 
       NO_DEFAULT_PATH
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -7,6 +7,42 @@
 #
 #===------------------------------------------------------------------------===#
 
+function(add_vanilla_googletest_subdirectory directory)
+  if (POLICY CMP0077)
+    # Prevent Google Test from adding to our install target (Google Test 1.8.0+)
+    # However, this can only be disabled starting with 1.8.1 (a.k.a. 1.9.0)
+    set(INSTALL_GTEST OFF)
+
+    # Google Mock is currently not used by our tests
+    set(BUILD_GMOCK OFF)
+
+    # (only) Google Test 1.8.0 with BUILD_GMOCK=OFF needs BUILD_GTEST=ON
+    set(BUILD_GTEST ON)
+
+    # Make option() in subdirectory respect normal variables (as set above).
+    # NOTE: The enclosing function limits the scope of this policy setting.
+    # FIXME: Remove once all supported Google Test versions require CMake 3.13+
+    #        (or set policy CMP0077 to NEW by themselves)
+    set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+  else()
+    # FIXME: Remove with CMake minimum version 3.13+
+    # Use cache variable workaround as option() ignores normal variables
+
+    # Prevent Google Test from adding to our install target (Google Test 1.8.0+)
+    # However, this can only be disabled starting with 1.8.1 (a.k.a. 1.9.0)
+    set(INSTALL_GTEST OFF CACHE BOOL "disable installing Google Test" FORCE)
+
+    # Google Mock is currently not used by our tests
+    set(BUILD_GMOCK OFF CACHE BOOL "disable building Google Mock" FORCE)
+
+    # (only) Google Test 1.8.0 with BUILD_GMOCK=OFF needs BUILD_GTEST=ON
+    set(BUILD_GTEST ON CACHE BOOL "enable building Google Test" FORCE)
+  endif()
+
+  # include Google Test's CMakeLists.txt
+  add_subdirectory(${directory} "${CMAKE_CURRENT_BINARY_DIR}/gtest_build")
+endfunction()
+
 if (TARGET gtest AND TARGET gtest_main)
   # try to reuse LLVM's targets
 
@@ -115,12 +151,7 @@ else()
     message(STATUS "Google Test: Building from source.")
     message(STATUS "GTEST_SRC_DIR: ${GTEST_SRC_DIR}")
 
-    # Prevent Google Test from adding to our install target.
-    # Required for >= 1.8.0, but can only be disabled starting with 1.8.1
-    set(INSTALL_GTEST OFF CACHE BOOL "disable installing Google Test" FORCE)
-
-    # Build Google Test as part of our project
-    add_subdirectory(${GTEST_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gtest_build")
+    add_vanilla_googletest_subdirectory(${GTEST_SRC_DIR})
   endif()
 
   # build Google Test with KLEE's defines and compile flags

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -174,11 +174,21 @@ message(STATUS "GTEST_INCLUDE_DIR: ${GTEST_INCLUDE_DIR}")
 
 add_library(unittest_main)
 target_sources(unittest_main PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/TestMain.cpp")
-target_link_libraries(unittest_main PUBLIC gtest)
+klee_get_llvm_libs(UNITTEST_MAIN_LIBS Support)
+target_link_libraries(unittest_main
+  PUBLIC
+  gtest
+
+  PRIVATE
+  ${UNITTEST_MAIN_LIBS}
+)
 target_include_directories(unittest_main
   PUBLIC
   ${GTEST_INCLUDE_DIR}
   ${KLEE_COMPONENT_EXTRA_INCLUDE_DIRS}
+
+  PRIVATE
+  ${LLVM_INCLUDE_DIRS}
 )
 target_compile_definitions(unittest_main PUBLIC ${KLEE_COMPONENT_CXX_DEFINES})
 target_compile_options(unittest_main PUBLIC ${KLEE_COMPONENT_CXX_FLAGS})

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -117,7 +117,7 @@ else()
 
     # Prevent Google Test from adding to our install target.
     # Required for >= 1.8.0, but can only be disabled starting with 1.8.1
-    set(GTEST_INSTALL OFF CACHE BOOL "disable installing Google Test" FORCE)
+    set(INSTALL_GTEST OFF CACHE BOOL "disable installing Google Test" FORCE)
 
     # Build Google Test as part of our project
     add_subdirectory(${GTEST_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gtest_build")

--- a/unittests/TestMain.cpp
+++ b/unittests/TestMain.cpp
@@ -1,6 +1,6 @@
 //===--- unittests/TestMain.cpp - unittest driver -------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
+//                     The KLEE Symbolic Virtual Machine
 //
 // This file is distributed under the University of Illinois Open Source
 // License. See LICENSE.TXT for details.
@@ -9,11 +9,6 @@
 
 #include "gtest/gtest.h"
 
-// WARNING: If LLVM's gtest_main target is reused
-//          or is built from LLVM's source tree,
-//          this file is ignored. Instead, LLVM's
-//          utils/unittest/UnitTestMain/TestMain.cpp
-//          is used.
 
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);

--- a/unittests/TestMain.cpp
+++ b/unittests/TestMain.cpp
@@ -7,10 +7,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "klee/Config/Version.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Signals.h"
+
 #include "gtest/gtest.h"
 
-
 int main(int argc, char **argv) {
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 9)
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0], true);
+#else
+  llvm::sys::PrintStackTraceOnErrorSignal(true);
+#endif
+
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
KLEE currently supports (and recommends) Google Test version 1.7.0. For newer versions (current: 1.11.0), however, there are certain issues:
- Google Test itself was moved into a `googletest` subdirectory (1.8.0+), as `googlemock` was added right next to it. This means **`GTEST_INCLUDE_DIR` has to be set manually** as it can no longer be derived automatically from `GTEST_SRC_DIR`. Note that adding the subdirectory to `GTEST_SRC_DIR`, while seemingly working for some versions, leads to issues in at least the most current version as it results in inclusion of the wrong `CMakeLists.txt` file.
- Google Test's `gtest_main` uses `__FILE__` (and thus a path to the file) for its "Running main() from" line, but `llvm-lit` (which we use to invoke unit tests) currently matches exactly "Running main() from gtest_main.cc" for determining whether to skip this line. **This results in spurious "tests" that will be shown as unresolved.** This affects Google Test versions 1.8.1+, but not if LLVM's `gtest_main` target is reused since LLVM got rid of the "Running main() from` line some time ago.

In addition to that, I recently noticed some issues with my older PR #1005 from ~2 years ago:
- I messed up `INSTALL_GTEST=OFF` by instead setting `GTEST_INSTALL` :angry: (Result: not solving the 1.8.0/1.8.1+ issue that **vanilla Google Test will add to our `install` target**)
- Ideally, such option settings should not be exposed as cache variables (changeable by whoever is building KLEE).
- Depending on whether LLVM's `gtest_main` target is reused or `gtest_main` is built from vanilla Google Test, **the output of `make unittests` may or may not include stack traces on failure**.
- I did not notice that `MainTest.cpp` (essentially just another implementation of `gtest_main`) was not used in either case.

In this PR, I address all of these issues (whether "The PR addresses a single issue" is thus left as an exercise for the reader :wink:). As they are quite closely related, I still think it makes sense to review them in one go. I tested with Google Test 1.7.0 through 1.11.0.

**TL;DR: This PR resolves various issues with the current Google Test integration. The changes enable a more consistent experience, regardless of whether LLVM's `gtest` target is reused or which version of vanilla Google Test used.**

## Checklist:
- [ ] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.

## Should we additionally...
- [ ] ...change the recommendation for Google Test in [the build instructions](http://klee.github.io/build-llvm9/)?
- [ ] ...let CI use a more recent version of Google Test?