### PR TITLE
some fixes/extensions for klee-stats

### DIFF
--- a/lib/Core/CoreStats.cpp
+++ b/lib/Core/CoreStats.cpp
@@ -21,7 +21,6 @@ Statistic stats::instructionTime("InstructionTimes", "Itime");
 Statistic stats::instructions("Instructions", "I");
 Statistic stats::minDistToReturn("MinDistToReturn", "Rdist");
 Statistic stats::minDistToUncovered("MinDistToUncovered", "UCdist");
-Statistic stats::reachableUncovered("ReachableUncovered", "IuncovReach");
 Statistic stats::resolveTime("ResolveTime", "Rtime");
 Statistic stats::solverTime("SolverTime", "Stime");
 Statistic stats::states("States", "States");

--- a/lib/Core/CoreStats.h
+++ b/lib/Core/CoreStats.h
@@ -34,10 +34,6 @@ namespace stats {
   /// isn't normally up-to-date.
   extern Statistic states;
 
-  /// Instruction level statistic for tracking number of reachable
-  /// uncovered instructions.
-  extern Statistic reachableUncovered;
-
   /// Instruction level statistic tracking the minimum intraprocedural
   /// distance to an uncovered instruction; this is only periodically
   /// updated.

--- a/test/Feature/KleeStats.c
+++ b/test/Feature/KleeStats.c
@@ -1,8 +1,20 @@
 // RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out  %t.bc 2> %t.log
-// RUN: %klee-stats --print-more %t.klee-out > %t.stats
+// RUN: %klee --output-dir=%t.klee-out %t.bc 2> %t.log
+// RUN: %klee-stats --print-more --table-format=csv %t.klee-out > %t.stats
 // RUN: FileCheck -check-prefix=CHECK-STATS -input-file=%t.stats %s
+// test --print-abs-times
+// RUN: %klee-stats --print-abs-times --table-format=csv %t.klee-out > %t2.stats
+// RUN: FileCheck -check-prefix=CHECK-STATS-ABS-TIMES -input-file=%t2.stats %s
+// test --print-rel-times
+// RUN: %klee-stats --print-rel-times --table-format=csv %t.klee-out > %t3.stats
+// RUN: FileCheck -check-prefix=CHECK-STATS-REL-TIMES -input-file=%t3.stats %s
+// test user-provided columns and ordering
+// RUN: %klee-stats --print-columns 'Time(s),Path,ICov(%)' --table-format=csv %t.klee-out > %t4.stats
+// RUN: FileCheck -check-prefix=CHECK-STATS-COL -input-file=%t4.stats %s
+// test wrong column name and empty columns
+// RUN: not %klee-stats --print-columns 'Path,Foo,ICov(%)' --table-format=csv %t.klee-out
+// RUN: not %klee-stats --print-columns '' --table-format=csv %t.klee-out
 #include "klee/klee.h"
 #include <stdlib.h>
 int main(){
@@ -13,7 +25,16 @@ int main(){
   }
   return 0;
 }
+
 // First check we find a line with the expected format
-// CHECK-STATS: | Path | Instrs| Time(s)| ICov(%)| BCov(%)| ICount| TSolver(%)|
-//Check there is a line with .klee-out dir, non zero instruction, less than 1 second execution time and 100 ICov.
-// CHECK-STATS: {{.*\.klee-out\|[ ]*[1-9]+\|[ ]*0\.([0-9]+)\|[ ]*100\.00}}
+// CHECK-STATS: Path,Instrs,Time(s),ICov(%),BCov(%),ICount,TSolver(%),ActiveStates,MaxActiveStates,Mem(MiB),MaxMem(MiB)
+// Check there is a line with .klee-out dir, non zero instruction, less than 1 second execution time and 100 ICov.
+// CHECK-STATS: {{.*\.klee-out,[1-9]+,0\.([0-9]+),100\.00}}
+
+// Check other formats
+// CHECK-STATS-ABS-TIMES: Path,Time(s),TUser(s),TResolve(s),TCex(s),TSolver(s),TFork(s)
+// CHECK-STATS-REL-TIMES: Path,Time(s),TSolver(%),TResolve(%),TCex(%),TFork(%),TUser(%)
+// CHECK-STATS-COL: Time(s),Path,ICov(%)
+
+// No Summary row for csv
+// CHECK-STATS-COL-NOT: {{^}}Total{{.*}}{{$}}

--- a/test/Feature/KleeStatsColumns.test
+++ b/test/Feature/KleeStatsColumns.test
@@ -1,5 +1,6 @@
 RUN: %klee-stats --print-all %S/klee-stats/missing_column %S/klee-stats/run %S/klee-stats/additional_column | FileCheck %s
 
-CHECK: {{^}}| missing_column  |        |{{.*}}|             |{{.*}}|{{$}}
-CHECK: {{^}}|       run       |       3|{{.*}}|             |{{.*}}|{{$}}
-CHECK: {{^}}|additional_column|       3|{{.*}}|         4711|{{.*}}|{{$}}
+// Path, Instrs, ..., extra_column
+CHECK: {{^}}| missing_column  |        |{{.*}}|             |{{$}}
+CHECK: {{^}}|       run       |       3|{{.*}}|             |{{$}}
+CHECK: {{^}}|additional_column|       3|{{.*}}|         4711|{{$}}

--- a/test/Feature/KleeStatsNoBr.c
+++ b/test/Feature/KleeStatsNoBr.c
@@ -1,0 +1,15 @@
+// RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out %t.bc 2> %t.log
+// RUN: %klee-stats --print-columns 'BCov(%),Branches,FullBranches,PartialBranches' --table-format=csv %t.klee-out > %t.stats
+// RUN: FileCheck -check-prefix=CHECK-STATS -input-file=%t.stats %s
+
+int main(){
+  int a = 42;
+  a -= 42;
+  return a;
+}
+
+// Check that there are no branches in stats but 100% coverage
+// CHECK-STATS: BCov(%),Branches,FullBranches,PartialBranches
+// CHECK-STATS: 100.00,0,0,0

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -350,6 +350,25 @@ def write_table(args, data, dirs, pr):
         name_mapping[entry[2]] = entry[0]
     table = rename_columns(table, name_mapping)
 
+    # Apply column filter provided by user
+    user_columns = []
+    if args.columns is not None:
+        user_columns = [c for c in map(lambda v: v.strip(), args.columns.split(',')) if c]
+        column_names = list(table.keys())
+        # error when user-provided column does not exist
+        diff = set(user_columns) - set(column_names)
+        if diff:
+            print('Column(s) not found:', ', '.join(diff), file=sys.stderr)
+            sys.exit(1)
+        # error when no name given
+        if not user_columns:
+            print('No column name specified for --print-columns.', file=sys.stderr)
+            sys.exit(1)
+        # filter
+        for k in column_names:
+            if k not in user_columns:
+                table.pop(k)
+
     # Add a summary row
     max_len = len(data)
     if max_len > 1 and args.tableFormat not in ['csv', 'readable-csv']:
@@ -370,15 +389,17 @@ def write_table(args, data, dirs, pr):
         table['Path'].append('Total ({0})'.format(max_len))
 
     # Prepare the order of the header: start to order entries according to the order in legend and add the unknown entries at the end
-    headers = ["Path"]
-    available_headers = list(table.keys())
-    for entry in Legend:
-        l_name = entry[0]
-        if l_name in available_headers:
-            headers.append(l_name)
-            available_headers.remove(l_name)
-    available_headers.sort()
-    headers += available_headers
+    headers = user_columns
+    if not headers:
+        headers = ["Path"]
+        available_headers = list(table.keys())
+        for entry in Legend:
+            l_name = entry[0]
+            if l_name in available_headers:
+                headers.append(l_name)
+                available_headers.remove(l_name)
+        available_headers.sort()
+        headers += available_headers
 
     # Make sure we keep the correct order of the column entries
     final_table = collections.OrderedDict()
@@ -479,13 +500,15 @@ def main():
                           action='store_true', dest='pMore',
                           help='Print extra information (needed when '
                           'monitoring an ongoing run).')
