### PR TITLE
Add KDAlloc, a deterministic allocator for dynamic symbolic execution

### DIFF
--- a/include/klee/ADT/Bits.h
+++ b/include/klee/ADT/Bits.h
@@ -11,8 +11,14 @@
 #define KLEE_BITS_H
 
 #include "klee/Config/Version.h"
+
 #include "llvm/Support/DataTypes.h"
-#include <assert.h>
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
 
 namespace klee {
   namespace bits32 {
@@ -57,10 +63,6 @@ namespace klee {
       assert(res < 32);
       assert((UINT32_C(1) << res) == x);
       return res;
-    } 
-
-    inline unsigned indexOfRightmostBit(unsigned x) {
-      return indexOfSingleBit(isolateRightmostBit(x));
     }
   }
 
@@ -103,11 +105,86 @@ namespace klee {
       assert(res < 64);
       assert((UINT64_C(1) << res) == x);
       return res;
-    } 
-
-    inline uint64_t indexOfRightmostBit(uint64_t x) {
-      return indexOfSingleBit(isolateRightmostBit(x));
     }
+  }
+
+  template <typename T>
+  [[nodiscard]] static constexpr inline auto countLeadingZeroes(T &&x) noexcept
+      -> std::enable_if_t<!std::numeric_limits<std::decay_t<T>>::is_signed &&
+                              std::numeric_limits<std::decay_t<T>>::digits ==
+                                  std::numeric_limits<unsigned>::digits,
+                          int> {
+      assert(x > 0);
+      return __builtin_clz(static_cast<unsigned>(x));
+  }
+
+  template <typename T>
+  [[nodiscard]] static constexpr inline auto countLeadingZeroes(T &&x) noexcept
+      -> std::enable_if_t<!std::numeric_limits<std::decay_t<T>>::is_signed &&
+                              std::numeric_limits<std::decay_t<T>>::digits ==
+                                  std::numeric_limits<unsigned long>::digits &&
+                              std::numeric_limits<unsigned>::digits !=
+                                  std::numeric_limits<unsigned long>::digits,
+                          int> {
+      assert(x > 0);
+      return __builtin_clzl(static_cast<unsigned long>(x));
+  }
+
+  template <typename T>
+  [[nodiscard]] static constexpr inline auto countLeadingZeroes(T &&x) noexcept
+      -> std::enable_if_t<
+          !std::numeric_limits<std::decay_t<T>>::is_signed &&
+              std::numeric_limits<std::decay_t<T>>::digits ==
+                  std::numeric_limits<unsigned long long>::digits &&
+              std::numeric_limits<unsigned>::digits !=
+                  std::numeric_limits<unsigned long long>::digits &&
+              std::numeric_limits<unsigned long>::digits !=
+                  std::numeric_limits<unsigned long long>::digits,
+          int> {
+      assert(x > 0);
+      return __builtin_clzll(static_cast<unsigned long long>(x));
+  }
+
+  template <typename T>
+  [[nodiscard]] static constexpr inline auto countTrailingZeroes(T &&x) noexcept
+      -> std::enable_if_t<!std::numeric_limits<std::decay_t<T>>::is_signed &&
+                              std::numeric_limits<std::decay_t<T>>::digits ==
+                                  std::numeric_limits<unsigned>::digits,
+                          int> {
+      assert(x > 0);
+      return __builtin_ctz(static_cast<unsigned>(x));
+  }
+
+  template <typename T>
+  [[nodiscard]] static constexpr inline auto countTrailingZeroes(T &&x) noexcept
+      -> std::enable_if_t<!std::numeric_limits<std::decay_t<T>>::is_signed &&
+                              std::numeric_limits<std::decay_t<T>>::digits ==
+                                  std::numeric_limits<unsigned long>::digits &&
+                              std::numeric_limits<unsigned>::digits !=
+                                  std::numeric_limits<unsigned long>::digits,
+                          int> {
+      assert(x > 0);
+      return __builtin_ctzl(static_cast<unsigned long>(x));
+  }
+
+  template <typename T>
+  [[nodiscard]] static constexpr inline auto countTrailingZeroes(T &&x) noexcept
+      -> std::enable_if_t<
+          !std::numeric_limits<std::decay_t<T>>::is_signed &&
+              std::numeric_limits<std::decay_t<T>>::digits ==
+                  std::numeric_limits<unsigned long long>::digits &&
+              std::numeric_limits<unsigned>::digits !=
+                  std::numeric_limits<unsigned long long>::digits &&
+              std::numeric_limits<unsigned long>::digits !=
+                  std::numeric_limits<unsigned long long>::digits,
+          int> {
+      assert(x > 0);
+      return __builtin_ctzll(static_cast<unsigned long long>(x));
+  }
+
+  [[nodiscard]] static constexpr inline std::size_t
+  roundUpToMultipleOf4096(std::size_t const x) {
+      return ((x - 1) | static_cast<std::size_t>(4096 - 1)) + 1;
   }
 } // End klee namespace
 

--- a/include/klee/KDAlloc/allocator.h
+++ b/include/klee/KDAlloc/allocator.h
@@ -1,0 +1,264 @@
+//===-- allocator.h ---------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KDALLOC_ALLOCATOR_H
+#define KDALLOC_ALLOCATOR_H
+
+#include "define.h"
+#include "location_info.h"
+#include "mapping.h"
+#include "suballocators/loh.h"
+#include "suballocators/slot_allocator.h"
+#include "tagged_logger.h"
+
+#include "klee/ADT/Bits.h"
+#include "klee/ADT/Ref.h"
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <ostream>
+#include <type_traits>
+
+namespace klee::kdalloc {
+/// Wraps a mapping that is shared with other allocators.
+class Allocator final : public TaggedLogger<Allocator> {
+public:
+  class Control final {
+    friend class Allocator;
+    friend class AllocatorFactory;
+
+    static constexpr const std::uint32_t unlimitedQuarantine =
+        static_cast<std::uint32_t>(-1);
+
+    /// @todo This should really be a data member `static constexpr const
+    /// std::array meta = { ... }`.
+    static inline const std::array<std::size_t, 8> &getMeta() noexcept {
+      static const std::array<std::size_t, 8> meta = {
+          1u,    // bool
+          4u,    // int
+          8u,    // pointer size
+          16u,   // double
+          32u,   // compound types #1
+          64u,   // compound types #2
+          256u,  // compound types #3
+          2048u, // reasonable buffers
+      };
+      return meta;
+    }
+
+    [[nodiscard]] static inline int
+    convertSizeToBinIndex(std::size_t const size) noexcept {
+      for (std::size_t i = 0; i < getMeta().size(); ++i) {
+        if (getMeta()[i] >= size) {
+          return i;
+        }
+      }
+      return getMeta().size();
+    }
+
+  public:
+    mutable class klee::ReferenceCounter _refCount;
+
+  private:
+    Mapping mapping;
+    std::array<suballocators::SlotAllocator::Control,
+               std::tuple_size<std::decay_t<decltype(getMeta())>>::value>
+        sizedBins;
+    suballocators::LargeObjectAllocator::Control largeObjectBin;
+
+  public:
+    Control() = delete;
+    Control(Control const &) = delete;
+    Control &operator=(Control const &) = delete;
+    Control(Control &&) = delete;
+    Control &operator=(Control &&) = delete;
+
+  private:
+    Control(Mapping &&mapping) : mapping(std::move(mapping)) {}
+  };
+
+  static constexpr const auto unlimitedQuarantine =
+      Control::unlimitedQuarantine;
+
+private:
+  klee::ref<Control> control;
+
+  std::array<suballocators::SlotAllocator,
+             std::tuple_size<std::decay_t<decltype(Control::getMeta())>>::value>
+      sizedBins;
+  suballocators::LargeObjectAllocator largeObjectBin;
+
+public:
+  std::ostream &logTag(std::ostream &out) const noexcept {
+    return out << "[alloc] ";
+  }
+
+  Allocator() = default;
+  Allocator(Allocator const &rhs) = default;
+  Allocator &operator=(Allocator const &rhs) = default;
+  Allocator(Allocator &&) = default;
+  Allocator &operator=(Allocator &&) = default;
+
+  Allocator(klee::ref<Control> control) : control(std::move(control)) {}
+
+  explicit operator bool() const noexcept { return !control.isNull(); }
+
+  auto const &getSizedBinInfo() const noexcept { return Control::getMeta(); }
+
+  [[nodiscard]] void *allocate(std::size_t size) {
+    assert(*this && "Invalid allocator");
+
+    auto const bin = Control::convertSizeToBinIndex(size);
+    traceLine("Allocating ", size, " bytes in bin ", bin);
+
+    void *result = nullptr;
+    if (bin < static_cast<int>(sizedBins.size())) {
+      result = sizedBins[bin].allocate(control->sizedBins[bin]);
+    } else {
+      result = largeObjectBin.allocate(control->largeObjectBin, size);
+    }
+    traceLine("Allocated ", result);
+    return result;
+  }
+
+  void free(void *ptr, std::size_t size) {
+    assert(*this && "Invalid allocator");
+    assert(ptr && "Freeing nullptrs is not supported"); // we are not ::free!
+
+    auto const bin = Control::convertSizeToBinIndex(size);
+    traceLine("Freeing ", ptr, " of size ", size, " in bin ", bin);
+
+    if (bin < static_cast<int>(sizedBins.size())) {
+      return sizedBins[bin].deallocate(control->sizedBins[bin], ptr);
+    } else {
+      return largeObjectBin.deallocate(control->largeObjectBin, ptr, size);
+    }
+  }
+
+  LocationInfo location_info(void const *const ptr,
+                             std::size_t const size) const noexcept {
+    assert(*this && "Invalid allocator");
+
+    if (!ptr || reinterpret_cast<std::uintptr_t>(ptr) < 4096) {
+      return LocationInfo::LI_NullPage;
+    }
+
+    // the following is technically UB if `ptr` does not actually point inside
+    // the mapping at all
+    for (std::size_t i = 0; i < Allocator::Control::getMeta().size(); ++i) {
+      if (control->sizedBins[i].mapping_begin() <= ptr &&
+          ptr < control->sizedBins[i].mapping_end()) {
+        if (reinterpret_cast<char const *>(ptr) + size <=
+            control->sizedBins[i].mapping_end()) {
+          return sizedBins[i].getLocationInfo(control->sizedBins[i], ptr, size);
+        } else {
+          return LocationInfo::LI_SpansSuballocators;
+        }
+      }
+    }
+    if (control->largeObjectBin.mapping_begin() <= ptr &&
+        ptr < control->largeObjectBin.mapping_end()) {
+      if (reinterpret_cast<char const *>(ptr) + size <=
+          control->largeObjectBin.mapping_end()) {
+        return largeObjectBin.getLocationInfo(control->largeObjectBin, ptr,
+                                              size);
+      } else {
+        // the loh is the suballocator using the largest addresses, therefore
+        // its mapping is not followed by that of another suballocator, but
+        // rather the end of the mapping
+        return LocationInfo::LI_NonNullOutsideMapping;
+      }
+    }
+
+    return LocationInfo::LI_NonNullOutsideMapping;
+  }
+};
+
+class AllocatorFactory {
+public:
+  static constexpr const auto unlimitedQuarantine =
+      Allocator::Control::unlimitedQuarantine;
+
+private:
+  klee::ref<Allocator::Control> control;
+
+public:
+  AllocatorFactory() = default;
+
+  AllocatorFactory(std::size_t const size, std::uint32_t const quarantineSize)
+      : AllocatorFactory(Mapping{0, size}, quarantineSize) {}
+
+  AllocatorFactory(std::uintptr_t const address, std::size_t const size,
+                   std::uint32_t const quarantineSize)
+      : AllocatorFactory(Mapping{address, size}, quarantineSize) {}
+
+  AllocatorFactory(Mapping &&mapping, std::uint32_t const quarantineSize) {
+    assert(mapping && "Invalid mapping");
+    assert(mapping.getSize() >
+               Allocator::Control::getMeta().size() * 4096 + 3 * 4096 &&
+           "Mapping is *far* to small");
+
+    control = new Allocator::Control(std::move(mapping));
+    auto const binSize =
+        static_cast<std::size_t>(1)
+        << (std::numeric_limits<std::size_t>::digits - 1 -
+            countLeadingZeroes(control->mapping.getSize() /
+                               (Allocator::Control::getMeta().size() + 1)));
+    char *const base = static_cast<char *>(control->mapping.getBaseAddress());
+    std::size_t totalSize = 0;
+    for (std::size_t i = 0; i < Allocator::Control::getMeta().size(); ++i) {
+      control->sizedBins[i].initialize(
+          base + totalSize, binSize, Allocator::Control::getMeta()[i],
+          quarantineSize == unlimitedQuarantine,
+          quarantineSize == unlimitedQuarantine ? 0 : quarantineSize);
+
+      totalSize += binSize;
+      assert(totalSize <= control->mapping.getSize() && "Mapping too small");
+    }
+
+    auto largeObjectBinSize = control->mapping.getSize() - totalSize;
+    assert(largeObjectBinSize > 0);
+    control->largeObjectBin.initialize(
+        base + totalSize, largeObjectBinSize,
+        quarantineSize == unlimitedQuarantine,
+        quarantineSize == unlimitedQuarantine ? 0 : quarantineSize);
+  }
+
+  explicit operator bool() const noexcept { return !control.isNull(); }
+
+  Mapping &getMapping() noexcept {
+    assert(!!*this && "Cannot get mapping of uninitialized factory.");
+    return control->mapping;
+  }
+
+  Mapping const &getMapping() const noexcept {
+    assert(!!*this && "Cannot get mapping of uninitialized factory.");
+    return control->mapping;
+  }
+
+  Allocator makeAllocator() const {
+    assert(!!*this &&
+           "Can only create an allocator from an initialized factory.");
+
+    return Allocator{control};
+  }
+
+  explicit operator Allocator() && {
+    assert(!!*this &&
+           "Can only create an allocator from an initialized factory.");
+
+    return Allocator{std::move(control)};
+  }
+};
+} // namespace klee::kdalloc
+
+#endif

--- a/include/klee/KDAlloc/define.h
+++ b/include/klee/KDAlloc/define.h
@@ -1,0 +1,17 @@
+//===-- define.h ------------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KDALLOC_DEFINE_H
+#define KDALLOC_DEFINE_H
+
+#ifndef KDALLOC_TRACE
+#define KDALLOC_TRACE 0
+#endif
+
+#endif

--- a/include/klee/KDAlloc/kdalloc.h
+++ b/include/klee/KDAlloc/kdalloc.h
@@ -1,0 +1,21 @@
+//===-- kdalloc.h -----------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KDALLOC_KDALLOC_H
+#define KDALLOC_KDALLOC_H
+
+#include "allocator.h"
+#include "mapping.h"
+
+namespace klee::kdalloc {
+using StackAllocator = Allocator;
+using StackAllocatorFactory = AllocatorFactory;
+} // namespace klee::kdalloc
+
+#endif

--- a/include/klee/KDAlloc/location_info.h
+++ b/include/klee/KDAlloc/location_info.h
@@ -1,0 +1,71 @@
+//===-- location_info.h -----------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KDALLOC_LOCATION_INFO_H
+#define KDALLOC_LOCATION_INFO_H
+
+#include <cassert>
+
+namespace klee::kdalloc {
+class LocationInfo {
+public:
+  enum Enum {
+    /// refers to the null page
+    LI_NullPage,
+    /// location is not inside the mapping (but not on the null page)
+    LI_NonNullOutsideMapping,
+    /// location spans suballocator mapping boundary
+    LI_SpansSuballocators,
+    /// area spans object alignment boundary
+    LI_Unaligned,
+    /// location always refers to a redzone
+    LI_AlwaysRedzone,
+    /// location currently refers to a redzone
+    LI_CurrentRedzone,
+    /// location is inside an object that is either currently allocated or in
+    /// quarantine
+    LI_AllocatedOrQuarantined,
+    /// location is potentially valid, but not currently allocated
+    LI_Unallocated,
+  };
+
+private:
+  Enum value;
+  void *address;
+
+public:
+  constexpr LocationInfo(Enum value, void *address = nullptr) noexcept
+      : value(value), address(address) {}
+  constexpr operator Enum() noexcept { return value; }
+
+  /// location is (partially) outside the mapping
+  constexpr bool isOutsideMapping() const noexcept {
+    return value != Enum::LI_NullPage &&
+           value != Enum::LI_NonNullOutsideMapping;
+  }
+
+  /// location is potentially valid
+  constexpr bool isValid() const noexcept {
+    return value == Enum::LI_AllocatedOrQuarantined ||
+           value == Enum::LI_Unallocated || value == Enum::LI_CurrentRedzone;
+  }
+
+  /// location (partially) refers to a redzone
+  constexpr bool isRedzone() const noexcept {
+    return value == Enum::LI_AlwaysRedzone || value == Enum::LI_CurrentRedzone;
+  }
+
+  constexpr void *getBaseAddress() const noexcept {
+    assert(value == Enum::LI_AllocatedOrQuarantined);
+    return address;
+  }
+};
+} // namespace klee::kdalloc
+
+#endif

