### PR TITLE
Update the Dockerfile to use the correct path for llvm-110

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ COPY --chown=klee:klee . /tmp/klee_src/
 RUN /tmp/klee_src/scripts/build/build.sh --debug --install-system-deps klee && chown -R klee:klee /tmp/klee_build* && pip3 install flask wllvm && \
     rm -rf /var/lib/apt/lists/*
 
-ENV PATH="$PATH:/tmp/llvm-90-install_O_D_A/bin:/home/klee/klee_build/bin"
+ENV PATH="$PATH:/tmp/llvm-110-install_O_D_A/bin:/home/klee/klee_build/bin"
 ENV BASE=/tmp
 
 # Add KLEE header files to system standard include folder


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
The current Dockerfile sets up the PATH variable to point to an incorrect llvm directory.  This interferes with easily running `clang`.  This lazy PR fixes it.

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