+    pControl.add_argument('--print-columns', type=str, dest='columns', default=None,
+                          help='Comma-separated list of table columns, e.g \'Path,Time(s),ICov(%%)\'.')
 
     args = parser.parse_args()
 
 
     # get print controls
     pr = 'NONE'
-    if args.pAll:
+    if args.pAll or args.columns:
         pr = 'all'
     elif args.pRelTimes:
         pr = 'reltime'

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -145,7 +145,7 @@ def select_columns(record, pr):
                   'CexCacheTime', 'ForkTime', 'ResolveTime']
     elif pr == 'more':
         s_column = ['Path', 'Instructions', 'WallTime', 'ICov', 'BCov', 'ICount',
-                  'RelSolverTime', 'States', 'maxStates', 'MallocUsage', 'maxMem']
+                  'RelSolverTime', 'NumStates', 'MaxStates', 'MallocUsage', 'MaxMem']
     else:
         s_column = ['Path', 'Instructions', 'WallTime', 'ICov',
                   'BCov', 'ICount', 'RelSolverTime']

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -352,7 +352,7 @@ def write_table(args, data, dirs, pr):
 
     # Add a summary row
     max_len = len(data)
-    if max_len > 1:
+    if max_len > 1 and args.tableFormat not in ['csv', 'readable-csv']:
         # calculate the total
         for k in table:
             if k == "Path": # Skip path

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -155,11 +155,6 @@ def select_columns(record, pr):
 
 
 def add_artificial_columns(record):
