### PR TITLE
.err files: minor readability changes to stack trace output

### DIFF
--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -327,18 +327,22 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
     std::stringstream AssStream;
     AssStream << std::setw(8) << std::setfill('0') << ii.assemblyLine;
     out << AssStream.str();
-    out << " in " << f->getName().str() << " (";
+    out << " in " << f->getName().str() << "(";
     // Yawn, we could go up and print varargs if we wanted to.
     unsigned index = 0;
     for (Function::arg_iterator ai = f->arg_begin(), ae = f->arg_end();
          ai != ae; ++ai) {
       if (ai!=f->arg_begin()) out << ", ";
 
-      out << ai->getName().str();
-      // XXX should go through function
+      if (ai->hasName())
+        out << ai->getName().str() << "=";
+
       ref<Expr> value = sf.locals[sf.kf->getArgRegister(index++)].value;
-      if (isa_and_nonnull<ConstantExpr>(value))
-        out << "=" << value;
+      if (isa_and_nonnull<ConstantExpr>(value)) {
+        out << value;
+      } else {
+        out << "symbolic";
+      }
     }
     out << ")";
     if (ii.file != "")

--- a/test/Feature/StackTraceOutput.c
+++ b/test/Feature/StackTraceOutput.c
@@ -1,0 +1,29 @@
+// REQUIRES: geq-llvm-7.0
+// RUN: %clang %s -emit-llvm %O0opt -g -c -fdiscard-value-names -o %t.bc
+// RUN: rm -rf %t.klee-out-d
+// RUN: %klee --output-dir=%t.klee-out-d %t.bc
+// RUN: FileCheck -input-file=%t.klee-out-d/test000001.assert.err -check-prefix=CHECK-DISCARD %s
+
+// RUN: %clang %s -emit-llvm %O0opt -g -c -fno-discard-value-names -o %t.bc
+// RUN: rm -rf %t.klee-out-n
+// RUN: %klee --output-dir=%t.klee-out-n %t.bc
+// RUN: FileCheck -input-file=%t.klee-out-n/test000001.assert.err -check-prefix=CHECK-NODISCARD %s
+
+#include "klee/klee.h"
+
+#include <assert.h>
+
+void foo(int i, int k) {
+  ++i; ++k;
+  assert(0);
+  // CHECK-DISCARD: {{.*}} in foo(symbolic, 12) at {{.*}}.c:18
+  // CHECK-DISCARD: {{.*}} in main() at {{.*}}.c:28
+  // CHECK-NODISCARD: {{.*}} in foo(i=symbolic, k=12) at {{.*}}.c:18
+  // CHECK-NODISCARD: {{.*}} in main() at {{.*}}.c:28
+}
+
+int main(void) {
+  int i, k=12;
+  klee_make_symbolic(&i, sizeof(i), "i");
+  foo(i,k);
+}


### PR DESCRIPTION
Beforehand the stack traces in `.err` files looked a bit odd:
```
	#000000026 in foo (i, k=12) at test.c:7 // with symbol names
	#100000050 in main () at test.c:15
```
or
```
	#000000025 in foo (, =12) at test.c:7 // without symbol names
	#100000048 in main () at test.c:15
```
I've slightly modified it to:
```
	#000000026 in foo(i=symbolic, k=12) at test.c:7
	#100000050 in main() at test.c:15
```
and
```
	#000000025 in foo(symbolic, 12) at test.c:7
	#100000048 in main() at test.c:15
```

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
