### PR TITLE
POSIX runtime: fstatat: check for nonnull path APIs

### DIFF
--- a/cmake/fstatat.c
+++ b/cmake/fstatat.c
@@ -1,0 +1,9 @@
+#include <fcntl.h>
+#include <stddef.h>
+#include <sys/stat.h>
+
+int main(void) {
+  struct stat buf;
+  #pragma GCC diagnostic error "-Wnonnull"
+  fstatat(0, NULL, &buf, 0);
+}

--- a/runtime/POSIX/CMakeLists.txt
+++ b/runtime/POSIX/CMakeLists.txt
@@ -20,6 +20,11 @@ set(SRC_FILES
         stubs.c
         )
 
+try_compile (FSTATAT_PATH_ACCEPTS_NULL
+        ${CMAKE_BINARY_DIR}
+        ${PROJECT_SOURCE_DIR}/cmake/fstatat.c
+        )
+
 # Build it
 include("${CMAKE_SOURCE_DIR}/cmake/compile_bitcode_library.cmake")
 prefix_with_path("${SRC_FILES}" "${CMAKE_CURRENT_SOURCE_DIR}/" prefixed_files)


### PR DESCRIPTION
When compiling POSIX runtime with glibc it spills out several warnings:

```
/klee/runtime/POSIX/fd.c:573:19: warning: nonnull parameter 'path' will evaluate to 'true' on first encounter [-Wpointer-bool-conversion]
                 (path ? __concretize_string(path) : NULL), buf, (long)flags);
                  ^~~~ ~
/usr/include/sys/stat.h:266:14: note: declared 'nonnull' here
     __THROW __nonnull ((2, 3));
             ^
/usr/include/sys/cdefs.h:390:28: note: expanded from macro '__nonnull'
# define __nonnull(params) __attribute_nonnull__ (params)
                           ^
/usr/include/sys/cdefs.h:384:57: note: expanded from macro '__attribute_nonnull__'
#  define __attribute_nonnull__(params) __attribute__ ((__nonnull__ params))
```

This PR tests if `path` is declared nonnull via cmake and removes the ternary operator in that case (but adds an `assert` just to be safe).

Another fix would have been to just disable the warning :man_shrugging:
```C
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wpointer-bool-conversion"
#if (defined __NR_newfstatat) && (__NR_newfstatat != 0)
  return syscall(__NR_newfstatat, (long)fd,
                 (path ? __concretize_string(path) : NULL), buf, (long)flags);
#else
  return syscall(__NR_fstatat64, (long)fd,
                 (path ? __concretize_string(path) : NULL), buf, (long)flags);
#endif
}
#pragma GCC diagnostic pop
```

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