-    # special case for straight-line code: report 100% branch coverage
-    if "NumBranches" in record and record["NumBranches"] == 0:
-        record["FullBranches"] = 1
-        record["NumBranches"] = 1
-
     # Convert recorded times from microseconds to seconds
     for key in ["UserTime", "WallTime", "QueryTime", "SolverTime", "CexCacheTime", "ForkTime", "ResolveTime"]:
         if not key in record:
@@ -184,7 +179,9 @@ def add_artificial_columns(record):
 
     # Calculate branch coverage
     if "FullBranches" in record and "PartialBranches" in record and "NumBranches" in record:
-        record["BCov"] = 100 * ( 2 * record["FullBranches"] + record["PartialBranches"]) / ( 2 * record["NumBranches"])
+        record["BCov"] = 100.0
+        if record["NumBranches"] != 0:
+            record["BCov"] *= (2 * record["FullBranches"] + record["PartialBranches"]) / (2 * record["NumBranches"])
 
     # Add relative times
     for key in ["SolverTime", "CexCacheTime", "ForkTime", "ResolveTime", "UserTime"]:

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -21,30 +21,47 @@ import collections
 # Mapping of: (column head, explanation, internal klee name)
 # column head must start with a capital letter
 Legend = [
+    # core stats
     ('Instrs', 'number of executed instructions', "Instructions"),
-    ('Time(s)', 'total wall time (s)', "WallTime"),
-    ('TUser(s)', 'total user time', "UserTime"),
-    ('ICov(%)', 'instruction coverage in the LLVM bitcode (%)', "ICov"),
-    ('BCov(%)', 'branch coverage in the LLVM bitcode (%)', "BCov"),
+    ('Time(s)', 'total wall time', "WallTime"),
+    ('ICov(%)', 'instruction coverage in the LLVM bitcode', "ICov"),
+    ('BCov(%)', 'conditional branch (br) coverage in the LLVM bitcode', "BCov"),
     ('ICount', 'total static instructions in the LLVM bitcode', "ICount"),
-    ('TSolver(s)', 'time spent in the constraint solver', "SolverTime"),
-    ('TSolver(%)', 'time spent in the constraint solver', "RelSolverTime"),
-    ('States', 'number of currently active states', "NumStates"),
-    ('MaxStates', 'maximum number of active states', "maxStates"),
-    ('AvgStates', 'average number of active states', "avgStates"),
-    ('Mem(MB)', 'megabytes of memory currently used', "MallocUsage"),
-    ('MaxMem(MB)', 'megabytes of memory currently used', "MaxMem"),
-    ('AvgMem(MB)', 'megabytes of memory currently used', "AvgMem"),
-    ('Queries', 'number of queries issued to STP', "NumQueries"),
-    ('AvgQC', 'average number of query constructs per query', "AvgQC"),
-    ('Tcex(s)', 'time spent in the counterexample caching code', "CexCacheTime"),
-    ('Tcex(%)', 'relative time spent in the counterexample caching code wrt wall time', "RelCexCacheTime"),
-    ('Tfork(s)', 'time spent forking', "ForkTime"),
-    ('Tfork(%)', 'relative time spent forking wrt wall time', "RelForkTime"),
+    ('TSolver(%)', 'relative time spent in the solver chain wrt wall time (incl. caches and constraint solver)', "RelSolverTime"),
+    # extended stats
+    # - code and coverage
+    ('ICovered', 'total covered instructions in the LLVM bitcode', "CoveredInstructions"),
+    ('IUncovered', 'total uncovered instructions in the LLVM bitcode', "UncoveredInstructions"),
+    ('Branches', 'number of conditional branch (br) instructions in the LLVM bitcode', 'NumBranches'),
+    ('FullBranches', 'number of fully-explored conditional branch (br) instructions in the LLVM bitcode', 'FullBranches'),
+    ('PartialBranches', 'number of partially-explored conditional branch (br) instructions in the LLVM bitcode', 'PartialBranches'),
+    # - time
+    ('TUser(s)', 'total user time', "UserTime"),
     ('TResolve(s)', 'time spent in object resolution', "ResolveTime"),
-    ('TResolve(%)', 'time spent in object resolution wrt wall time', "RelResolveTime"),
+    ('TResolve(%)', 'relative time spent in object resolution wrt wall time', "RelResolveTime"),
+    ('TCex(s)', 'time spent in the counterexample caching code (incl. constraint solver)', "CexCacheTime"),
+    ('TCex(%)', 'relative time spent in the counterexample caching code wrt wall time (incl. constraint solver)', "RelCexCacheTime"),
+    ('TQuery(s)', 'time spent in the constraint solver', "QueryTime"),
+    ('TSolver(s)', 'time spent in the solver chain (incl. caches and constraint solver)', "SolverTime"),
+    # - states
+    ('ActiveStates', 'number of currently active states (0 after successful termination)', "NumStates"),
+    ('MaxActiveStates', 'maximum number of active states', "MaxStates"),
+    ('AvgActiveStates', 'average number of active states', "AvgStates"),
+    # - constraint caching/solving
+    ('Queries', 'number of queries issued to the constraint solver', "NumQueries"),
+    ('QueryConstructs', 'number of query constructs for all queries send to the constraint solver', "NumQueryConstructs"),
+    ('AvgSolverQuerySize', 'average number of query constructs per query issued to the constraint solver', "AvgQC"),
     ('QCexCMisses', 'Counterexample cache misses', "QueryCexCacheMisses"),
     ('QCexCHits', 'Counterexample cache hits', "QueryCexCacheHits"),
+    # - memory
+    ('Mem(MiB)', 'mebibytes of memory currently used', "MallocUsage"),
+    ('MaxMem(MiB)', 'maximum memory usage', "MaxMem"),
+    ('AvgMem(MiB)', 'average memory usage', "AvgMem"),
+    # - debugging
+    ('TArrayHash(s)', 'time spent hashing arrays (if KLEE_ARRAY_DEBUG enabled, otherwise -1)', "ArrayHashTime"),
+    ('TFork(s)', 'time spent forking states', "ForkTime"),
+    ('TFork(%)', 'relative time spent forking states wrt wall time', "RelForkTime"),
+    ('TUser(%)', 'relative user time wrt wall time', "RelUserTime"),
 ]
 
 def getInfoFile(path):
