### PR TITLE
build: install llvm-dev package (fix klee-uclibc CI)

### DIFF
--- a/scripts/build/p-clang-linux-ubuntu.inc
+++ b/scripts/build/p-clang-linux-ubuntu.inc
@@ -36,7 +36,7 @@ install_binary_artifact_clang() {
   )
 
   #Install essential dependencies
-  apt -y --no-install-recommends install "${dependencies[@]}" || return 1
+  apt -y install "${dependencies[@]}" || return 1
 }
 
 get_docker_config_id_clang() {


### PR DESCRIPTION
I think what happens is that `klee/scripts/build/build.sh uclibc --install-system-deps --debug` installs LLVM, but not the `-dev` package. The subsequent KLEE installation detects the LLVM installation, starts compilation but fails due to missing static libraries. The simplest fix I came up with, that at least works locally, is to just install a few recommended packages.

One could also add it as dependency explicitly or extend the KLEE-build checks for LLVM... None of it is really nice.

@MartinNowack Any opinions?

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
