### PR TITLE
build: fix missing target for grep

### DIFF
--- a/scripts/build/p-clang-linux-ubuntu.inc
+++ b/scripts/build/p-clang-linux-ubuntu.inc
@@ -23,7 +23,7 @@ install_binary_artifact_clang() {
     # Add repository
     codename="$(lsb_release --codename --short)"
     apt_entry="deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}${version} main"
-    if [[ ! $(grep -q "${apt_entry}") ]]; then
+    if [[ ! $(grep -rq "${apt_entry}" /etc/apt) ]]; then
       echo "${apt_entry}" >> /etc/apt/sources.list
       apt update -y
     fi

--- a/scripts/build/p-llvm-linux-ubuntu.inc
+++ b/scripts/build/p-llvm-linux-ubuntu.inc
@@ -81,7 +81,7 @@ install_binary_artifact_llvm() {
   # Add repository
   codename="$(lsb_release --codename --short)"
   apt_entry="deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}${version} main"
-  if [[ ! $(grep -q "${apt_entry}") ]]; then
+  if [[ ! $(grep -rq "${apt_entry}" /etc/apt) ]]; then
     echo  "${apt_entry}" >> /etc/apt/sources.list
     apt update -y
   fi


### PR DESCRIPTION
`build.sh` hangs as `grep` waits for input in two cases

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [ x There are test cases for the code you added or modified OR no such test cases are required.
