### PR TITLE
Fix building GTest from LLVM sources

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -105,6 +105,8 @@ else()
 
       # add includes for LLVM's modifications
       target_include_directories(gtest BEFORE PRIVATE ${LLVM_INCLUDE_DIRS})
+      # we cannot disable gtest_main, but will not use it later
+      target_include_directories(gtest_main BEFORE PRIVATE ${LLVM_INCLUDE_DIRS})
     else()
       # try to find Google Test, as GTEST_SRC_DIR is not manually specified
       find_path(GTEST_SRC_DIR


### PR DESCRIPTION
When building KLEE with `-DUSE_CMAKE_FIND_PACKAGE_LLVM=1` and an LLVM with source tree that does not export target `gtest`, we will use the GTest sources that come along LLVM. One of the changes made by #1458 is that `gtest_main` is no longer used because we cannot reliably control the source from which it will be build. However, it will still be built and in case of the LLVM version includes LLVM specific headers. I thus removed a line too much in my last PR which I am re-adding here. Otherwise, the compilation of `gtest_main` will fail like this:
```
llvm/llvm/utils/unittest/UnitTestMain/TestMain.cpp:9:10: fatal error: llvm/Support/CommandLine.h: No such file or directory
    9 | #include "llvm/Support/CommandLine.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