@@ -66,7 +83,7 @@ class LazyEvalList:
 
     def aggregateRecords(self):
         try:
-            memC = self.conn().execute("SELECT max(MallocUsage) / 1024 / 1024, avg(MallocUsage) / 1024 / 1024 from stats")
+            memC = self.conn().execute("SELECT max(MallocUsage)*1.0 / 1024 / 1024, avg(MallocUsage) / 1024 / 1024 from stats")
             maxMem, avgMem = memC.fetchone()
         except sqlite3.OperationalError as e:
             maxMem, avgMem = None, None
@@ -77,7 +94,7 @@ class LazyEvalList:
         except sqlite3.OperationalError as e:
             maxStates, avgStates = None, None
 
-        return {"maxMem":maxMem, "avgMem": avgMem, "maxState": maxStates, "avgStates": avgStates}
+        return {"MaxMem":maxMem, "AvgMem": avgMem, "MaxStates": maxStates, "AvgStates": avgStates}
 
     def getLastRecord(self):
         try:
@@ -151,7 +168,7 @@ def add_artificial_columns(record):
 
     # Convert memory from byte to MiB
     if "MallocUsage" in record:
-        record["MallocUsage"] /= (1024*1024)
+        record["MallocUsage"] /= 1024 * 1024
 
     # Calculate avg. query construct
     if "NumQueryConstructs" in record and "NumQueries" in record:


### PR DESCRIPTION
KLEE:
* removes `reachableUncovered` (unused)

klee-stats:
* show MaxMemory as float (before rounded integer, often < AvgMem)
* show MiB instead of MB (to reflect computation)
* fixes BCov calculation when no `br` instructions in bitcode
* extends/adapts some tests
* reorders/renames columns in `klee-stats` to
  * increase consistency
  * improve readability by grouping topic-wise
* add missing and (hopefully) improve documentation for stats in --help message
* add `--print-columns` to print user-defined columns, e.g. `--print-columns 'Path,Instrs,Time(s)'`

RFC:
* I'd also remove
  * `TFork` from KLEE as it is misleading and not well implemented
  * and maybe: `RelUserTime` (`TUser(%)`) from `klee-stats` - not sure what this is good for (we already have `TUser(s)` and for short run times it's just weird to see 20,000%)
* change `AvgQC` to `AvgQueryConstructs`? [changed to AvgSolverQuerySize]

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
