### PR TITLE
Remove unnecessary call to deprecated function sqlite3_enable_shared_cache

### DIFF
--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -229,7 +229,6 @@ StatsTracker::StatsTracker(Executor &_executor, std::string _objectFilename,
 
   if (OutputStats) {
     sqlite3_config(SQLITE_CONFIG_SINGLETHREAD);
-    sqlite3_enable_shared_cache(0);
 
     // open database
     auto db_filename = executor.interpreterHandler->getOutputFilename("run.stats");


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Remove unnecessary call to deprecated function sqlite3_enable_shared_cache, which triggers a warning on macOS. 
From https://sqlite.org/c3ref/enable_shared_cache.html: "Shared cache is disabled by default. It is recommended that it stay that way. In other words, do not use this routine."

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