--- a/include/klee/KDAlloc/mapping.h
+++ b/include/klee/KDAlloc/mapping.h
@@ -1,0 +1,158 @@
+//===-- mapping.h -----------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KDALLOC_MAPPING_H
+#define KDALLOC_MAPPING_H
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <utility>
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#if defined(__linux__)
+#include <linux/version.h>
+#endif
+
+#if defined(__APPLE__)
+#include <mach/vm_map.h>
+#include <sys/types.h>
+#endif
+
+#include "klee/Support/ErrorHandling.h"
+
+namespace klee::kdalloc {
+class Mapping {
+  void *baseAddress = MAP_FAILED;
+  std::size_t size = 0;
+
+  bool try_map(std::uintptr_t baseAddress) noexcept {
+    assert(this->baseAddress == MAP_FAILED);
+
+    int flags = MAP_ANON | MAP_PRIVATE;
+#if defined(__linux__)
+    flags |= MAP_NORESERVE;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+    if (baseAddress != 0) {
+      flags |= MAP_FIXED_NOREPLACE;
+    }
+#endif
+#elif defined(__FreeBSD__)
+    if (baseAddress != 0) {
+      flags |= MAP_FIXED | MAP_EXCL;
+    }
+#endif
+
+    auto mappedAddress = ::mmap(reinterpret_cast<void *>(baseAddress), size,
+                                PROT_READ | PROT_WRITE, flags, -1, 0);
+    if (baseAddress != 0 &&
+        baseAddress != reinterpret_cast<std::uintptr_t>(mappedAddress)) {
+      [[maybe_unused]] int rc = ::munmap(mappedAddress, size);
+      assert(rc == 0 && "munmap failed");
+      this->baseAddress = MAP_FAILED;
+      return false;
+    }
+    if (mappedAddress == MAP_FAILED) {
+      this->baseAddress = MAP_FAILED;
+      return false;
+    }
+    this->baseAddress = mappedAddress;
+
+#if defined(__linux__)
+    {
+      [[maybe_unused]] int rc =
+          ::madvise(this->baseAddress, size,
+                    MADV_NOHUGEPAGE | MADV_DONTFORK | MADV_RANDOM);
+      assert(rc == 0 && "madvise failed");
+    }
+#elif defined(__FreeBSD__)
+    {
+      [[maybe_unused]] int rc =
+          ::minherit(this->baseAddress, size, INHERIT_NONE);
+      assert(rc == 0 && "minherit failed");
+    }
+#elif defined(__APPLE__)
+    {
+      [[maybe_unused]] int rc =
+          ::minherit(this->baseAddress, size, VM_INHERIT_NONE);
+      assert(rc == 0 && "minherit failed");
+    }
+#endif
+
+    return true;
+  }
+
+public:
+  Mapping() = default;
+
+  explicit Mapping(std::size_t size) noexcept : Mapping(0, size) {}
+
+  Mapping(std::uintptr_t baseAddress, std::size_t size) noexcept : size(size) {
+    try_map(baseAddress);
+    assert(*this && "failed to allocate mapping");
+    if (!*this) {
+      std::abort();
+    }
+  }
+
+  Mapping(Mapping const &) = delete;
+  Mapping &operator=(Mapping const &) = delete;
+
+  Mapping(Mapping &&other) noexcept
+      : baseAddress(other.baseAddress), size(other.size) {
+    other.baseAddress = MAP_FAILED;
+    other.size = 0;
+  }
+  Mapping &operator=(Mapping &&other) noexcept {
+    if (&other != this) {
+      using std::swap;
+      swap(other.baseAddress, baseAddress);
+      swap(other.size, size);
+    }
+    return *this;
+  }
+
+  [[nodiscard]] void *getBaseAddress() const noexcept {
+    assert(*this && "Invalid mapping");
+    return baseAddress;
+  }
+
+  [[nodiscard]] std::size_t getSize() const noexcept { return size; }
+
+  void clear() {
+    assert(*this && "Invalid mapping");
+
+#if defined(__linux__)
+    [[maybe_unused]] int rc = ::madvise(baseAddress, size, MADV_DONTNEED);
+    assert(rc == 0 && "madvise failed");
+#else
+    auto address = reinterpret_cast<std::uintptr_t>(baseAddress);
+    [[maybe_unused]] int rc = ::munmap(baseAddress, size);
+    assert(rc == 0 && "munmap failed");
+    baseAddress = MAP_FAILED;
+    auto success = try_map(address);
+    assert(success && "could not recreate the mapping");
+#endif
+  }
+
+  explicit operator bool() const noexcept { return baseAddress != MAP_FAILED; }
+
+  ~Mapping() {
+    if (*this) {
+      [[maybe_unused]] int rc = ::munmap(baseAddress, size);
+      assert(rc == 0 && "munmap failed");
+    }
+  }
+};
+} // namespace klee::kdalloc
+
+#endif

--- a/include/klee/KDAlloc/suballocators/cow_ptr.h
+++ b/include/klee/KDAlloc/suballocators/cow_ptr.h
@@ -1,0 +1,180 @@
+//===-- cow_ptr.h -----------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KDALLOC_UTIL_COW_H
+#define KDALLOC_UTIL_COW_H
+
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <new>
+#include <utility>
+
+namespace klee::kdalloc::suballocators {
+template <typename T> class CoWPtr {
+  struct Wrapper {
+    std::size_t referenceCount;
+    T data;
+
+    template <typename... V>
+    explicit Wrapper(std::size_t const referenceCount, V &&...args)
+        : referenceCount(referenceCount), data(std::forward<V>(args)...) {}
+  };
+
+  Wrapper *ptr = nullptr;
+
+public:
+  constexpr CoWPtr() = default;
+
+  CoWPtr(CoWPtr const &other) noexcept : ptr(other.ptr) {
+    if (ptr != nullptr) {
+      ++ptr->referenceCount;
+      assert(ptr->referenceCount > 1);
+    }
+  }
+
+  CoWPtr &operator=(CoWPtr const &other) {
+    if (this != &other) {
+      release();
+
+      ptr = other.ptr;
+      if (ptr != nullptr) {
+        ++ptr->referenceCount;
+        assert(ptr->referenceCount > 1);
+      }
+    }
+    return *this;
+  }
+
+  CoWPtr(CoWPtr &&other) noexcept : ptr(std::exchange(other.ptr, nullptr)) {}
+
+  CoWPtr &operator=(CoWPtr &&other) noexcept {
+    if (this != &other) {
+      release();
+      ptr = std::exchange(other.ptr, nullptr);
+    }
+    return *this;
+  }
+
+  /// A stand-in for C++17's `std::in_place_t`
+  struct in_place_t {};
+
+  template <typename... V>
+  explicit CoWPtr(in_place_t, V &&...args)
+      : ptr(new Wrapper(1, std::forward<V>(args)...)) {}
+
+  ~CoWPtr() { release(); }
+
+  /// Returns `true` iff `*this` is not in an empty state.
+  [[nodiscard]] explicit operator bool() const noexcept { return !isEmpty(); }
+
+  /// Returns `true` iff `*this` is in an empty state.
+  [[nodiscard]] bool isEmpty() const noexcept { return ptr == nullptr; }
+
+  /// Returns `true` iff `*this` is not in an empty state and owns the CoW
+  /// object.
+  [[nodiscard]] bool isOwned() const noexcept {
+    return ptr != nullptr && ptr->referenceCount == 1;
+  }
+
+  /// Accesses an existing object.
+  /// Must not be called when `*this` is in an empty state.
+  T const &operator*() const noexcept {
+    assert(ptr && "the `CoWPtr` must not be empty");
+    return get();
+  }
+
+  /// Accesses an existing object.
+  /// Must not be called when `*this` is in an empty state.
+  T const *operator->() const noexcept {
+    assert(ptr && "the `CoWPtr` must not be empty");
+    return &get();
+  }
+
+  /// Accesses an existing object.
+  /// Must not be called when `*this` is in an empty state.
+  T const &get() const noexcept {
+    assert(ptr && "the `CoWPtr` must not be empty");
+    return ptr->data;
+  }
+
+  /// Accesses an existing, owned object.
+  /// Must not be called when `*this` does not hold CoW ownership.
+  T &getOwned() noexcept {
+    assert(isOwned() && "the `CoWPtr` must be owned");
+    return ptr->data;
+  }
+
+  /// Accesses an existing, owned object.
+  /// Must not be called when `*this` does not hold CoW ownership.
+  ///
+  /// Note: This function is included for completeness' sake. Instead of calling
+  /// `getOwned` on a constant, one should probably just call `get` as it
+  /// produces the same result without requiring the target object to hold
+  /// ownership of the data.
+  T const &getOwned() const noexcept {
+    assert(isOwned() && "the `CoWPtr` must be owned");
+    return ptr->data;
+  }
+
+  /// Acquires CoW ownership of an existing object and returns a reference to
+  /// the owned object. Must not be called when `*this` is in an empty state.
+  T &acquire() {
+    assert(ptr != nullptr &&
+           "May only call `acquire` for an active CoW object");
+    assert(ptr->referenceCount > 0);
+    if (ptr->referenceCount > 1) {
+      --ptr->referenceCount;
+      ptr = new Wrapper(*ptr);
+      ptr->referenceCount = 1;
+    }
+    assert(ptr->referenceCount == 1);
+    return ptr->data;
+  }
+
+  /// Releases CoW ownership of an existing object or does nothing if the object
+  /// does not exist. Leaves `*this` in an empty state.
+  void release() noexcept(noexcept(delete ptr)) {
+    if (ptr != nullptr) {
+      --ptr->referenceCount;
+      if (ptr->referenceCount == 0) {
+        delete ptr;
+      }
+      ptr = nullptr;
+    }
+  }
+
+  /// Leaves `*this` holding and owning an object `T(std::forward<V>(args)...)`.
+  /// This function is always safe to call and will perform the operation as
+  /// efficient as possible. Notably, `foo.emplace(...)` may be more efficient
+  /// than the otherwise equivalent `foo = CoWPtr(CoWPtr::in_place_t{}, ...)`.
+  template <typename... V> T &emplace(V &&...args) {
+    if (ptr) {
+      if (ptr->referenceCount == 1) {
+        ptr->data = T(std::forward<V>(args)...);
+      } else {
+        auto *new_ptr = new Wrapper(
+            1, std::forward<V>(args)...); // possibly throwing operation
+
+        assert(ptr->referenceCount > 1);
+        --ptr->referenceCount;
+        ptr = new_ptr;
+      }
+    } else {
+      ptr = new Wrapper(1, std::forward<V>(args)...);
+    }
+    assert(ptr != nullptr);
+    assert(ptr->referenceCount == 1);
+    return ptr->data;
+  }
+};
+} // namespace klee::kdalloc::suballocators
+
+#endif

--- a/include/klee/KDAlloc/suballocators/loh.h
+++ b/include/klee/KDAlloc/suballocators/loh.h
@@ -1,0 +1,346 @@
+//===-- loh.h ---------------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KDALLOC_SUBALLOCATORS_LOH_H
+#define KDALLOC_SUBALLOCATORS_LOH_H
+
+#include "../define.h"
+#include "../location_info.h"
+#include "../tagged_logger.h"
+#include "sized_regions.h"
+
+#include "klee/ADT/Bits.h"
+
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <ostream>
+#include <utility>
+#include <vector>
+
+#if KDALLOC_TRACE >= 2
+#include <iostream>
+#endif
+
+namespace klee::kdalloc::suballocators {
+/// The large object heap is implemented as what amounts to as a bi-directional
+/// mapping between the position of each unallocated region and its actual size.
+/// The implemented algorithm performs allocations in the middle of the largest
+/// available unallocated region. Allocations are guaranteed to be aligned to
+/// 4096 bytes.
+class LargeObjectAllocator final : public TaggedLogger<LargeObjectAllocator> {
+  struct Data final {
+    /// The reference count.
+    std::size_t referenceCount = 1;
+
+    /// A CoW enabled treap that is a tree over base addresses and a max-heap
+    /// over sizes
+    SizedRegions regions;
+
+    static_assert(
+        sizeof(void *) >= sizeof(std::size_t),
+        "The quarantine elements are alternating `void*` and `std::size_t`");
+    static_assert(
+        alignof(void *) >= alignof(std::size_t),
+        "The quarantine elements are alternating `void*` and `std::size_t`");
+    using QuarantineElement =
+        std::aligned_storage_t<sizeof(void *), alignof(void *)>;
+
+    /// The quarantine position followed by the quarantine ring buffer
+    /// Structure: [pos, ptr1, size1, ptr2, size2, ...]
+    QuarantineElement quarantine[];
+
+    Data() = default;
+    Data(Data const &rhs) : regions(rhs.regions) {}
+    Data &operator=(Data const &) = delete;
+    Data(Data &&) = delete;
+    Data &operator=(Data &&) = delete;
+  };
+
+public:
+  class Control final : public TaggedLogger<Control> {
+    friend class LargeObjectAllocator;
+
+    void *baseAddress = nullptr;
+    std::size_t size = 0;
+    std::uint32_t quarantineSize = 0;
+    bool unlimitedQuarantine = false;
+
+  public:
+    Control() = default;
+    Control(Control const &) = delete;
+    Control &operator=(Control const &) = delete;
+    Control(Control &&) = delete;
+    Control &operator=(Control &&) = delete;
+
+    void initialize(void *const baseAddress, std::size_t const size,
+                    bool const unlimitedQuarantine,
+                    std::uint32_t const quarantineSize) {
+      assert(size >= 3 * 4096 && "The LOH requires at least three pages");
+
+      this->baseAddress = baseAddress;
+      this->size = size;
+      if (unlimitedQuarantine) {
+        this->quarantineSize = 0;
+        this->unlimitedQuarantine = true;
+      } else {
+        this->quarantineSize = quarantineSize == 0 ? 0 : quarantineSize * 2 + 1;
+        this->unlimitedQuarantine = false;
+      }
+
+      traceLine("Initialization complete for region ", baseAddress, " + ",
+                size);
+    }
+
+    inline std::ostream &logTag(std::ostream &out) const noexcept {
+      return out << "[LOH control] ";
+    }
+
+    constexpr void *mapping_begin() const noexcept { return baseAddress; }
+    constexpr void *mapping_end() const noexcept {
+      return static_cast<void *>(static_cast<char *>(baseAddress) + size);
+    }
+  };
+
+private:
+  Data *data = nullptr;
+
+  inline void releaseData() noexcept {
+    if (data) {
+      --data->referenceCount;
+      if (data->referenceCount == 0) {
+        data->~Data();
+        std::free(data);
+      }
+      data = nullptr;
+    }
+  }
+
+  inline void acquireData(Control const &control) noexcept {
+    assert(!!data);
+    if (data->referenceCount > 1) {
+      auto newData = static_cast<Data *>(std::malloc(
+          sizeof(Data) + control.quarantineSize * sizeof(std::size_t)));
+      assert(newData && "allocation failure");
+
+      new (newData) Data(*data);
+      std::memcpy(&newData->quarantine[0], &data->quarantine[0],
+                  sizeof(Data::QuarantineElement) * control.quarantineSize);
+
+      --data->referenceCount;
+      assert(data->referenceCount > 0);
+      data = newData;
+    }
+    assert(data->referenceCount == 1);
+  }
+
+  std::pair<void *, std::size_t>
+  quarantine(Control const &control, void *const ptr, std::size_t const size) {
+    assert(!!data &&
+           "Deallocations can only happen if allocations happened beforehand");
+    assert(!control.unlimitedQuarantine);
+
+    if (control.quarantineSize == 0) {
+      return {ptr, size};
+    }
+
+    assert(data->referenceCount == 1 &&
+           "Must hold CoW ownership to quarantine a new pointer+size pair");
+
+    auto const pos = reinterpret_cast<std::size_t &>(data->quarantine[0]);
+    if (pos + 2 == control.quarantineSize) {
+      reinterpret_cast<std::size_t &>(data->quarantine[0]) = 1;
+    } else {
+      reinterpret_cast<std::size_t &>(data->quarantine[0]) = pos + 2;
+    }
+
+    auto quarantinedPtr = std::exchange(
+        reinterpret_cast<void *&>(data->quarantine[pos]), std::move(ptr));
+    auto quarantinedSize = std::exchange(
+        reinterpret_cast<std::size_t &>(data->quarantine[pos + 1]),
+        std::move(size));
+    return {quarantinedPtr, quarantinedSize};
+  }
+
+public:
+  constexpr LargeObjectAllocator() = default;
+
+  LargeObjectAllocator(LargeObjectAllocator const &rhs) noexcept
+      : data(rhs.data) {
+    if (data) {
+      ++data->referenceCount;
+      assert(data->referenceCount > 1);
+    }
+  }
+
+  LargeObjectAllocator &operator=(LargeObjectAllocator const &rhs) noexcept {
+    if (data != rhs.data) {
+      releaseData();
+      data = rhs.data;
+      if (data) {
+        ++data->referenceCount;
+        assert(data->referenceCount > 1);
+      }
+    }
+    return *this;
+  }
+
+  LargeObjectAllocator(LargeObjectAllocator &&rhs) noexcept
+      : data(std::exchange(rhs.data, nullptr)) {
+    assert(data->referenceCount > 0);
+  }
+
+  LargeObjectAllocator &operator=(LargeObjectAllocator &&rhs) noexcept {
+    if (data != rhs.data) {
+      releaseData();
+      data = std::exchange(rhs.data, nullptr);
+    }
+    return *this;
+  }
+
+  ~LargeObjectAllocator() noexcept { releaseData(); }
+
+  inline std::ostream &logTag(std::ostream &out) const noexcept {
+    return out << "[LOH] ";
+  }
+
+  LocationInfo getLocationInfo(Control const &control, void const *const ptr,
+                               std::size_t const size) const noexcept {
+    assert(control.mapping_begin() <= ptr &&
+           reinterpret_cast<char const *>(ptr) + size < control.mapping_end() &&
+           "This property should have been ensured by the caller");
+
+    if (!data) {
+      return LocationInfo::LI_Unallocated;
+    }
+    assert(!data->regions.isEmpty());
+
+    if (reinterpret_cast<char const *>(control.mapping_begin()) + 4096 >
+            reinterpret_cast<char const *>(ptr) ||
+        reinterpret_cast<char const *>(control.mapping_end()) - 4096 <
+            reinterpret_cast<char const *>(ptr) + size) {
+      return LocationInfo::LI_AlwaysRedzone;
+    }
+
+    return data->regions.getLocationInfo(reinterpret_cast<char const *>(ptr),
+                                         size);
+  }
+
+  [[nodiscard]] void *allocate(Control const &control, std::size_t size) {
+    if (!data) {
+      data = static_cast<Data *>(std::malloc(
+          sizeof(Data) + control.quarantineSize * sizeof(std::size_t)));
+      assert(data && "allocation failure");
+
+      new (data) Data();
+      if (control.quarantineSize > 0) {
+        reinterpret_cast<std::size_t &>(data->quarantine[0]) = 1;
+        std::memset(&data->quarantine[1], 0,
+                    (control.quarantineSize - 1) *
+                        sizeof(Data::QuarantineElement));
+      }
+
+      data->regions.insert(static_cast<char *>(control.baseAddress),
+                           control.size);
+    } else {
+      acquireData(control);
+    }
+    assert(data->referenceCount == 1);
+
+    auto const quantizedSize = roundUpToMultipleOf4096(size);
+    traceLine("Allocating ", size, " (", quantizedSize, ") bytes");
+    assert(size > 0);
+    assert(quantizedSize % 4096 == 0);
+    traceContents(control);
+
+    size = quantizedSize;
+
+    assert(!data->regions.isEmpty());
+    auto const &node = data->regions.getLargestRegion();
+    std::size_t const rangeSize = node->getSize();
+    assert(rangeSize + 2 * 4096 >= size && "Zero (or below) red zone size!");
+    char *const rangePos = node->getBaseAddress();
+
+    auto offset = (rangeSize - size) / 2;
+    offset = roundUpToMultipleOf4096(offset);
+
+    // left subrange
+    data->regions.resizeLargestRegion(offset);
+
+    // right subrange
+    data->regions.insert(rangePos + offset + size, rangeSize - offset - size);
+
+    auto const result = static_cast<void *>(rangePos + offset);
+    traceLine("Allocation result: ", result);
+    return result;
+  }
+
+  void deallocate(Control const &control, void *ptr, std::size_t size) {
+    assert(!!data &&
+           "Deallocations can only happen if allocations happened beforehand");
+
+    if (control.unlimitedQuarantine) {
+      traceLine("Quarantining ", ptr, " for ever");
+    } else {
+      auto quantizedSize = roundUpToMultipleOf4096(size);
+      traceLine("Quarantining ", ptr, " with size ", size, " (", quantizedSize,
+                ") for ", (control.quarantineSize - 1) / 2, " deallocations");
+      assert(size > 0);
+      assert(quantizedSize % 4096 == 0);
+
+      acquireData(control); // we will need quarantine and/or region ownership
+      std::tie(ptr, size) = quarantine(control, ptr, size);
+      if (!ptr) {
+        return;
+      }
+
+      quantizedSize = roundUpToMultipleOf4096(size);
+      traceLine("Deallocating ", ptr, " with size ", size, " (", quantizedSize,
+                ")");
+
+      assert(data->referenceCount == 1);
+      assert(size > 0);
+      assert(quantizedSize % 4096 == 0);
+      size = quantizedSize;
+      traceContents(control);
+      traceLine("Merging region at ",
+                static_cast<void *>(static_cast<char *>(ptr) + size),
+                " with the preceding region");
+
+      data->regions.mergeRegionWithPrevious(static_cast<char *>(ptr) + size);
+    }
+  }
+
+  void traceContents(Control const &) const noexcept {
+    if (data->regions.isEmpty()) {
+      traceLine("regions is empty");
+    } else {
+#if KDALLOC_TRACE >= 2
+      traceLine("regions:");
+      data->regions.dump(std::cout);
+
+#if !defined(NDEBUG)
+      auto invariantsHold = data->regions.checkInvariants();
+      if (!invariantsHold.first) {
+        traceln("TREE INVARIANT DOES NOT HOLD!");
+      }
+      if (!invariantsHold.second) {
+        traceln("HEAP INVARIANT DOES NOT HOLD!");
+      }
+      assert(invariantsHold.first && invariantsHold.second);
+#endif
+#else
+      traceLine("regions is not empty");
+#endif
+    }
+  }
+};
+} // namespace klee::kdalloc::suballocators
+
+#endif

