### PR TITLE
Fix FD_Fail test in nix sandbox

### DIFF
--- a/test/Runtime/POSIX/FD_Fail.c
+++ b/test/Runtime/POSIX/FD_Fail.c
@@ -6,18 +6,18 @@
 #include <assert.h>
 
 int main(int argc, char** argv) {
-  char buf[1024];  
-  FILE* f = fopen("/etc/mtab", "r");
+  char buf[1024];
+  FILE* f = fopen("/dev/zero", "rb");
   assert(f);
-    
+
   int r = fread(buf, 1, 100, f);
-  printf("fread(): %s\n", 
+  printf("fread(): %s\n",
          r ? "ok" : "fail");
   // CHECK-DAG: fread(): ok
   // CHECK-DAG: fread(): fail
 
   r = fclose(f);
-  printf("fclose(): %s\n", 
+  printf("fclose(): %s\n",
          r ? "ok" : "fail");
   // CHECK-DAG: fclose(): ok
   // CHECK-DAG: fclose(): fail


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

/etc/mtab doesn't exist in the Nix build sandbox since /etc doesn't
exist. However, /dev/zero is more common on UNIX systems and does.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