--- a/include/klee/KDAlloc/suballocators/sized_regions.h
+++ b/include/klee/KDAlloc/suballocators/sized_regions.h
@@ -1,0 +1,589 @@
+//===-- sized_regions.h -----------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KDALLOC_UTIL_SIZED_REGIONS_H
+#define KDALLOC_UTIL_SIZED_REGIONS_H
+
+#include "../define.h"
+#include "../location_info.h"
+#include "cow_ptr.h"
+
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <utility>
+
+namespace klee::kdalloc::suballocators {
+class SizedRegions;
+
+class Node final {
+  friend class SizedRegions;
+
+  CoWPtr<Node> lhs;
+  CoWPtr<Node> rhs;
+
+  // std::size_t _precomputed_hash;
+  char *baseAddress;
+  std::size_t size;
+
+  inline std::uintptr_t hash() const noexcept {
+    // This hash function implements a very simple hash based only on the base
+    // address. The hash is (only) used to break ties w.r.t. the heap property.
+    // Note that multiplication with an odd number (as done here) modulo a power
+    // of two (the domain of std::size_t) is a permutation, meaning that the
+    // hash is guaranteed to break any ties (as tree-keys are unique in the
+    // treap). The constant is chosen in such a way that the high bits of the
+    // result depend each byte of input while still enabling a fast computation
+    // due to the low number of 1-bits involved. It is also chosen odd to ensure
+    // co-primality with powers of two.
+
+    static_assert(
+        std::numeric_limits<std::uintptr_t>::digits <= 64,
+        "Please choose a more appropriate constant in the line below.");
+    return reinterpret_cast<std::uintptr_t>(baseAddress) *
+           static_cast<std::uintptr_t>(0x8080'8080'8080'8081u);
+  }
+
+public:
+  char *const &getBaseAddress() const noexcept { return baseAddress; }
+  void setBaseAddress(char *const newBaseAddress) noexcept {
+    baseAddress = newBaseAddress;
+  }
+
+  std::size_t const &getSize() const noexcept { return size; }
+  void setSize(std::size_t const newSize) noexcept { size = newSize; }
+
+  Node(char *const baseAddress, std::size_t const size) noexcept
+      : baseAddress(baseAddress), size(size) {}
+};
+
+class SizedRegions {
+  CoWPtr<Node> root;
+
+  static void insertRec(CoWPtr<Node> &treap, CoWPtr<Node> &&region) {
+    assert(treap && "target subtreap must exist (insertion at the call "
+                    "site is trivial otherwise)");
+    assert(region && "region to be inserted must exist");
+    assert(treap->getBaseAddress() != region->getBaseAddress() &&
+           "multiple insertions of the same tree-key are not supported");
+
+    auto &node = treap.acquire();
+    if (region->getBaseAddress() < node.getBaseAddress()) {
+      if (node.lhs) {
+        insertRec(node.lhs, std::move(region));
+      } else {
+        node.lhs = std::move(region);
+      }
+      if (node.lhs->getSize() > node.getSize() ||
+          (node.lhs->getSize() == node.getSize() &&
+           node.lhs->hash() > node.hash())) {
+        auto temp = std::move(node.lhs);
+        auto &nodeTemp = temp.acquire();
+        node.lhs = std::move(nodeTemp.rhs);
+        nodeTemp.rhs = std::move(treap);
+        treap = std::move(temp);
+      }
+    } else {
+      if (node.rhs) {
+        insertRec(node.rhs, std::move(region));
+      } else {
+        node.rhs = std::move(region);
+      }
+      if (node.rhs->getSize() > node.getSize() ||
+          (node.rhs->getSize() == node.getSize() &&
+           node.rhs->hash() > node.hash())) {
+        auto temp = std::move(node.rhs);
+        auto &nodeTemp = temp.acquire();
+        node.rhs = std::move(nodeTemp.lhs);
+        nodeTemp.lhs = std::move(treap);
+        treap = std::move(temp);
+      }
+    }
+  }
+
+  static void mergeTreaps(CoWPtr<Node> *target, CoWPtr<Node> lhs,
+                          CoWPtr<Node> rhs) {
+    assert(!*target && "empty the target first");
+    assert(
+        (lhs || rhs) &&
+        "merging two empty subtreaps should be handled by hand, as it does not "
+        "require "
+        "acquisition of the object holding `*target` (usually a parent node)");
+    for (;;) {
+      assert(!*target);
+      if (!lhs) {
+        *target = std::move(rhs);
+        break;
+      }
+      if (!rhs) {
+        *target = std::move(lhs);
+        break;
+      }
+      assert(lhs->getBaseAddress() < rhs->getBaseAddress() &&
+             "tree property violated");
+      if (lhs->getSize() > rhs->getSize() ||
+          (lhs->getSize() == rhs->getSize() && lhs->hash() > rhs->hash())) {
+        // Ties w.r.t. the heap property (size) are explicitly broken using a
+        // hash derived from the tree key. At the time of writing, the "hash"
+        // function is a permutation (if `std::size_t` and `std::uintptr_t` are
+        // of the same size), which means that hash collisions are not just
+        // unlikely, but rather impossible.
+        Node &lhsNode = lhs.acquire();
+        *target = std::move(lhs);
+        lhs = std::move(lhsNode.rhs);
+        target = &lhsNode.rhs;
+      } else {
+        Node &rhsNode = rhs.acquire();
+        *target = std::move(rhs);
+        rhs = std::move(rhsNode.lhs);
+        target = &rhsNode.lhs;
+      }
+    }
+    assert(!lhs && "lhs must have been consumed");
+    assert(!rhs && "rhs must have been consumed");
+  }
+
+public:
+  constexpr SizedRegions() = default;
+  SizedRegions(SizedRegions const &other) = default;
+  SizedRegions &operator=(SizedRegions const &other) = default;
+  SizedRegions(SizedRegions &&other) = default;
+  SizedRegions &operator=(SizedRegions &&other) = default;
+
+  [[nodiscard]] bool isEmpty() const noexcept { return !root; }
+
+  /// Computes the LocationInfo. This functionality really belongs to the
+  /// `LargeObjectAllocator`, as it assumes that this treap contains free
+  /// regions in between allocations. It also knows that there is a redzone at
+  /// the beginning and end and in between any two allocations.
+  inline LocationInfo getLocationInfo(char const *const address,
+                                      std::size_t const size) const noexcept {
+    assert(root && "Cannot compute location_info for an empty treap");
+
+    Node const *currentNode = &*root;
+    Node const *closestPredecessor = nullptr;
+    for (;;) {
+      if (currentNode->getBaseAddress() <= address) {
+        if (address < currentNode->getBaseAddress() + currentNode->getSize()) {
+          if (address + size <=
+              currentNode->getBaseAddress() + currentNode->getSize()) {
+            return LocationInfo::LI_Unallocated;
+          } else {
+            return LocationInfo::LI_Unaligned;
+          }
+        } else {
+          closestPredecessor = currentNode;
+          if (!currentNode->rhs) {
+            return {LocationInfo::LI_AllocatedOrQuarantined,
+                    closestPredecessor->getBaseAddress() +
+                        closestPredecessor->getSize()};
+          }
+          currentNode = &*currentNode->rhs;
+        }
+      } else {
+        assert(closestPredecessor &&
+               "If there is no closest predecessor, there must not be a "
+               "predecessor at all. Since regions are only ever split, "
+               "this would mean that the lookup is outside the valid "
+               "range, which has to be handled by the caller.");
+        if (currentNode->getBaseAddress() < address + size) {
+          return LocationInfo::LI_Unaligned;
+        }
+        if (!currentNode->lhs) {
+          return {LocationInfo::LI_AllocatedOrQuarantined,
+                  closestPredecessor->getBaseAddress() +
+                      closestPredecessor->getSize()};
+        }
+        currentNode = &*currentNode->lhs;
+      }
+    }
+  }
+
+  void insert(char *const baseAddress, std::size_t const size) {
+    assert(size > 0 && "region to be inserted must contain at least one byte");
+    insert(CoWPtr<Node>(CoWPtr<Node>::in_place_t{}, baseAddress, size));
+  }
+
+  void insert(CoWPtr<Node> region) {
+    assert(region && "region to be inserted must exist");
+    assert(region->getSize() > 0 &&
+           "region to be inserted must contain at least one byte");
+    if (region->lhs || region->rhs) {
+      if (region.isOwned()) {
+        auto &node = region.acquire();
+        node.lhs.release();
+        node.rhs.release();
+      } else {
+        // If region is not owned, then acquiring it would copy the `lhs` and
+        // `rhs` members, thereby incrementing and decrementing the refcounts in
+        // unrelated objects. To avoid this, we simply recreate the region.
+        region = CoWPtr<Node>(CoWPtr<Node>::in_place_t{},
+                              region->getBaseAddress(), region->getSize());
+      }
+    }
+    assert(!region->lhs);
+    assert(!region->rhs);
+
+    auto *target = &root;
+    while (*target && ((*target)->getSize() > region->getSize() ||
+                       ((*target)->getSize() == region->getSize() &&
+                        (*target)->hash() > region->hash()))) {
+      auto &node = target->acquire();
+      assert(node.getBaseAddress() != region->getBaseAddress() &&
+             "multiple insertions of the same tree-key are not supported");
+      target = region->getBaseAddress() < node.getBaseAddress() ? &node.lhs
+                                                                : &node.rhs;
+    }
+    if (!*target) {
+      *target = std::move(region);
+    } else {
+      insertRec(*target, std::move(region));
+    }
+  }
+
+  [[nodiscard]] CoWPtr<Node> const &getLargestRegion() const noexcept {
+    assert(root && "querying the largest region only makes sense if the "
+                   "treap is not empty");
+    return root;
+  }
+
+  CoWPtr<Node> extractLargestRegion() {
+    assert(root && "cannot extract the largest region of an empty treap");
+
+    auto result = std::move(root);
+    if (result->lhs || result->rhs) {
+      auto &node = result.acquire();
+      mergeTreaps(&root, std::move(node.lhs), std::move(node.rhs));
+    }
+    return result;
+  }
+
+private:
+  static void pushDownRightHeap(CoWPtr<Node> *target, CoWPtr<Node> update,
+                                CoWPtr<Node> rhs, std::size_t const newSize,
+                                std::uintptr_t const newHash) {
+    while (rhs && (newSize < rhs->getSize() ||
+                   (newSize == rhs->getSize() && newHash < rhs->hash()))) {
+      // optimization opportunity: once lhs does not exist anymore, it will
+      // never exist in the future
+      *target = std::move(rhs);
+      auto &targetNode = target->acquire();
+      rhs = std::move(targetNode.lhs);
+      target = &targetNode.lhs;
+    }
+
+    update.getOwned().rhs = std::move(rhs);
+    *target = std::move(update);
+  }
+
+  static void pushDownLeftHeap(CoWPtr<Node> *target, CoWPtr<Node> update,
+                               CoWPtr<Node> lhs, std::size_t const newSize,
+                               std::uintptr_t const newHash) {
+    while (lhs && (newSize < lhs->getSize() ||
+                   (newSize == lhs->getSize() && newHash < lhs->hash()))) {
+      // optimization opportunity: once lhs does not exist anymore, it will
+      // never exist in the future
+      *target = std::move(lhs);
+      auto &targetNode = target->acquire();
+      lhs = std::move(targetNode.rhs);
+      target = &targetNode.rhs;
+    }
+
+    update.getOwned().lhs = std::move(lhs);
+    *target = std::move(update);
+  }
+
+public:
+  void resizeLargestRegion(std::size_t const newSize) {
+    assert(root && "updating the largest region only makes sense if the "
+                   "treap is not empty");
+
+    auto update = std::move(root);
+    auto &node = update.acquire();
+    node.setSize(newSize);
+    auto const newHash = node.hash();
+    auto lhs = std::move(node.lhs);
+    auto rhs = std::move(node.rhs);
+
+    auto *target = &root;
+
+    if (!lhs || !(newSize < lhs->getSize() ||
+                  (newSize == lhs->getSize() && newHash < lhs->hash()))) {
+      node.lhs = std::move(lhs);
+      pushDownRightHeap(target, std::move(update), std::move(rhs), newSize,
+                        newHash);
+    } else if (!rhs ||
+               !(newSize < rhs->getSize() ||
+                 (newSize == rhs->getSize() && newHash < rhs->hash()))) {
+      node.rhs = std::move(rhs);
+      pushDownLeftHeap(target, std::move(update), std::move(lhs), newSize,
+                       newHash);
+    } else {
+      for (;;) {
+        assert(lhs && (newSize < lhs->getSize() ||
+                       (newSize == lhs->getSize() && newHash < lhs->hash())));
+        assert(rhs && (newSize < rhs->getSize() ||
+                       (newSize == rhs->getSize() && newHash < rhs->hash())));
+
+        if (lhs->getSize() < rhs->getSize() ||
+            (lhs->getSize() == rhs->getSize() && lhs->hash() < rhs->hash())) {
+          *target = std::move(rhs);
+          auto &targetNode = target->acquire();
+          rhs = std::move(targetNode.lhs);
+          target = &targetNode.lhs;
+
+          if (!rhs || !(newSize < rhs->getSize() ||
+                        (newSize == rhs->getSize() && newHash < rhs->hash()))) {
+            node.rhs = std::move(rhs);
+            pushDownLeftHeap(target, std::move(update), std::move(lhs), newSize,
+                             newHash);
+            return;
+          }
+        } else {
+          *target = std::move(lhs);
+          auto &targetNode = target->acquire();
+          lhs = std::move(targetNode.rhs);
+          target = &targetNode.rhs;
+
+          if (!lhs || !(newSize < lhs->getSize() ||
+                        (newSize == lhs->getSize() && newHash < lhs->hash()))) {
+            node.lhs = std::move(lhs);
+            pushDownRightHeap(target, std::move(update), std::move(rhs),
+                              newSize, newHash);
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  CoWPtr<Node> extractRegion(char const *const baseAddress) {
+    CoWPtr<Node> *target = &root;
+    for (;;) {
+      assert(*target && "cannot extract region that is not part of the treap");
+      if ((*target)->getBaseAddress() < baseAddress) {
+        target = &target->acquire().rhs;
+      } else if ((*target)->getBaseAddress() > baseAddress) {
+        target = &target->acquire().lhs;
+      } else {
+        assert((*target)->getBaseAddress() == baseAddress);
+        auto result = std::move(*target);
+        if (result->lhs || result->rhs) {
+          auto &node = result.acquire();
+          mergeTreaps(target, std::move(node.lhs), std::move(node.rhs));
+        }
+        return result;
+      }
+    }
+  }
+
+private:
+  static CoWPtr<Node> mergeRegionWithPreviousRec(CoWPtr<Node> &treap,
+                                                 char *const baseAddress) {
+    assert(treap && "cannot extract region that is not part of the treap");
+    if (baseAddress < treap->getBaseAddress()) {
+      auto &node = treap.acquire();
+      if (auto greater = mergeRegionWithPreviousRec(node.lhs, baseAddress)) {
+        if (node.getBaseAddress() < greater->getBaseAddress()) {
+          auto newSize = static_cast<std::size_t>(greater->getBaseAddress() -
+                                                  node.getBaseAddress() +
+                                                  greater->getSize());
+          assert(
+              newSize > node.getSize() &&
+              "Sizes only get greater by adding `greater - smaller` to them");
+          node.setSize(newSize);
+          return {};
+        } else {
+          return greater;
+        }
+      } else {
+        if (node.lhs->getSize() > node.getSize() ||
+            (node.lhs->getSize() == node.getSize() &&
+             node.lhs->hash() > node.hash())) {
+          auto temp = std::move(node.lhs);
+          auto &nodeTemp = temp.getOwned();
+          node.lhs = std::move(nodeTemp.rhs);
+          nodeTemp.rhs = std::move(treap);
+          treap = std::move(temp);
+        }
+        return {};
+      }
+    } else if (treap->getBaseAddress() < baseAddress) {
+      auto &node = treap.acquire();
+      if (auto greater = mergeRegionWithPreviousRec(node.rhs, baseAddress)) {
+        if (node.getBaseAddress() < greater->getBaseAddress()) {
+          auto newSize = static_cast<std::size_t>(greater->getBaseAddress() -
+                                                  node.getBaseAddress() +
+                                                  greater->getSize());
+          assert(
+              newSize > node.getSize() &&
+              "Sizes only get greater by adding `greater - smaller` to them");
+          node.setSize(newSize);
+          return {};
+        } else {
+          return greater;
+        }
+      } else {
+        if (node.rhs->getSize() > node.getSize() ||
+            (node.rhs->getSize() == node.getSize() &&
+             node.rhs->hash() > node.hash())) {
+          auto temp = std::move(node.rhs);
+          auto &nodeTemp = temp.getOwned();
+          node.rhs = std::move(nodeTemp.lhs);
+          nodeTemp.lhs = std::move(treap);
+          treap = std::move(temp);
+        }
+        return greater;
+      }
+    } else {
+      assert(treap->getBaseAddress() == baseAddress);
+      // target is now the greater (w.r.t. the tree key) of the two regions we
+      // are looking for
+      if (treap->lhs) {
+        CoWPtr<Node> lhs, rhs;
+        if (treap.isOwned()) {
+          auto &node = treap.acquire();
+          lhs = std::move(node.lhs);
+          rhs = std::move(node.rhs);
+        } else {
+          lhs = treap->lhs;
+          rhs = treap->rhs;
+        }
+        auto const greaterBaseAddress = treap->getBaseAddress();
+        auto const greaterSize = treap->getSize();
+
+        auto *target = &lhs;
+        while ((*target)->rhs) {
+          target = &target->acquire().rhs;
+        }
+        treap = std::move(*target);
+        auto &node = treap.acquire();
+        *target = std::move(node.lhs);
+
+        assert(greaterBaseAddress > node.getBaseAddress());
+        auto newSize = static_cast<std::size_t>(
+            greaterBaseAddress - node.getBaseAddress() + greaterSize);
+        assert(newSize > node.getSize() &&
+               "Sizes only get greater by adding `greater - smaller` to them");
+        node.setSize(newSize);
+
+        assert(!node.rhs && "We looked for a node that has no rhs");
+        assert((!rhs || node.getBaseAddress() < rhs->getBaseAddress()) &&
+               "`lesser` comes from the left subtree of `greater`, while "
+               "rhs is the right subtree of `greater`");
+        assert((!rhs || node.getSize() > rhs->getSize()) &&
+               "The old size of `greater` was >= that of its right subtree, "
+               "so the new size (of `lesser`) is strictly greater");
+        node.rhs = std::move(rhs);
+
+        assert(!node.lhs && "The lhs of this node has already been removed");
+        assert((!lhs || lhs->getBaseAddress() < node.getBaseAddress()) &&
+               "`lesser` is the greatest child of the `lhs` subtree");
+        assert((!lhs || node.getSize() > lhs->getSize()) &&
+               "The old size of `greater` was >= that of its left subtree, "
+               "so the new size (of `lesser`) is strictly greater");
+        node.lhs = std::move(lhs);
+        return {};
+      } else {
+        auto greater = std::move(treap);
+        if (greater->rhs) {
+          if (greater.isOwned()) {
+            treap = std::move(greater.acquire().rhs);
+          } else {
+            treap = greater->rhs;
+          }
+        }
+        return greater; // no move to enable copy elision
+      }
+    }
+  }
+
+public:
+  /// This function merges the region starting at the given address, with the
+  /// region immediately preceding it. Both regions must exist. The resulting
+  /// region has the same base address as the lesser region with its size large
+  /// enough to cover the space to the end of the greater region (filling any
+  /// holes in the process).
+  inline void mergeRegionWithPrevious(char *const baseAddress) {
+    assert(root && "An empty treap holds no regions to merge");
+    mergeRegionWithPreviousRec(root, baseAddress);
+  }
+
+private:
+  template <typename OutStream>
+  static void dumpRec(OutStream &out, std::string &prefix,
+                      CoWPtr<Node> const &treap) {
+    if (treap) {
+      out << "[" << static_cast<void *>(treap->getBaseAddress()) << "; "
+          << static_cast<void *>(treap->getBaseAddress() + treap->getSize())
+          << ") of size " << treap->getSize() << "\n";
+
+      auto oldPrefix = prefix.size();
+
+      out << prefix << "├";
+      prefix += "│";
+      dumpRec(out, prefix, treap->lhs);
+
+      prefix.resize(oldPrefix);
+
+      out << prefix << "╰";
+      prefix += " ";
+      dumpRec(out, prefix, treap->rhs);
+    } else {
+      out << "<nil>\n";
+    }
+  }
+
+public:
+  template <typename OutStream> OutStream &dump(OutStream &out) {
+    std::string prefix;
+    dumpRec(out, prefix, root);
+    return out;
+  }
+
+private:
+  static void checkInvariants(std::pair<bool, bool> &result,
+                              CoWPtr<Node> const &treap) {
+    if (!result.first && !result.second) {
+      return;
+    }
+
+    if (treap->lhs) {
+      if (treap->lhs->getBaseAddress() >= treap->getBaseAddress()) {
+        result.first = false;
+      }
+      if (treap->lhs->getSize() > treap->getSize()) {
+        result.second = false;
+      }
+      checkInvariants(result, treap->lhs);
+    }
+    if (treap->rhs) {
+      if (treap->rhs->getBaseAddress() <= treap->getBaseAddress()) {
+        result.first = false;
+      }
+      if (treap->rhs->getSize() > treap->getSize()) {
+        result.second = false;
+      }
+      checkInvariants(result, treap->rhs);
+    }
+  }
+
+public:
+  std::pair<bool, bool> checkInvariants() const {
+    std::pair<bool, bool> result = {true, true};
+    if (root) {
+      checkInvariants(result, root);
+    }
+    return result;
+  }
+};
+} // namespace klee::kdalloc::suballocators
+
+#endif

--- a/include/klee/KDAlloc/suballocators/slot_allocator.h
+++ b/include/klee/KDAlloc/suballocators/slot_allocator.h
@@ -1,0 +1,538 @@
+//===-- slot_allocator.h ----------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KDALLOC_SUBALLOCATORS_SLOT_ALLOCATOR_H
+#define KDALLOC_SUBALLOCATORS_SLOT_ALLOCATOR_H
+
+#include "../define.h"
+#include "../location_info.h"
+#include "../tagged_logger.h"
+
+#include "klee/ADT/Bits.h"
+
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+#include <limits>
+#include <ostream>
+#include <type_traits>
+
+namespace klee::kdalloc::suballocators {
+class SlotAllocator final : public TaggedLogger<SlotAllocator> {
+  static_assert(static_cast<std::size_t>(-1) == ~static_cast<std::size_t>(0),
+                "-1 must be ~0 for size_t");
+  struct Data final {
+    /// The reference count.
+    std::size_t referenceCount; // initial value is 1 as soon as this member
+                                // is actually allocated
+
+    /// The number of allocated words. Always non-negative.
+    std::ptrdiff_t capacity; // initial value is 0 (changes as soon as this
+                             // member is actually allocated)
+
+    /// Always less than or equal to the first word that contains a one bit.
+    /// Less than or equal to _capacity. Always non-negative.
+    std::ptrdiff_t firstFreeFinger; // initial value is 0
+
+    /// Always greater than or equal to the last word that contains a zero bit.
+    /// Less than _capacity. May be negative (exactly -1).
+    std::ptrdiff_t lastUsedFinger; // initial value is -1
+
+    /// position in the quarantine, followed by the quarantine ring buffer,
+    /// followed by the bitmap
+    std::size_t quarantineAndBitmap[];
+  };
+
+  static_assert(std::is_pod<Data>::value, "Data must be POD");
+
+public:
+  class Control final : public TaggedLogger<Control> {
+    friend class SlotAllocator;
+
+    /// pointer to the start of the range managed by this allocator
+    char *baseAddress = nullptr;
+
+    /// size in bytes of the range managed by this allocator
+    std::size_t size = 0;
+
+    /// size in bytes of the slots that are managed in this slot allocator
+    std::size_t slotSize = 0;
+
+    /// number of bytes before the start of the bitmap (includes ordinary
+    /// members and quarantine)
+    std::size_t prefixSize = -1;
+
+    /// quarantine size *including* the position (=> is never 1)
+    std::uint32_t quarantineSize = 0;
+
+    /// true iff the quarantine is unlimited (=> _qurantine_size == 0)
+    bool unlimitedQuarantine = false;
+
+    [[nodiscard]] inline std::size_t
+    convertIndexToPosition(std::size_t index) const noexcept {
+      index += 1;
+      int const layer =
+          std::numeric_limits<std::size_t>::digits - countLeadingZeroes(index);
+      auto const layerSlots = static_cast<std::size_t>(1) << (layer - 1);
+      auto const currentSlotSize = (size >> layer);
+      assert(currentSlotSize > slotSize && "Zero (or below) red zone size!");
+
+      auto const highBit = static_cast<std::size_t>(1) << (layer - 1);
+      assert((index & highBit) != 0 && "Failed to compute high bit");
+      assert((index ^ highBit) < highBit && "Failed to compute high bit");
+
+      auto layerIndex = index ^ highBit;
+      if (layerIndex % 2 == 0) {
+        layerIndex /= 2; // drop trailing 0
+      } else {
+        layerIndex /= 2; // drop trailing 1
+        layerIndex = layerSlots - 1 - layerIndex;
+      }
+      assert(layerIndex < highBit && "Invalid tempering");
+      auto const pos = layerIndex * 2 + 1;
+      return currentSlotSize * pos;
+    }
+
+    [[nodiscard]] inline std::size_t
+    convertPositionToIndex(std::size_t const Position) const noexcept {
+      int const trailingZeroes = countTrailingZeroes(Position);
+      auto const layer = countTrailingZeroes(size) - trailingZeroes;
+      auto const layerSlots = static_cast<std::size_t>(1) << (layer - 1);
+
+      auto const highBit = static_cast<std::size_t>(1) << (layer - 1);
+      auto layerIndex = Position >> (trailingZeroes + 1);
+      assert(layerIndex < highBit &&
+             "Tempered value was not restored correctly");
+
+      if (layerIndex < (layerSlots + 1) / 2) {
+        layerIndex *= 2; // add trailing 0
+      } else {
+        layerIndex = layerSlots - 1 - layerIndex;
+        layerIndex = layerIndex * 2 + 1; // add trailing 1
+      }
+      assert(layerIndex < highBit && "Invalid reverse tempering");
+
+      auto const index = highBit ^ layerIndex;
+      return index - 1;
+    }
+
+  public:
+    Control() = default;
+    Control(Control const &) = delete;
+    Control &operator=(Control const &) = delete;
+    Control(Control &&) = delete;
+    Control &operator=(Control &&) = delete;
+
+    void initialize(void *const baseAddress, std::size_t const size,
+                    std::size_t const slotSize, bool const unlimitedQuarantine,
+                    std::uint32_t const quarantineSize) noexcept {
+      assert(size > 0 && (size & (size - 1)) == 0 &&
+             "Sizes of sized bins must be powers of two");
+
+      this->baseAddress = static_cast<char *>(baseAddress);
+      this->size = size;
+      this->slotSize = slotSize;
+      if (unlimitedQuarantine) {
+        this->quarantineSize = 0;
+        this->unlimitedQuarantine = true;
+      } else {
+        this->quarantineSize = quarantineSize == 0 ? 0 : quarantineSize + 1;
+        this->unlimitedQuarantine = false;
+      }
+      this->prefixSize =
+          sizeof(Data) + this->quarantineSize * sizeof(std::size_t);
+
+      traceLine("Initialization complete");
+    }
+
+    inline std::ostream &logTag(std::ostream &out) const noexcept {
+      return out << "[slot " << slotSize << " Control] ";
+    }
+
+    constexpr void *mapping_begin() const noexcept { return baseAddress; }
+    constexpr void *mapping_end() const noexcept {
+      return static_cast<void *>(static_cast<char *>(baseAddress) + size);
+    }
+  };
+
+private:
+  Data *data = nullptr;
+
+  inline void releaseData() noexcept {
+    if (data) {
+      --data->referenceCount;
+      if (data->referenceCount == 0) {
+        std::free(data);
+      }
+      data = nullptr;
+    }
+  }
+
+  inline void acquireData(Control const &Control) noexcept {
+    assert(!!data);
+    if (data->referenceCount > 1) {
+      auto newCapacity = computeNextCapacity(
+          getLastUsed(Control) +
+          1); // one more, since `getLastUsed` is an index, not a size
+      auto objectSize = Control.prefixSize + newCapacity * sizeof(std::size_t);
+      auto newData = static_cast<Data *>(std::malloc(objectSize));
+      assert(newData && "allocation failure");
+
+      std::memcpy(newData, data,
+                  static_cast<std::size_t>(
+                      reinterpret_cast<char *>(
+                          &data->quarantineAndBitmap[Control.quarantineSize +
+                                                     data->lastUsedFinger] +
+                          1) -
+                      reinterpret_cast<char *>(data)));
+      newData->referenceCount = 1;
+      newData->capacity = newCapacity;
+      std::fill(
+          &newData->quarantineAndBitmap[Control.quarantineSize +
+                                        newData->lastUsedFinger + 1],
+          &newData->quarantineAndBitmap[Control.quarantineSize + newCapacity],
+          ~static_cast<std::size_t>(0));
+
+      --data->referenceCount;
+      assert(data->referenceCount > 0);
+      data = newData;
+    }
+    assert(data->referenceCount == 1);
+  }
+
+  std::size_t quarantine(Control const &control, std::size_t const index) {
+    assert(!!data &&
+           "Deallocations can only happen if allocations happened beforehand");
+    assert(
+        !control.unlimitedQuarantine &&
+        "Please check for unlimited quarantine before calling this function");
+
+    if (control.quarantineSize == 0) {
+      return index;
+    }
+
+    assert(data->referenceCount == 1 &&
+           "Must hold CoW ownership to quarantine a new index");
+
+    auto const pos = data->quarantineAndBitmap[0];
+    if (pos + 1 == control.quarantineSize) {
+      data->quarantineAndBitmap[0] = 1;
+    } else {
+      data->quarantineAndBitmap[0] = pos + 1;
+    }
+
+    return std::exchange(data->quarantineAndBitmap[pos], index);
+  }
+
+  inline static constexpr std::ptrdiff_t
+  computeNextCapacity(std::ptrdiff_t oldCapacity) noexcept {
+    assert(oldCapacity >= 0);
+    assert(oldCapacity <
+           (std::numeric_limits<std::ptrdiff_t>::max)() /
+               std::max<std::ptrdiff_t>(8, sizeof(std::uint64_t)));
+    return std::max<std::ptrdiff_t>(8, (oldCapacity * 7) / 4);
+  }
+
+  /// Get index of first word that contains a one bit. (Internally update the
+  /// associated finger.)
+  [[nodiscard]] std::ptrdiff_t
+  getFirstFree(Control const &control) const noexcept {
+    if (!data) {
+      return 0;
+    }
+
+    assert(data->firstFreeFinger >= 0);
+    assert(data->firstFreeFinger <= data->capacity);
+
+    while (data->firstFreeFinger < data->capacity &&
+           data->quarantineAndBitmap[control.quarantineSize +
+                                     data->firstFreeFinger] == 0) {
+      ++data->firstFreeFinger;
+    }
+    assert(data->firstFreeFinger <= data->capacity);
+
+    return data->firstFreeFinger;
+  }
+
+  /// Get index of last word that contains a zero bit. (Internally update the
+  /// associated finger.)
+  [[nodiscard]] inline std::ptrdiff_t
+  getLastUsed(Control const &control) const noexcept {
+    if (!data) {
+      return -1;
+    }
+
+    assert(data->lastUsedFinger >= -1);
+    assert(data->lastUsedFinger < data->capacity);
+
+    while (data->lastUsedFinger >= 0 &&
+           ~data->quarantineAndBitmap[control.quarantineSize +
+                                      data->lastUsedFinger] == 0) {
+      --data->lastUsedFinger;
+    }
+    assert(data->lastUsedFinger >= -1);
+
+    return data->lastUsedFinger;
+  }
+
+  /// Returns true iff the bit at `index` is used
+  [[nodiscard]] bool isUsed(Control const &control,
+                            std::size_t const index) const noexcept {
+    if (!data) {
+      return false;
+    }
+
+    auto const loc = static_cast<std::ptrdiff_t>(
+        index / std::numeric_limits<std::size_t>::digits);
+    auto const shift =
+        static_cast<int>(index % std::numeric_limits<std::size_t>::digits);
+
+    if (loc <= data->lastUsedFinger) {
+      return (data->quarantineAndBitmap[control.quarantineSize + loc] &
+              (static_cast<std::uint64_t>(1) << shift)) == 0;
+    } else {
+      return false;
+    }
+  }
+
+  void setFree(Control const &control, std::size_t const index) noexcept {
+    auto const loc = static_cast<std::ptrdiff_t>(
+        index / std::numeric_limits<std::size_t>::digits);
+    auto const shift =
+        static_cast<int>(index % std::numeric_limits<std::size_t>::digits);
+
+    assert(!!data);
+    assert(loc <= data->lastUsedFinger);
+    assert(data->lastUsedFinger < data->capacity);
+    // 0 <= loc <= _last_used_finger < _capacity
+
+    acquireData(control);
+
+    auto word = data->quarantineAndBitmap[control.quarantineSize + loc];
+    auto const mask = static_cast<std::size_t>(1) << shift;
+    assert((word & mask) == 0);
+    word ^= mask;
+    data->quarantineAndBitmap[control.quarantineSize + loc] = word;
+
+    if (~word == 0 && loc == data->lastUsedFinger) {
+      data->lastUsedFinger = loc - 1;
+    }
+
+    if (loc < data->firstFreeFinger) {
+      data->firstFreeFinger = loc;
+    }
+  }
+
+  /// Toggles the first free bit to allocated and returns its index
+  [[nodiscard]] std::size_t
+  setFirstFreeToUsed(Control const &control) noexcept {
+    auto const loc = getFirstFree(control);
+    if (!data) {
+      auto newCapacity = computeNextCapacity(0);
+      auto objectSize = control.prefixSize + newCapacity * sizeof(std::size_t);
+      data = static_cast<Data *>(std::malloc(objectSize));
+      assert(data && "allocation failure");
+      data->referenceCount = 1;
+      data->capacity = newCapacity;
+      data->firstFreeFinger = 0;
+      data->lastUsedFinger = -1;
+
+      if (control.quarantineSize == 0) {
+        std::fill(&data->quarantineAndBitmap[0],
+                  &data->quarantineAndBitmap[newCapacity],
+                  ~static_cast<std::size_t>(0));
+      } else {
+        data->quarantineAndBitmap[0] = 1;
+        std::fill(
+            &data->quarantineAndBitmap[1],
+            &data->quarantineAndBitmap[control.quarantineSize + newCapacity],
+            ~static_cast<std::size_t>(0));
+      }
+    } else {
+      if (loc == data->capacity && data->referenceCount == 1) {
+        auto newCapacity = computeNextCapacity(data->capacity);
+        auto objectSize =
+            control.prefixSize + newCapacity * sizeof(std::size_t);
+        data = static_cast<Data *>(std::realloc(data, objectSize));
+        assert(data && "allocation failure");
+        std::fill(
+            &data->quarantineAndBitmap[control.quarantineSize + data->capacity],
+            &data->quarantineAndBitmap[control.quarantineSize + newCapacity],
+            ~static_cast<std::size_t>(0));
+        data->capacity = newCapacity;
+      } else {
+        acquireData(control);
+        assert(loc < data->capacity &&
+               "acquire_data performs a growth step in the sense of "
+               "`computeNextCapacity`");
+      }
+    }
+
+    assert(!!data);
+    assert(data->referenceCount == 1);
+    assert(loc < data->capacity);
+
+    auto word = data->quarantineAndBitmap[control.quarantineSize + loc];
+    auto const shift = countTrailingZeroes(word);
+    auto const mask = static_cast<std::size_t>(1) << shift;
+    assert((word & mask) == mask);
+    word ^= mask;
+    data->quarantineAndBitmap[control.quarantineSize + loc] = word;
+
+    if (word == 0 && data->firstFreeFinger == loc) {
+      data->firstFreeFinger = loc + 1;
+    }
+
+    if (loc > data->lastUsedFinger) {
+      data->lastUsedFinger = loc;
+    }
+
+    return static_cast<std::size_t>(
+        loc * std::numeric_limits<std::size_t>::digits + shift);
+  }
+
+public:
+  constexpr SlotAllocator() = default;
+
+  SlotAllocator(SlotAllocator const &rhs) noexcept : data(rhs.data) {
+    if (data) {
+      ++data->referenceCount;
+      assert(data->referenceCount > 1);
+    }
+  }
+
+  SlotAllocator &operator=(SlotAllocator const &rhs) noexcept {
+    if (data != rhs.data) {
+      releaseData();
+      data = rhs.data;
+      if (data) {
+        ++data->referenceCount;
+        assert(data->referenceCount > 1);
+      }
+    }
+    return *this;
+  }
+
+  SlotAllocator(SlotAllocator &&rhs) noexcept
+      : data(std::exchange(rhs.data, nullptr)) {
+    assert(data == nullptr || data->referenceCount > 0);
+  }
+
+  SlotAllocator &operator=(SlotAllocator &&rhs) noexcept {
+    if (data != rhs.data) {
+      releaseData();
+      data = std::exchange(rhs.data, nullptr);
+    }
+    return *this;
+  }
+
+  ~SlotAllocator() noexcept { releaseData(); }
+
+  inline std::ostream &logTag(std::ostream &out) const noexcept {
+    return out << "[slot] ";
+  }
+
+  LocationInfo getLocationInfo(Control const &control, void const *const ptr,
+                               std::size_t const size) const noexcept {
+    assert(control.mapping_begin() <= ptr &&
+           reinterpret_cast<char const *>(ptr) + size < control.mapping_end() &&
+           "This property should have been ensured by the caller");
+
+    auto const begin = static_cast<std::size_t>(static_cast<char const *>(ptr) -
+                                                control.baseAddress);
+    auto const end = static_cast<std::size_t>(static_cast<char const *>(ptr) +
+                                              size - control.baseAddress);
+    assert(control.slotSize > 0 && "Uninitialized Control structure");
+    auto const pos = begin - begin % control.slotSize;
+    if (pos != (end - 1) - (end - 1) % control.slotSize) {
+      return LocationInfo::LI_Unaligned;
+    }
+
+    auto const index = control.convertPositionToIndex(pos);
+    auto const loc = static_cast<std::ptrdiff_t>(
+        index / std::numeric_limits<std::size_t>::digits);
+    auto const shift =
+        static_cast<int>(index % std::numeric_limits<std::size_t>::digits);
+
+    if (!data || loc > data->lastUsedFinger) {
+      return LocationInfo::LI_Unallocated;
+    }
+    assert(data->lastUsedFinger < data->capacity);
+
+    auto word = data->quarantineAndBitmap[control.quarantineSize + loc];
+    auto const mask = static_cast<std::size_t>(1) << shift;
+    if ((word & mask) == 0) {
+      return {LocationInfo::LI_AllocatedOrQuarantined,
+              control.baseAddress + pos};
+    } else {
+      return LocationInfo::LI_Unallocated;
+    }
+  }
+
+  [[nodiscard]] void *allocate(Control const &control) noexcept {
+    traceLine("Allocating ", control.slotSize, " bytes");
+    traceContents(control);
+
+    auto const index = setFirstFreeToUsed(control);
+    return control.baseAddress + control.convertIndexToPosition(index);
+  }
+
+  void deallocate(Control const &control, void *const ptr) {
+    assert(!!data &&
+           "Deallocations can only happen if allocations happened beforehand");
+
+    if (control.unlimitedQuarantine) {
+      traceLine("Quarantining ", ptr, " for ever");
+    } else {
+      auto pos = static_cast<std::size_t>(static_cast<char *>(ptr) -
+                                          control.baseAddress);
+      acquireData(control); // we will need quarantine and/or bitmap ownership
+
+      traceLine("Quarantining ", ptr, " as ", pos, " for ",
+                control.quarantineSize, " deallocations");
+      pos = quarantine(control, pos);
+
+      if (pos == static_cast<std::size_t>(-1)) {
+        traceLine("Nothing to deallocate");
+      } else {
+        traceLine("Deallocating ", pos);
+        traceContents(control);
+        assert(pos < control.size);
+
+        setFree(control, control.convertPositionToIndex(pos));
+      }
+    }
+  }
+
+  void traceContents(Control const &control) const noexcept {
+    static_cast<void>(control);
+
+#if KDALLOC_TRACE >= 2
+    traceLine("bitmap:");
+    bool isEmpty = true;
+    for (std::size_t i = 0; i < data->capacity; ++i) {
+      if (is_used(Control, i)) {
+        isEmpty = false;
+        traceLine("  ", i, " ",
+                  static_cast<void *>(control.baseAddress +
+                                      control.convertIndexToPosition(i)));
+      }
+    }
+    if (isEmpty) {
+      traceLine("  <empty>");
+    }
+#else
+    traceLine("bitmap has a capacity of ", data ? data->capacity : 0,
+              " entries");
+#endif
+  }
+};
+} // namespace klee::kdalloc::suballocators
+
+#endif

--- a/include/klee/KDAlloc/tagged_logger.h
+++ b/include/klee/KDAlloc/tagged_logger.h
@@ -1,0 +1,43 @@
+//===-- tagged_logger.h -----------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KDALLOC_UTIL_TAGGED_LOGGER_H
+#define KDALLOC_UTIL_TAGGED_LOGGER_H
+
+#include "define.h"
+
+#include <utility>
+
+#if KDALLOC_TRACE >= 1
+#include <iostream>
+#endif
+
+namespace klee::kdalloc {
+template <typename C> class TaggedLogger {
+  template <typename O> inline void traceLineImpl(O &out) const noexcept {
+    out << "\n";
+  }
+
+  template <typename O, typename T, typename... V>
+  inline void traceLineImpl(O &out, T &&head, V &&...tail) const noexcept {
+    out << head;
+    traceLineImpl(out, std::forward<V>(tail)...);
+  }
+
+protected:
+  template <typename... V> inline void traceLine(V &&...args) const noexcept {
+#if KDALLOC_TRACE >= 1
+    traceLineImpl(static_cast<C const *>(this)->logTag(std::cout),
+                  std::forward<T>(args));
+#endif
+  }
+};
+} // namespace klee::kdalloc
+
+#endif

--- a/lib/Core/AddressSpace.h
+++ b/lib/Core/AddressSpace.h
@@ -126,7 +126,11 @@ namespace klee {
 
     /// Copy the concrete values of all managed ObjectStates into the
     /// actual system memory location they were allocated at.
-    void copyOutConcretes();
+    /// Returns the (hypothetical) number of pages needed provided each written
+    /// object occupies (at least) a single page.
+    std::size_t copyOutConcretes();
+
+    void copyOutConcrete(const MemoryObject *mo, const ObjectState *os) const;
 
     /// Copy the concrete values of all managed ObjectStates back from
     /// the actual system memory location they were allocated

--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -11,12 +11,14 @@
 #define KLEE_EXECUTIONSTATE_H
 
 #include "AddressSpace.h"
+#include "MemoryManager.h"
 #include "MergeHandler.h"
 
 #include "klee/ADT/ImmutableSet.h"
 #include "klee/ADT/TreeStream.h"
 #include "klee/Expr/Constraints.h"
 #include "klee/Expr/Expr.h"
+#include "klee/KDAlloc/kdalloc.h"
 #include "klee/Module/KInstIterator.h"
 #include "klee/Solver/Solver.h"
 #include "klee/System/Time.h"
@@ -180,6 +182,12 @@ public:
   /// @brief Address space used by this state (e.g. Global and Heap)
   AddressSpace addressSpace;
 
+  /// @brief Stack allocator (used with deterministic allocation)
+  kdalloc::StackAllocator stackAllocator;
+
+  /// @brief Heap allocator (used with deterministic allocation)
+  kdalloc::Allocator heapAllocator;
+
   /// @brief Constraints collected so far
   ConstraintSet constraints;
 
@@ -246,7 +254,7 @@ public:
   ExecutionState() = default;
 #endif
   // only to create the initial state
-  explicit ExecutionState(KFunction *kf);
+  explicit ExecutionState(KFunction *kf, MemoryManager *mm);
   // no copy assignment, use copy constructor
   ExecutionState &operator=(const ExecutionState &) = delete;
   // no move ctor
@@ -260,6 +268,8 @@ public:
 
   void pushFrame(KInstIterator caller, KFunction *kf);
   void popFrame();
+
+  void deallocate(const MemoryObject *mo);
 
   void addSymbolic(const MemoryObject *mo, const Array *array);
 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -138,13 +138,13 @@ private:
   /// happens with other states (that don't satisfy the seeds) depends
   /// on as-yet-to-be-determined flags.
   std::map<ExecutionState*, std::vector<SeedInfo> > seedMap;
-  
+
   /// Map of globals to their representative memory object.
   std::map<const llvm::GlobalValue*, MemoryObject*> globalObjects;
 
   /// Map of globals to their bound address. This also includes
-  /// globals that have no representative object (i.e. functions).
-  std::map<const llvm::GlobalValue*, ref<ConstantExpr> > globalAddresses;
+  /// globals that have no representative object (e.g. aliases).
+  std::map<const llvm::GlobalValue*, ref<ConstantExpr>> globalAddresses;
 
   /// Map of legal function addresses to the corresponding Function.
   /// Used to validate and dereference function pointers.
@@ -212,8 +212,7 @@ private:
   /// Return the typeid corresponding to a certain `type_info`
   ref<ConstantExpr> getEhTypeidFor(ref<Expr> type_info);
 
-  llvm::Function* getTargetFunction(llvm::Value *calledVal,
-                                    ExecutionState &state);
+  llvm::Function* getTargetFunction(llvm::Value *calledVal);
   
   void executeInstruction(ExecutionState &state, KInstruction *ki);
 

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -50,6 +50,7 @@ public:
 
   /// size in bytes
   unsigned size;
+  unsigned alignment;
   mutable std::string name;
 
   bool isLocal;
@@ -76,18 +77,20 @@ public:
     : id(counter++),
       address(_address),
       size(0),
+      alignment(0),
       isFixed(true),
       parent(NULL),
       allocSite(0) {
   }
 
-  MemoryObject(uint64_t _address, unsigned _size, 
+  MemoryObject(uint64_t _address, unsigned _size, unsigned _alignment,
                bool _isLocal, bool _isGlobal, bool _isFixed,
                const llvm::Value *_allocSite,
                MemoryManager *_parent)
     : id(counter++),
       address(_address),
       size(_size),
+      alignment(_alignment),
       name("unnamed"),
       isLocal(_isLocal),
       isGlobal(_isGlobal),

--- a/lib/Core/MemoryManager.cpp
+++ b/lib/Core/MemoryManager.cpp
@@ -10,76 +10,261 @@
 #include "MemoryManager.h"
 
 #include "CoreStats.h"
+#include "ExecutionState.h"
 #include "Memory.h"
 
 #include "klee/Expr/Expr.h"
 #include "klee/Support/ErrorHandling.h"
 
+#include "llvm/IR/GlobalVariable.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/MathExtras.h"
+#if LLVM_VERSION_CODE >= LLVM_VERSION(10, 0)
+#include "llvm/Support/Alignment.h"
+#else
+#include "llvm/Support/MathExtras.h"
+#endif
 
-#include <inttypes.h>
+#include <cinttypes>
+#include <algorithm>
 #include <sys/mman.h>
+#include <tuple>
+#include <string>
 
 using namespace klee;
 
-namespace {
+namespace klee {
+std::uint32_t MemoryManager::quarantine;
 
+std::size_t MemoryManager::pageSize = sysconf(_SC_PAGE_SIZE);
+
+bool MemoryManager::isDeterministic;
+} // namespace klee
+
+namespace {
 llvm::cl::OptionCategory MemoryCat("Memory management options",
                                    "These options control memory management.");
 
-llvm::cl::opt<bool> DeterministicAllocation(
-    "allocate-determ",
+llvm::cl::opt<bool, true> DeterministicAllocation(
+    "kdalloc",
     llvm::cl::desc("Allocate memory deterministically (default=false)"),
-    llvm::cl::init(false), llvm::cl::cat(MemoryCat));
+    llvm::cl::location(MemoryManager::isDeterministic), llvm::cl::init(false),
+    llvm::cl::cat(MemoryCat));
 
-llvm::cl::opt<unsigned> DeterministicAllocationSize(
-    "allocate-determ-size",
+llvm::cl::opt<bool> DeterministicAllocationMarkAsUnneeded(
+    "kdalloc-mark-as-unneeded",
+    llvm::cl::desc("Mark allocations as unneeded after external function calls "
+                   "(default=true)"),
+    llvm::cl::init(true), llvm::cl::cat(MemoryCat));
+
+llvm::cl::opt<unsigned> DeterministicAllocationGlobalsSize(
+    "kdalloc-globals-size",
+    llvm::cl::desc("Reserved memory for globals in GiB (default=10)"),
+    llvm::cl::init(10), llvm::cl::cat(MemoryCat));
+
+llvm::cl::opt<unsigned> DeterministicAllocationConstantsSize(
+    "kdalloc-constants-size",
+    llvm::cl::desc("Reserved memory for constant globals in GiB (default=10)"),
+    llvm::cl::init(10), llvm::cl::cat(MemoryCat));
+
+llvm::cl::opt<unsigned> DeterministicAllocationHeapSize(
+    "kdalloc-heap-size",
+    llvm::cl::desc("Reserved memory for heap in GiB (default=1024)"),
+    llvm::cl::init(1024), llvm::cl::cat(MemoryCat));
+
+llvm::cl::opt<unsigned> DeterministicAllocationStackSize(
+    "kdalloc-stack-size",
+    llvm::cl::desc("Reserved memory for stack in GiB (default=100)"),
+    llvm::cl::init(128), llvm::cl::cat(MemoryCat));
+
+llvm::cl::opt<std::uintptr_t> DeterministicAllocationGlobalsStartAddress(
+    "kdalloc-globals-start-address",
     llvm::cl::desc(
-        "Preallocated memory for deterministic allocation in MB (default=100)"),
-    llvm::cl::init(100), llvm::cl::cat(MemoryCat));
+        "Start address for globals segment (has to be page aligned)"),
+    llvm::cl::cat(MemoryCat));
+
+llvm::cl::opt<std::uintptr_t> DeterministicAllocationConstantsStartAddress(
+    "kdalloc-constants-start-address",
+    llvm::cl::desc(
+        "Start address for constant globals segment (has to be page aligned)"),
+    llvm::cl::cat(MemoryCat));
+
+llvm::cl::opt<std::uintptr_t> DeterministicAllocationHeapStartAddress(
+    "kdalloc-heap-start-address",
+    llvm::cl::desc("Start address for heap segment (has to be page aligned)"),
+    llvm::cl::cat(MemoryCat));
+
+llvm::cl::opt<std::uintptr_t> DeterministicAllocationStackStartAddress(
+    "kdalloc-stack-start-address",
+    llvm::cl::desc("Start address for stack segment (has to be page aligned)"),
+    llvm::cl::cat(MemoryCat));
+
+struct QuarantineSizeParser : public llvm::cl::parser<std::uint32_t> {
+  explicit QuarantineSizeParser(llvm::cl::Option &O)
+      : llvm::cl::parser<std::uint32_t>(O) {}
+
+  bool parse(llvm::cl::Option &O, llvm::StringRef ArgName, llvm::StringRef Arg,
+             std::uint32_t &Val) {
+    if (Arg == "-1") {
+      Val = kdalloc::Allocator::unlimitedQuarantine;
+    } else if (Arg.getAsInteger(0, Val)) {
+      return O.error("'" + Arg + "' value invalid!");
+    }
+
+    return false;
+  }
+};
+
+llvm::cl::opt<std::uint32_t, true, QuarantineSizeParser>
+    DeterministicAllocationQuarantineSize(
+        "kdalloc-quarantine",
+        llvm::cl::desc("Size of quarantine queues in allocator (default=8, "
+                       "disabled=0, unlimited=-1)"),
+        llvm::cl::location(klee::MemoryManager::quarantine),
+        llvm::cl::value_desc("size"), llvm::cl::init(8),
+        llvm::cl::cat(MemoryCat));
 
 llvm::cl::opt<bool> NullOnZeroMalloc(
     "return-null-on-zero-malloc",
     llvm::cl::desc("Returns NULL if malloc(0) is called (default=false)"),
     llvm::cl::init(false), llvm::cl::cat(MemoryCat));
-
-llvm::cl::opt<unsigned> RedzoneSize(
-    "redzone-size",
-    llvm::cl::desc("Set the size of the redzones to be added after each "
-                   "allocation (in bytes). This is important to detect "
-                   "out-of-bounds accesses (default=10)"),
-    llvm::cl::init(10), llvm::cl::cat(MemoryCat));
-
-llvm::cl::opt<unsigned long long> DeterministicStartAddress(
-    "allocate-determ-start-address",
-    llvm::cl::desc("Start address for deterministic allocation. Has to be page "
-                   "aligned (default=0x7ff30000000)"),
-    llvm::cl::init(0x7ff30000000), llvm::cl::cat(MemoryCat));
 } // namespace
 
 /***/
 MemoryManager::MemoryManager(ArrayCache *_arrayCache)
-    : arrayCache(_arrayCache), deterministicSpace(0), nextFreeSlot(0),
-      spaceSize(DeterministicAllocationSize.getValue() * 1024 * 1024) {
+    : arrayCache(_arrayCache) {
   if (DeterministicAllocation) {
-    // Page boundary
-    void *expectedAddress = (void *)DeterministicStartAddress.getValue();
-
-    char *newSpace =
-        (char *)mmap(expectedAddress, spaceSize, PROT_READ | PROT_WRITE,
-                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-
-    if (newSpace == MAP_FAILED) {
-      klee_error("Couldn't mmap() memory for deterministic allocations");
-    }
-    if (expectedAddress != newSpace && expectedAddress != 0) {
-      klee_error("Could not allocate memory deterministically");
+    if (DeterministicAllocationQuarantineSize ==
+        kdalloc::Allocator::unlimitedQuarantine) {
+      klee_message("Deterministic allocator: Using unlimited quarantine");
+    } else if (DeterministicAllocationQuarantineSize != 0) {
+      klee_message("Deterministic allocator: Using quarantine queue size %u",
+                   DeterministicAllocationQuarantineSize.getValue());
     }
 
-    klee_message("Deterministic memory allocation starting from %p", newSpace);
-    deterministicSpace = newSpace;
-    nextFreeSlot = newSpace;
+    std::vector<std::tuple<std::string,
+                           std::uintptr_t, // start address (0 if none
+                                           // requested)
+                           std::size_t,    // size of segment
+                           std::reference_wrapper<kdalloc::AllocatorFactory>,
+                           kdalloc::Allocator *>>
+        requestedSegments;
+    requestedSegments.emplace_back(
+        "globals",
+        DeterministicAllocationGlobalsStartAddress
+            ? DeterministicAllocationGlobalsStartAddress.getValue()
+            : 0,
+        static_cast<std::size_t>(
+            DeterministicAllocationGlobalsSize.getValue()) *
+            1024 * 1024 * 1024,
+        globalsFactory, &globalsAllocator);
+    requestedSegments.emplace_back(
+        "constants",
+        DeterministicAllocationConstantsStartAddress
+            ? DeterministicAllocationConstantsStartAddress.getValue()
+            : 0,
+        static_cast<std::size_t>(
+            DeterministicAllocationConstantsSize.getValue()) *
+            1024 * 1024 * 1024,
+        constantsFactory, &constantsAllocator);
+    requestedSegments.emplace_back(
+        "heap",
+        DeterministicAllocationHeapStartAddress
+            ? DeterministicAllocationHeapStartAddress.getValue()
+            : 0,
+        static_cast<std::size_t>(DeterministicAllocationHeapSize.getValue()) *
+            1024 * 1024 * 1024,
+        heapFactory, nullptr);
+    requestedSegments.emplace_back(
+        "stack",
+        DeterministicAllocationStackStartAddress
+            ? DeterministicAllocationStackStartAddress.getValue()
+            : 0,
+        static_cast<std::size_t>(DeterministicAllocationStackSize.getValue()) *
+            1024 * 1024 * 1024,
+        stackFactory, nullptr);
+
+    // check invariants
+#if LLVM_VERSION_CODE >= LLVM_VERSION(10, 0)
+    llvm::Align pageAlignment(pageSize);
+#endif
+    for (auto &requestedSegment : requestedSegments) {
+      auto &segment1 = std::get<0>(requestedSegment);
+      auto &start1 = std::get<1>(requestedSegment);
+      auto &size1 = std::get<2>(requestedSegment);
+      // check for page alignment
+      // NOTE: sizes are assumed to be page aligned due to multiplication
+#if LLVM_VERSION_CODE >= LLVM_VERSION(10, 0)
+      if (start1 != 0 && !llvm::isAligned(pageAlignment, start1)) {
+        klee_error("Deterministic allocator: Requested start address for %s "
+                   "is not page aligned (page size: %zu B)",
+                   segment1.c_str(), pageAlignment.value());
+      }
+#else
+      if (start1 != 0 && llvm::OffsetToAlignment(start1, pageSize) != 0) {
+        klee_error("Deterministic allocator: Requested start address for %s "
+                   "is not page aligned (page size: %zu B)",
+                   segment1.c_str(), pageSize);
+      }
+#endif
+
+      // check for overlap of segments
+      std::uintptr_t end1 = start1 + size1;
+      for (auto &requestedSegment : requestedSegments) {
+        auto &segment2 = std::get<0>(requestedSegment);
+        auto &start2 = std::get<1>(requestedSegment);
+        auto &size2 = std::get<2>(requestedSegment);
+        if (start1 != 0 && start2 != 0 && segment1 != segment2) {
+          std::uintptr_t end2 = start2 + size2;
+          if (!(end1 <= start2 || start1 >= end2)) {
+            klee_error("Deterministic allocator: Requested mapping for %s "
+                       "(start-address=0x%" PRIxPTR " size=%zu GiB) "
+                       "overlaps with that for %s "
+                       "(start-address=0x%" PRIxPTR " size=%zu GiB)",
+                       segment1.c_str(), start1, size1 / (1024 * 1024 * 1024),
+                       segment2.c_str(), start2, size2 / (1024 * 1024 * 1024));
+          }
+        }
+      }
+    }
+
+    // initialize factories and allocators
+    for (auto &requestedSegment : requestedSegments) {
+      auto &segment = std::get<0>(requestedSegment);
+      auto &start = std::get<1>(requestedSegment);
+      auto &size = std::get<2>(requestedSegment);
+      auto &factory = std::get<3>(requestedSegment);
+      auto &allocator = std::get<4>(requestedSegment);
+      factory.get() = kdalloc::AllocatorFactory(
+          start, size, DeterministicAllocationQuarantineSize);
+
+      if (!factory.get()) {
+        klee_error(
+            "Deterministic allocator: Could not allocate mapping for %s: %s",
+            segment.c_str(), strerror(errno));
+      }
+      if (start && factory.get().getMapping().getBaseAddress() !=
+                       reinterpret_cast<void *>(start)) {
+        klee_error("Deterministic allocator: Could not allocate mapping for %s "
+                   "at requested address",
+                   segment.c_str());
+      }
+      if (factory.get().getMapping().getSize() != size) {
+        klee_error("Deterministic allocator: Could not allocate mapping for %s "
+                   "with the requested size",
+                   segment.c_str());
+      }
+
+      klee_message("Deterministic allocator: %s "
+                   "(start-address=0x%" PRIxPTR " size=%zu GiB)",
+                   segment.c_str(),
+                   reinterpret_cast<std::uintptr_t>(
+                       factory.get().getMapping().getBaseAddress()),
+                   size / (1024 * 1024 * 1024));
+      if (allocator) {
+        *allocator = factory.get().makeAllocator();
+      }
+    }
   }
 }
 
@@ -91,13 +276,10 @@ MemoryManager::~MemoryManager() {
     objects.erase(mo);
     delete mo;
   }
-
-  if (DeterministicAllocation)
-    munmap(deterministicSpace, spaceSize);
 }
 
 MemoryObject *MemoryManager::allocate(uint64_t size, bool isLocal,
-                                      bool isGlobal,
+                                      bool isGlobal, ExecutionState *state,
                                       const llvm::Value *allocSite,
                                       size_t alignment) {
   if (size > 10 * 1024 * 1024)
@@ -116,19 +298,29 @@ MemoryObject *MemoryManager::allocate(uint64_t size, bool isLocal,
 
   uint64_t address = 0;
   if (DeterministicAllocation) {
-    address = llvm::alignTo((uint64_t)nextFreeSlot + alignment - 1, alignment);
+    void *allocAddress;
 
-    // Handle the case of 0-sized allocations as 1-byte allocations.
-    // This way, we make sure we have this allocation between its own red zones
-    size_t alloc_size = std::max(size, (uint64_t)1);
-    if ((char *)address + alloc_size < deterministicSpace + spaceSize) {
-      nextFreeSlot = (char *)address + alloc_size + RedzoneSize;
+    if (isGlobal) {
+      const llvm::GlobalVariable *gv =
+          dyn_cast<llvm::GlobalVariable>(allocSite);
+      if (isa<llvm::Function>(allocSite) || (gv && gv->isConstant())) {
+        allocAddress = constantsAllocator.allocate(
+            std::max(size, static_cast<std::uint64_t>(alignment)));
+      } else {
+        allocAddress = globalsAllocator.allocate(
+            std::max(size, static_cast<std::uint64_t>(alignment)));
+      }
     } else {
-      klee_warning_once(0, "Couldn't allocate %" PRIu64
-                           " bytes. Not enough deterministic space left.",
-                        size);
-      address = 0;
+      if (isLocal) {
+        allocAddress = state->stackAllocator.allocate(
+            std::max(size, static_cast<std::uint64_t>(alignment)));
+      } else {
+        allocAddress = state->heapAllocator.allocate(
+            std::max(size, static_cast<std::uint64_t>(alignment)));
+      }
     }
+
+    address = reinterpret_cast<std::uint64_t>(allocAddress);
   } else {
     // Use malloc for the standard case
     if (alignment <= 8)
@@ -146,8 +338,8 @@ MemoryObject *MemoryManager::allocate(uint64_t size, bool isLocal,
     return 0;
 
   ++stats::allocations;
-  MemoryObject *res = new MemoryObject(address, size, isLocal, isGlobal, false,
-                                       allocSite, this);
+  MemoryObject *res = new MemoryObject(address, size, alignment, isLocal,
+                                       isGlobal, false, allocSite, this);
   objects.insert(res);
   return res;
 }
@@ -165,12 +357,10 @@ MemoryObject *MemoryManager::allocateFixed(uint64_t address, uint64_t size,
 
   ++stats::allocations;
   MemoryObject *res =
-      new MemoryObject(address, size, false, true, true, allocSite, this);
+      new MemoryObject(address, size, 0, false, true, true, allocSite, this);
   objects.insert(res);
   return res;
 }
-
-void MemoryManager::deallocate(const MemoryObject *mo) { assert(0); }
 
 void MemoryManager::markFreed(MemoryObject *mo) {
   if (objects.find(mo) != objects.end()) {
@@ -180,6 +370,21 @@ void MemoryManager::markFreed(MemoryObject *mo) {
   }
 }
 
+bool MemoryManager::markMappingsAsUnneeded() {
+  if (!DeterministicAllocation)
+    return false;
+
+  if (!DeterministicAllocationMarkAsUnneeded)
+    return false;
+
+  globalsFactory.getMapping().clear();
+  heapFactory.getMapping().clear();
+  stackFactory.getMapping().clear();
+
+  return true;
+}
+
 size_t MemoryManager::getUsedDeterministicSize() {
-  return nextFreeSlot - deterministicSpace;
+  // TODO: implement
+  return 0;
 }

--- a/lib/Solver/ConstantDivision.cpp
+++ b/lib/Solver/ConstantDivision.cpp
@@ -86,7 +86,7 @@ void ComputeMultConstants64(uint64_t multiplicand,
 
   while (x) {
     // Determine rightmost contiguous region of 1s.
-    unsigned low = bits64::indexOfRightmostBit(x);
+    unsigned low = countTrailingZeroes(x);
     uint64_t lowbit = 1LL << low;
     uint64_t p = x + lowbit;
     uint64_t q = bits64::isolateRightmostBit(p);

--- a/test/DeterministicAllocation/OneOutOfBounds.c
+++ b/test/DeterministicAllocation/OneOutOfBounds.c
@@ -1,0 +1,12 @@
+// RUN: %clang %s -g -emit-llvm %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --kdalloc %t.bc 2>&1 | FileCheck %s
+// RUN: test -f %t.klee-out/test000001.ptr.err
+
+int main() {
+  int *x = malloc(sizeof(int));
+  // CHECK: OneOutOfBounds.c:[[@LINE+1]]: memory error: out of bound pointer
+  x[1] = 1;
+  free(x);
+  return 0;
+}

--- a/test/DeterministicAllocation/double-free-loh.c
+++ b/test/DeterministicAllocation/double-free-loh.c
@@ -1,0 +1,16 @@
+// RUN: %clang %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -kdalloc -kdalloc-quarantine=1 -output-dir=%t.klee-out %t.bc -exit-on-error >%t.output 2>&1
+// RUN: FileCheck %s -input-file=%t.output
+
+#include <stdlib.h>
+
+int main() {
+  void *ptr = malloc(4096);
+  free(ptr);
+
+  // CHECK: double free
+  free(ptr);
+
+  return 0;
+}

--- a/test/DeterministicAllocation/double-free.c
+++ b/test/DeterministicAllocation/double-free.c
@@ -1,0 +1,16 @@
+// RUN: %clang %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -kdalloc -kdalloc-quarantine=1 -output-dir=%t.klee-out %t.bc -exit-on-error >%t.output 2>&1
+// RUN: FileCheck %s -input-file=%t.output
+
+#include <stdlib.h>
+
+int main() {
+  void *ptr = malloc(8);
+  free(ptr);
+
+  // CHECK: double free
+  free(ptr);
+
+  return 0;
+}

--- a/test/DeterministicAllocation/madvise.c
+++ b/test/DeterministicAllocation/madvise.c
@@ -1,0 +1,49 @@
+// REQUIRES: not-msan && not-asan
+// RUN: %clang %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out %t.log
+// RUN: %klee -kdalloc -kdalloc-quarantine=-1 -output-dir=%t.klee-out %t.bc -exit-on-error 2>&1 | tee %t.log
+// RUN: FileCheck %s -input-file=%t.log
+
+// This test is disabled for asan and msan because they create additional page faults
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+
+#include "klee/klee.h"
+
+size_t maxrss() {
+  struct rusage usage;
+  int res = getrusage(RUSAGE_SELF, &usage);
+  assert(!res && "getrusage succeeded");
+  return usage.ru_maxrss;
+}
+
+int main(void) {
+  size_t baseline = maxrss();
+#if defined(__APPLE__)
+  size_t limit = baseline + 100 * 1024 * 1024; // limit is 100 MiB above baseline
+#else
+  size_t limit = baseline + 100 * 1024; // limit is 100 MiB above baseline
+#endif
+
+  // CHECK: Deterministic allocator: Using unlimited quarantine
+
+  size_t bins[] = {1, 4, 8, 16, 32, 64, 256, 2048};
+  for (int i = 0; i < 1000; ++i) {
+    for (size_t j = 0; j < sizeof(bins) / sizeof(*bins); ++j) {
+      void *volatile p = malloc(bins[j]);
+      void *volatile p2 = malloc(4096); // for faster growth
+
+      // CHECK: calling external: getrusage
+      // CHECK-NOT: ASSERTION FAIL
+      assert(maxrss() < limit && "MaxRSS is below limit");
+
+      free(p);
+      free(p2);
+    }
+  }
+
+  return 0;
+}

--- a/test/DeterministicAllocation/nullpage-read.c
+++ b/test/DeterministicAllocation/nullpage-read.c
@@ -1,0 +1,20 @@
+// RUN: %clang %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -kdalloc -kdalloc-quarantine=1 -output-dir=%t.klee-out %t.bc -exit-on-error >%t.output 2>&1
+// RUN: FileCheck %s -input-file=%t.output
+
+#include <stdlib.h>
+#include <string.h>
+
+int main() {
+  struct {
+    int x;
+    int y;
+  } *ptr = NULL;
+
+  // CHECK: null page access
+  int y;
+  memcpy(&y, &ptr->y, sizeof(ptr->y));
+
+  return 0;
+}

--- a/test/DeterministicAllocation/nullpage-write.c
+++ b/test/DeterministicAllocation/nullpage-write.c
@@ -1,0 +1,19 @@
+// RUN: %clang %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -kdalloc -kdalloc-quarantine=1 -output-dir=%t.klee-out %t.bc -exit-on-error >%t.output 2>&1
+// RUN: FileCheck %s -input-file=%t.output
+
+#include <stdlib.h>
+#include <string.h>
+
+int main() {
+  struct {
+    int x;
+    int y;
+  } *ptr = NULL;
+
+  // CHECK: null page access
+  memset(&ptr->y, 0, sizeof(ptr->y));
+
+  return 0;
+}

--- a/test/DeterministicAllocation/use-after-free-loh.c
+++ b/test/DeterministicAllocation/use-after-free-loh.c
@@ -1,0 +1,17 @@
+// RUN: %clang %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -kdalloc -kdalloc-quarantine=1 -output-dir=%t.klee-out %t.bc -exit-on-error >%t.output 2>&1
+// RUN: FileCheck %s -input-file=%t.output
+
+#include <stdlib.h>
+#include <string.h>
+
+int main() {
+  void *ptr = malloc(4096);
+  free(ptr);
+
+  // CHECK: use after free
+  memset(ptr, 0, 4096);
+
+  return 0;
+}

--- a/test/DeterministicAllocation/use-after-free.c
+++ b/test/DeterministicAllocation/use-after-free.c
@@ -1,0 +1,17 @@
+// RUN: %clang %s -emit-llvm -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -kdalloc -kdalloc-quarantine=1 -output-dir=%t.klee-out %t.bc -exit-on-error >%t.output 2>&1
+// RUN: FileCheck %s -input-file=%t.output
+
+#include <stdlib.h>
+#include <string.h>
+
+int main() {
+  void *ptr = malloc(8);
+  free(ptr);
+
+  // CHECK: use after free
+  memset(ptr, 0, 8);
+
+  return 0;
+}

--- a/test/Feature/VarArg.c
+++ b/test/Feature/VarArg.c
@@ -7,7 +7,7 @@
 
 // RUN: %clang %s -emit-llvm %O0opt -c -g -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --allocate-determ=true --allocate-determ-start-address=0x0 %t1.bc | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --kdalloc %t1.bc | FileCheck %s
 // RUN: test -f %t.klee-out/test000001.ptr.err
 
 #include <stdarg.h>

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -235,6 +235,7 @@ endfunction()
 # Unit Tests
 add_subdirectory(Assignment)
 add_subdirectory(Expr)
+add_subdirectory(KDAlloc)
 add_subdirectory(Ref)
 add_subdirectory(Solver)
 add_subdirectory(Searcher)

--- a/unittests/KDAlloc/CMakeLists.txt
+++ b/unittests/KDAlloc/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_klee_unit_test(KDAllocTest
+  allocate.cpp
+  randomtest.cpp
+  reuse.cpp
+  rusage.cpp
+  sample.cpp
+  stacktest.cpp)
+target_compile_definitions(KDAllocTest PUBLIC "-DKDALLOC_CHECKED" "-DUSE_KDALLOC" "-DUSE_GTEST_INSTEAD_OF_MAIN")
+target_compile_definitions(KDAllocTest PRIVATE ${KLEE_COMPONENT_CXX_DEFINES})
+target_compile_options(KDAllocTest PRIVATE ${KLEE_COMPONENT_CXX_FLAGS})

--- a/unittests/KDAlloc/allocate.cpp
+++ b/unittests/KDAlloc/allocate.cpp
@@ -1,0 +1,66 @@
+//===-- allocate.cpp ------------------------------------------------------===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "klee/KDAlloc/kdalloc.h"
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+#include "gtest/gtest.h"
+#endif
+
+#include <cassert>
+#include <deque>
+#include <iomanip>
+#include <iostream>
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+int allocate_sample_test() {
+#else
+int main() {
+#endif
+  // initialize a factory and an associated allocator (using the location "0"
+  // gives an OS-assigned location)
+  klee::kdalloc::AllocatorFactory factory(static_cast<std::size_t>(1) << 20, 0);
+  klee::kdalloc::Allocator allocator = factory.makeAllocator();
+
+  std::deque<void *> allocations;
+  for (std::size_t i = 0; i < 10; ++i) {
+    auto p = allocator.allocate(4);
+    allocations.emplace_back(p);
+    std::cout << "Allocated     " << std::right << std::setw(64 / 4) << std::hex
+              << (static_cast<char *>(p) -
+                  static_cast<char *>(factory.getMapping().getBaseAddress()))
+              << "\n";
+  }
+
+  {
+    auto p = allocations[2];
+    allocations.erase(allocations.begin() + 2);
+    std::cout << "Freeing       " << std::right << std::setw(64 / 4) << std::hex
+              << (static_cast<char *>(p) -
+                  static_cast<char *>(factory.getMapping().getBaseAddress()))
+              << "\n";
+    allocator.free(p, 4);
+  }
+
+  for (auto p : allocations) {
+    std::cout << "Freeing       " << std::right << std::setw(64 / 4) << std::hex
+              << (static_cast<char *>(p) -
+                  static_cast<char *>(factory.getMapping().getBaseAddress()))
+              << "\n";
+    allocator.free(p, 4);
+  }
+
+  exit(0);
+}
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+TEST(KDAllocDeathTest, AllocateSample) {
+  ASSERT_EXIT(allocate_sample_test(), ::testing::ExitedWithCode(0), "");
+}
+#endif

--- a/unittests/KDAlloc/randomtest.cpp
+++ b/unittests/KDAlloc/randomtest.cpp
@@ -1,0 +1,177 @@
+//===-- randomtest.cpp ----------------------------------------------------===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "klee/KDAlloc/kdalloc.h"
+#include "xoshiro.h"
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+#include "gtest/gtest.h"
+#endif
+
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <utility>
+#include <vector>
+
+namespace {
+class RandomTest {
+  xoshiro512 rng;
+
+#if defined(USE_KDALLOC)
+  klee::kdalloc::Allocator allocator;
+#endif
+
+  std::vector<std::pair<void *, std::size_t>> allocations;
+
+  std::geometric_distribution<std::size_t> allocation_bin_distribution;
+  std::geometric_distribution<std::size_t> large_allocation_distribution;
+
+public:
+  std::size_t maximum_concurrent_allocations = 0;
+  std::uint64_t allocation_count = 0;
+  std::uint64_t deallocation_count = 0;
+
+  RandomTest(std::uint64_t seed = 0x31337)
+      : rng(seed)
+#if defined(USE_KDALLOC)
+        ,
+        allocator(klee::kdalloc::AllocatorFactory(
+            static_cast<std::size_t>(1) << 42, 0))
+#endif
+        ,
+        allocation_bin_distribution(0.3),
+        large_allocation_distribution(0.00003) {
+  }
+
+  void run(std::uint64_t const iterations) {
+    std::uniform_int_distribution<std::uint32_t> choice(0, 999);
+    for (std::uint64_t i = 0; i < iterations; ++i) {
+      auto chosen = choice(rng);
+      if (chosen < 650) {
+        ++allocation_count;
+        allocate_sized();
+      } else if (chosen < 700) {
+        ++allocation_count;
+        allocate_large();
+      } else if (chosen < 1000) {
+        ++deallocation_count;
+        deallocate();
+      }
+    }
+    cleanup();
+  }
+
+  void cleanup() {
+    while (!allocations.empty()) {
+      auto choice = std::uniform_int_distribution<std::size_t>(
+          0, allocations.size() - 1)(rng);
+#if defined(USE_KDALLOC)
+      allocator.free(allocations[choice].first, allocations[choice].second);
+#else
+      free(allocations[choice].first);
+#endif
+      allocations[choice] = allocations.back();
+      allocations.pop_back();
+    }
+  }
+
+  void allocate_sized() {
+    auto bin = allocation_bin_distribution(rng);
+    while (bin >= 11) {
+      bin = allocation_bin_distribution(rng);
+    }
+    auto min = (bin == 0 ? 1 : (static_cast<std::size_t>(1) << (bin + 1)) + 1);
+    auto max = static_cast<std::size_t>(1) << (bin + 2);
+    auto size = std::uniform_int_distribution<std::size_t>(min, max)(rng);
+
+#if defined(USE_KDALLOC)
+    allocations.emplace_back(allocator.allocate(size), size);
+#else
+    allocations.emplace_back(std::malloc(size), size);
+#endif
+    if (allocations.size() > maximum_concurrent_allocations) {
+      maximum_concurrent_allocations = allocations.size();
+    }
+  }
+
+  void allocate_large() {
+    auto size = 0;
+    while (size <= 4096 || size > 1073741825) {
+      size = large_allocation_distribution(rng) + 4097;
+    }
+
+#if defined(USE_KDALLOC)
+    allocations.emplace_back(allocator.allocate(size), size);
+#else
+    allocations.emplace_back(std::malloc(size), size);
+#endif
+    if (allocations.size() > maximum_concurrent_allocations) {
+      maximum_concurrent_allocations = allocations.size();
+    }
+  }
+
+  void deallocate() {
+    if (allocations.empty()) {
+      return;
+    }
+    auto choice = std::uniform_int_distribution<std::size_t>(
+        0, allocations.size() - 1)(rng);
+#if defined(USE_KDALLOC)
+    allocator.free(allocations[choice].first, allocations[choice].second);
+#else
+    free(allocations[choice].first);
+#endif
+    allocations[choice] = allocations.back();
+    allocations.pop_back();
+  }
+};
+} // namespace
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+int random_test() {
+#else
+int main() {
+#endif
+#if defined(USE_KDALLOC)
+  std::cout << "Using kdalloc\n";
+#else
+  std::cout << "Using std::malloc\n";
+#endif
+  auto start = std::chrono::steady_clock::now();
+
+  RandomTest tester;
+  tester.run(10'000'000);
+
+  auto stop = std::chrono::steady_clock::now();
+  std::cout << std::dec
+            << std::chrono::duration_cast<std::chrono::milliseconds>(stop -
+                                                                     start)
+                   .count()
+            << " ms\n";
+  std::cout << "\n";
+
+  std::cout << "Allocations: " << tester.allocation_count << "\n";
+  std::cout << "Deallocations: " << tester.deallocation_count << "\n";
+  std::cout << "Maximum concurrent allocations: "
+            << tester.maximum_concurrent_allocations << "\n";
+
+  exit(0);
+}
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+TEST(KDAllocDeathTest, Random) {
+  ASSERT_EXIT(random_test(), ::testing::ExitedWithCode(0), "");
+}
+#endif

--- a/unittests/KDAlloc/reuse.cpp
+++ b/unittests/KDAlloc/reuse.cpp
@@ -1,0 +1,134 @@
+//===-- reuse.cpp ---------------------------------------------------------===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "klee/KDAlloc/kdalloc.h"
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+#include "gtest/gtest.h"
+#endif
+
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <unordered_set>
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+int reuse_test() {
+#else
+int main() {
+#endif
+  {
+    static const std::size_t size = 8;
+    static const std::uint32_t quarantine = 0;
+    std::cout << "size = " << size << " quarantine = " << quarantine << "\n";
+    auto allocator =
+        static_cast<klee::kdalloc::Allocator>(klee::kdalloc::AllocatorFactory(
+            static_cast<std::size_t>(1) << 42, quarantine));
+    auto a = allocator.allocate(size);
+    allocator.free(a, size);
+    auto b = allocator.allocate(size);
+    allocator.free(b, size);
+    auto c = allocator.allocate(size);
+    allocator.free(c, size);
+    auto d = allocator.allocate(size);
+    allocator.free(d, size);
+
+    std::cout << "a: " << a << "\nb: " << b << "\nc: " << c << "\nd: " << d
+              << "\n";
+    assert(a == b);
+    assert(a == c);
+    assert(a == d);
+  }
+
+  std::cout << "\n\n";
+
+  {
+    static const std::size_t size = 8;
+    static const std::uint32_t quarantine = 1;
+    std::cout << "size = " << size << " quarantine = " << quarantine << "\n";
+    auto allocator =
+        static_cast<klee::kdalloc::Allocator>(klee::kdalloc::AllocatorFactory(
+            static_cast<std::size_t>(1) << 42, quarantine));
+    auto a = allocator.allocate(size);
+    allocator.free(a, size);
+    auto b = allocator.allocate(size);
+    allocator.free(b, size);
+    auto c = allocator.allocate(size);
+    allocator.free(c, size);
+    auto d = allocator.allocate(size);
+    allocator.free(d, size);
+
+    std::cout << "a: " << a << "\nb: " << b << "\nc: " << c << "\nd: " << d
+              << "\n";
+    assert(a != b);
+    assert(a == c);
+    assert(b == d);
+  }
+
+  std::cout << "\n\n";
+
+  {
+    static const std::size_t size = 8;
+    static const std::uint32_t quarantine = 2;
+    std::cout << "size = " << size << " quarantine = " << quarantine << "\n";
+    auto allocator =
+        static_cast<klee::kdalloc::Allocator>(klee::kdalloc::AllocatorFactory(
+            static_cast<std::size_t>(1) << 42, quarantine));
+    auto a = allocator.allocate(size);
+    allocator.free(a, size);
+    auto b = allocator.allocate(size);
+    allocator.free(b, size);
+    auto c = allocator.allocate(size);
+    allocator.free(c, size);
+    auto d = allocator.allocate(size);
+    allocator.free(d, size);
+
+    std::cout << "a: " << a << "\nb: " << b << "\nc: " << c << "\nd: " << d
+              << "\n";
+    assert(a != b);
+    assert(a != c);
+    assert(b != c);
+    assert(a == d);
+  }
+
+  std::cout << "\n\n";
+
+  {
+    static const std::size_t size = 8;
+    static const std::uint32_t quarantine =
+        klee::kdalloc::AllocatorFactory::unlimitedQuarantine;
+    std::cout << "size = " << size << " quarantine unlimited\n";
+    auto allocator =
+        static_cast<klee::kdalloc::Allocator>(klee::kdalloc::AllocatorFactory(
+            static_cast<std::size_t>(1) << 42, quarantine));
+
+#if KDALLOC_TRACE >= 2
+    static const std::size_t iterations = 10;
+#else
+    static const std::size_t iterations = 10'000;
+#endif
+    std::unordered_set<void *> allocations;
+    allocations.reserve(iterations);
+    for (std::size_t i = 0; i < iterations; ++i) {
+      auto *ptr = allocator.allocate(size);
+      allocator.free(ptr, 8);
+      auto emplaced = allocations.emplace(ptr);
+      assert(emplaced.second);
+    }
+  }
+
+  std::exit(0);
+}
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+TEST(KDAllocDeathTest, Reuse) {
+  ASSERT_EXIT(reuse_test(), ::testing::ExitedWithCode(0), "");
+}
+#endif

--- a/unittests/KDAlloc/rusage.cpp
+++ b/unittests/KDAlloc/rusage.cpp
@@ -1,0 +1,66 @@
+//===-- rusage.cpp --------------------------------------------------------===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "klee/KDAlloc/kdalloc.h"
+
+#include "gtest/gtest.h"
+
+#include <deque>
+
+#include <sys/resource.h>
+
+// This test is disabled for asan and msan because they create additional page
+// faults
+#if !defined(__has_feature) ||                                                 \
+    (!__has_feature(memory_sanitizer) && !__has_feature(address_sanitizer))
+
+std::size_t write_to_allocations(std::deque<void *> &allocations) {
+  struct rusage ru;
+  getrusage(RUSAGE_SELF, &ru);
+  auto initial = ru.ru_minflt;
+
+  for (auto p : allocations) {
+    auto pp = static_cast<char *>(p);
+    *pp = 1;
+  }
+
+  getrusage(RUSAGE_SELF, &ru);
+  return ru.ru_minflt - initial;
+}
+
+TEST(KDAllocTest, Rusage) {
+  // initialize a factory and an associated allocator (using the location "0"
+  // gives an OS-assigned location)
+  klee::kdalloc::AllocatorFactory factory(static_cast<std::size_t>(1) << 30,
+                                          0); // 1 GB
+  klee::kdalloc::Allocator allocator = factory.makeAllocator();
+
+  std::deque<void *> allocations;
+  for (std::size_t i = 0; i < 1000; ++i) {
+    auto p = allocator.allocate(16);
+    allocations.emplace_back(p);
+  }
+
+  auto pageFaults = write_to_allocations(allocations);
+
+  ASSERT_GT(pageFaults, static_cast<std::size_t>(0))
+      << "No page faults happened";
+  ASSERT_EQ(pageFaults, allocations.size())
+      << "Number of (minor) page faults and objects differs";
+
+  factory.getMapping().clear();
+
+  // try again: this should (again) trigger a minor page fault for every object
+  auto pageFaultsSecondTry = write_to_allocations(allocations);
+
+  ASSERT_EQ(pageFaults, pageFaultsSecondTry)
+      << "Number of minor page faults in second try differs";
+}
+
+#endif

--- a/unittests/KDAlloc/sample.cpp
+++ b/unittests/KDAlloc/sample.cpp
@@ -1,0 +1,68 @@
+//===-- sample.cpp --------------------------------------------------------===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "klee/KDAlloc/kdalloc.h"
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+#include "gtest/gtest.h"
+#endif
+
+#include <cassert>
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+int sample_test() {
+#else
+int main() {
+#endif
+  // initialize a factory and an associated allocator (using the location "0"
+  // gives an OS-assigned location)
+  klee::kdalloc::AllocatorFactory factory(static_cast<std::size_t>(1) << 40, 0);
+  klee::kdalloc::Allocator allocator = factory.makeAllocator();
+
+  // let us create an integer
+  void *ptr = allocator.allocate(sizeof(int));
+  int *my_int = static_cast<int *>(ptr);
+  *my_int = 42;
+  assert(*my_int == 42 &&
+         "While we can use the addresses, this is not the point of kdalloc");
+
+  {
+    auto allocator2 = factory.makeAllocator();
+    int *my_second_int = static_cast<int *>(allocator2.allocate(sizeof(int)));
+    assert(reinterpret_cast<std::uintptr_t>(my_int) ==
+               reinterpret_cast<std::uintptr_t>(my_second_int) &&
+           "kdalloc is intended to produce reproducible addresses");
+    allocator2.free(my_second_int, sizeof(int));
+    assert(*my_int == 42 &&
+           "The original allocation (from allocator) is still valid");
+  }
+
+  // now let us clone the allocator state
+  {
+    auto allocator2 = allocator;
+    int *my_second_int = static_cast<int *>(allocator2.allocate(sizeof(int)));
+    assert(reinterpret_cast<std::uintptr_t>(my_int) !=
+               reinterpret_cast<std::uintptr_t>(my_second_int) &&
+           "the new address must be different, as allocator2 also contains the "
+           "previous allocation");
+    allocator2.free(my_second_int, sizeof(int));
+    assert(*my_int == 42 &&
+           "The original allocation (from allocator) is still valid");
+  }
+
+  // there is no need to return allocated memory, so we omit
+  // `allocator.free(my_int, sizeof(int));`
+  exit(0);
+}
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+TEST(KDAllocDeathTest, Sample) {
+  ASSERT_EXIT(sample_test(), ::testing::ExitedWithCode(0), "");
+}
+#endif

--- a/unittests/KDAlloc/stacktest.cpp
+++ b/unittests/KDAlloc/stacktest.cpp
@@ -1,0 +1,172 @@
+//===-- stacktest.cpp -----------------------------------------------------===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "klee/KDAlloc/kdalloc.h"
+#include "xoshiro.h"
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+#include "gtest/gtest.h"
+#endif
+
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <utility>
+#include <vector>
+
+namespace {
+class RandomTest {
+  xoshiro512 rng;
+
+#if defined(USE_KDALLOC)
+  klee::kdalloc::StackAllocator allocator;
+#endif
+
+  std::vector<std::pair<void *, std::size_t>> allocations;
+
+  std::geometric_distribution<std::size_t> allocation_bin_distribution;
+  std::geometric_distribution<std::size_t> large_allocation_distribution;
+
+public:
+  std::size_t maximum_concurrent_allocations = 0;
+  std::uint64_t allocation_count = 0;
+  std::uint64_t deallocation_count = 0;
+
+  RandomTest(std::mt19937_64::result_type seed = 0x31337)
+      : rng(seed)
+#if defined(USE_KDALLOC)
+        ,
+        allocator(klee::kdalloc::StackAllocatorFactory(
+            static_cast<std::size_t>(1) << 42, 0))
+#endif
+        ,
+        allocation_bin_distribution(0.3),
+        large_allocation_distribution(0.00003) {
+  }
+
+  void run(std::uint64_t const iterations) {
+    allocations.reserve((iterations * 7) / 10);
+    std::uniform_int_distribution<std::uint32_t> choice(0, 999);
+    for (std::uint64_t i = 0; i < iterations; ++i) {
+      auto chosen = choice(rng);
+      if (chosen < 650) {
+        ++allocation_count;
+        allocate_sized();
+      } else if (chosen < 700) {
+        ++allocation_count;
+        allocate_large();
+      } else if (chosen < 1000) {
+        ++deallocation_count;
+        deallocate();
+      }
+    }
+    cleanup();
+  }
+
+  void cleanup() {
+    while (!allocations.empty()) {
+#if defined(USE_KDALLOC)
+      allocator.free(allocations.back().first, allocations.back().second);
+#else
+      free(allocations.back().first);
+#endif
+      allocations.pop_back();
+    }
+  }
+
+  void allocate_sized() {
+    auto bin = allocation_bin_distribution(rng);
+    while (bin >= 11) {
+      bin = allocation_bin_distribution(rng);
+    }
+    auto min = (bin == 0 ? 1 : (static_cast<std::size_t>(1) << (bin + 1)) + 1);
+    auto max = static_cast<std::size_t>(1) << (bin + 2);
+    auto size = std::uniform_int_distribution<std::size_t>(min, max)(rng);
+
+#if defined(USE_KDALLOC)
+    allocations.emplace_back(allocator.allocate(size), size);
+#else
+    allocations.emplace_back(std::malloc(size), size);
+#endif
+    if (allocations.size() > maximum_concurrent_allocations) {
+      maximum_concurrent_allocations = allocations.size();
+    }
+  }
+
+  void allocate_large() {
+    auto size = 0;
+    while (size <= 4096 || size > 1073741825) {
+      size = large_allocation_distribution(rng) + 4097;
+    }
+
+#if defined(USE_KDALLOC)
+    allocations.emplace_back(allocator.allocate(size), size);
+#else
+    allocations.emplace_back(std::malloc(size), size);
+#endif
+    if (allocations.size() > maximum_concurrent_allocations) {
+      maximum_concurrent_allocations = allocations.size();
+    }
+  }
+
+  void deallocate() {
+    if (allocations.empty()) {
+      return;
+    }
+#if defined(USE_KDALLOC)
+    allocator.free(allocations.back().first, allocations.back().second);
+#else
+    free(allocations.back().first);
+#endif
+    allocations.pop_back();
+  }
+};
+} // namespace
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+int stack_test() {
+#else
+int main() {
+#endif
+#if defined(USE_KDALLOC)
+  std::cout << "Using kdalloc\n";
+#else
+  std::cout << "Using std::malloc\n";
+#endif
+  auto start = std::chrono::steady_clock::now();
+
+  RandomTest tester;
+  tester.run(10'000'000);
+
+  auto stop = std::chrono::steady_clock::now();
+  std::cout << std::dec
+            << std::chrono::duration_cast<std::chrono::milliseconds>(stop -
+                                                                     start)
+                   .count()
+            << " ms\n";
+  std::cout << "\n";
+
+  std::cout << "Allocations: " << tester.allocation_count << "\n";
+  std::cout << "Deallocations: " << tester.deallocation_count << "\n";
+  std::cout << "Maximum concurrent allocations: "
+            << tester.maximum_concurrent_allocations << "\n";
+
+  exit(0);
+}
+
+#if defined(USE_GTEST_INSTEAD_OF_MAIN)
+TEST(KDAllocDeathTest, Stack) {
+  ASSERT_EXIT(stack_test(), ::testing::ExitedWithCode(0), "");
+}
+#endif

--- a/unittests/KDAlloc/xoshiro.h
+++ b/unittests/KDAlloc/xoshiro.h
@@ -1,0 +1,56 @@
+//===-- xoshiro.h ---------------------------------------------------------===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdint>
+
+/// A xoshiro512** generator
+class xoshiro512 {
+  static constexpr const ::std::uint64_t A = 11;
+  static constexpr const ::std::uint64_t B = 21;
+
+  static constexpr const ::std::uint64_t S = 5;
+  static constexpr const ::std::uint64_t R = 7;
+  static constexpr const ::std::uint64_t T = 9;
+
+  ::std::uint64_t s[8] = {0x243F6A8885A308D3u, 0x13198A2E03707344u,
+                          0xA4093822299F31D0u, 0x082EFA98EC4E6C89u,
+                          0x452821E638D01377u, 0xBE5466CF34E90C6Cu,
+                          0xC0AC29B7C97C50DDu, 0x3F84D5B5B5470917u};
+
+public:
+  explicit xoshiro512(std::uint64_t const seed) noexcept {
+    for (auto &x : s) {
+      x ^= seed;
+    }
+  }
+
+  using result_type = std::uint64_t;
+
+  std::uint64_t operator()() noexcept {
+    auto const t = s[1] * S;
+    auto const result = ((t << R) | (t >> (64 - R))) * T;
+    auto const u = s[1] << A;
+    s[2] ^= s[0];
+    s[5] ^= s[1];
+    s[1] ^= s[2];
+    s[7] ^= s[3];
+    s[3] ^= s[4];
+    s[4] ^= s[5];
+    s[0] ^= s[6];
+    s[6] ^= s[7];
+    s[6] ^= u;
+    s[7] = ((s[7] << B) | (s[7] >> (64 - B)));
+    return result;
+  }
+
+  static constexpr ::std::uint64_t(min)() noexcept { return 0; }
+  static constexpr ::std::uint64_t(max)() noexcept {
+    return static_cast<std::uint64_t>(0) - static_cast<std::uint64_t>(1);
+  }
+};


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Given the following program:
```
#include <stdlib.h>
#include <stdio.h>
#include <klee/klee.h>

int main(int argc, char** argv) {
        int x = klee_int("x");
        if(x) {
                printf("%p\n", malloc(1));
        } else {
                printf("%p\n", malloc(1));
        }
}
```
KLEE's current deterministic allocator yields something like the following:
```
$ klee --allocate-determ test.bc
...
0x7ff30001478
0x7ff30001460
KLEE: Deterministic memory allocation starting from 0x7ff30000000
...
```
This is because the two paths allocate (deterministically) from the same pool of addresses. The same happens with the default memory allocator. Therefore, memory is not allocated deterministically from the point of view of the program under test.

This PR implements the memory allocator described in our upcoming ECOOP 2022 publication ["A Deterministic Memory Allocator for Dynamic Symbolic Execution"](https://srg.doc.ic.ac.uk/publications/22-kdalloc-ecoop.html). It mainly differs from the artifact for that publication in that it is cleaned up for integration in mainline KLEE. We also ensured that kernels with transparent huge page support set to "always" will work out of the box.

Running the same example with KDAlloc as the deterministic allocator:
```
$ ../build-host/bin/klee --allocate-determ test.bc
...
0x7e88152e7000
0x7e88152e7000
KLEE: Deterministic allocator: Using quarantine queue size 8
KLEE: Deterministic allocator: globals (start-address=0x7f62952e7000 size=10 GiB)
KLEE: Deterministic allocator: constants (start-address=0x7f60152e7000 size=10 GiB)
KLEE: Deterministic allocator: heap (start-address=0x7e60152e7000 size=1024 GiB)
KLEE: Deterministic allocator: stack (start-address=0x7e40152e7000 size=128 GiB)
...
```

Additionally, KDAlloc provides controlled address reuse ("quarantine queue size 8" in the example), and is much more likely to catch out of bounds accesses (allocations are distributed over the large virtual address spaces, e.g., 1024 GiB for the heap in the example).

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
