### PR TITLE
Inline assembly support (external call)

### DIFF
--- a/include/klee/Module/KCallable.h
+++ b/include/klee/Module/KCallable.h
@@ -1,0 +1,71 @@
+//===-- KCallable.h ---------------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KLEE_KCALLABLE_H
+#define KLEE_KCALLABLE_H
+
+#include <string>
+
+#include "llvm/ADT/Twine.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/LLVMContext.h"
+
+namespace klee {
+/// Wrapper for callable objects passed in callExternalFunction
+class KCallable {
+public:
+  enum CallableKind { CK_Function, CK_InlineAsm };
+
+private:
+  const CallableKind Kind;
+
+public:
+  KCallable(CallableKind Kind) : Kind(Kind) {}
+
+  CallableKind getKind() const { return Kind; }
+
+  virtual llvm::StringRef getName() const = 0;
+  virtual llvm::PointerType *getType() const = 0;
+  virtual llvm::Value *getValue() = 0;
+
+  virtual ~KCallable() = default;
+};
+
+class KInlineAsm : public KCallable {
+private:
+  static unsigned getFreshAsmId() {
+    static unsigned globalId = 0;
+    return globalId++;
+  }
+
+  llvm::InlineAsm *value;
+  std::string name;
+
+public:
+  KInlineAsm(llvm::InlineAsm *value)
+      : KCallable(CK_InlineAsm), value(value),
+        name("__asm__" + llvm::Twine(getFreshAsmId()).str()) {}
+
+  llvm::StringRef getName() const override { return name; }
+
+  llvm::PointerType *getType() const override { return value->getType(); }
+
+  llvm::Value *getValue() override { return value; }
+
+  static bool classof(const KCallable *callable) {
+    return callable->getKind() == CK_InlineAsm;
+  }
+
+  llvm::InlineAsm *getInlineAsm() { return value; }
+};
+
+} // namespace klee
+
+#endif /* KLEE_KCALLABLE_H */

--- a/include/klee/Module/KModule.h
+++ b/include/klee/Module/KModule.h
@@ -12,6 +12,7 @@
 
 #include "klee/Config/Version.h"
 #include "klee/Core/Interpreter.h"
+#include "klee/Module/KCallable.h"
 
 #include "llvm/ADT/ArrayRef.h"
 
@@ -39,7 +40,7 @@ namespace klee {
   class KModule;
   template<class T> class ref;
 
-  struct KFunction {
+  struct KFunction : public KCallable {
     llvm::Function *function;
 
     unsigned numArgs, numRegisters;
@@ -53,14 +54,23 @@ namespace klee {
     /// "coverable" for statistics and search heuristics.
     bool trackCoverage;
 
-  public:
-    explicit KFunction(llvm::Function*, KModule *);
+    explicit KFunction(llvm::Function*, KModule*);
     KFunction(const KFunction &) = delete;
     KFunction &operator=(const KFunction &) = delete;
 
     ~KFunction();
 
     unsigned getArgRegister(unsigned index) { return index; }
+
+    llvm::StringRef getName() const override { return function->getName(); }
+
+    llvm::PointerType *getType() const override { return function->getType(); }
+
+    llvm::Value *getValue() override { return function; }
+
+    static bool classof(const KCallable *callable) {
+      return callable->getKind() == CK_Function;
+    }
   };
 
 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -64,6 +64,7 @@ namespace klee {
   class ExternalDispatcher;
   class Expr;
   class InstructionInfoTable;
+  class KCallable;
   struct KFunction;
   struct KInstruction;
   class KInstIterator;
@@ -240,7 +241,7 @@ private:
 
   void callExternalFunction(ExecutionState &state,
                             KInstruction *target,
-                            llvm::Function *function,
+                            KCallable *callable,
                             std::vector< ref<Expr> > &arguments);
 
   ObjectState *bindObjectInState(ExecutionState &state, const MemoryObject *mo,

--- a/lib/Core/ExternalDispatcher.h
+++ b/lib/Core/ExternalDispatcher.h
@@ -20,11 +20,11 @@
 namespace llvm {
 class Instruction;
 class LLVMContext;
-class Function;
 }
 
 namespace klee {
 class ExternalDispatcherImpl;
+class KCallable;
 class ExternalDispatcher {
 private:
   ExternalDispatcherImpl *impl;
@@ -37,7 +37,7 @@ public:
    * ci with arguments in args[1], args[2], ... and writing the result
    * into args[0].
    */
-  bool executeCall(llvm::Function *function, llvm::Instruction *i,
+  bool executeCall(KCallable *callable, llvm::Instruction *i,
                    uint64_t *args);
   void *resolveSymbol(const std::string &name);
 

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -303,7 +303,6 @@ void KModule::manifest(InterpreterHandler *ih, bool forceSourceOutput) {
   for (auto &Function : *module) {
     if (Function.isDeclaration()) {
       declarations.push_back(&Function);
-      continue;
     }
 
     auto kf = std::unique_ptr<KFunction>(new KFunction(&Function, this));
@@ -406,7 +405,8 @@ static int getOperandNum(Value *v,
 
 KFunction::KFunction(llvm::Function *_function,
                      KModule *km) 
-  : function(_function),
+  : KCallable(CK_Function),
+    function(_function),
     numArgs(function->arg_size()),
     numInstructions(0),
     trackCoverage(true) {

--- a/test/Feature/InlineAsm.c
+++ b/test/Feature/InlineAsm.c
@@ -1,0 +1,25 @@
+// RUN: %clang %s -emit-llvm %O0opt -c -g -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --external-calls=all --exit-on-error --output-dir=%t.klee-out %t.bc > %t.output.log 2>&1
+
+#include <assert.h>
+
+int main() {
+
+  int x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  if (x == 239) {
+    __asm__("neg %0"
+            : "+r"(x));
+    assert(x == -239);
+  }
+
+  int y = x;
+  __asm__("add $5, %0"
+          : "+r"(x));
+  __asm__("add $0, %0"
+          : "+r"(y));
+  assert(x == y + 5);
+
+  return 0;
+}

--- a/test/regression/2012-05-13-asm-causes-aborts.c
+++ b/test/regression/2012-05-13-asm-causes-aborts.c
@@ -1,9 +1,0 @@
-// RUN: %clang %s -emit-llvm %O0opt -c -o %t1.bc
-// RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out %t1.bc
-
-int main(int argc, char *argv[]){
-	__asm__ __volatile__ ("movl %eax, %eax");
-	return 0;
-}
-

--- a/test/regression/2022-06-28-asm-causes-error.c
+++ b/test/regression/2022-06-28-asm-causes-error.c
@@ -1,0 +1,9 @@
+// RUN: %clang %s -g -emit-llvm %O0opt -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --external-calls=none --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck %s
+
+int main(int argc, char *argv[]) {
+  // CHECK: 2022-06-28-asm-causes-error.c:[[@LINE+1]]: external calls disallowed (in particular inline asm)
+  __asm__ __volatile__("movl %eax, %eax");
+  return 0;
+}

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -909,19 +909,6 @@ void externalsAndGlobalsCheck(const llvm::Module *m) {
        fnIt != fn_ie; ++fnIt) {
     if (fnIt->isDeclaration() && !fnIt->use_empty())
       externals.insert(std::make_pair(fnIt->getName(), false));
-    for (Function::const_iterator bbIt = fnIt->begin(), bb_ie = fnIt->end();
-         bbIt != bb_ie; ++bbIt) {
-      for (BasicBlock::const_iterator it = bbIt->begin(), ie = bbIt->end();
-           it != ie; ++it) {
-        if (const CallInst *ci = dyn_cast<CallInst>(it)) {
-          if (isa<InlineAsm>(ci->getCalledOperand())) {
-            klee_warning_once(&*fnIt,
-                              "function \"%s\" has inline asm",
-                              fnIt->getName().data());
-          }
-        }
-      }
-    }
   }
 
   for (Module::const_global_iterator


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

The wrapper (`KCallable`) was created for the objects (`Function, InlineAsm`) that can be called in LLVM IR. Now `callExternalFunction` takes the `KCallable` wrapper as an argument. In the `ExternalDispatcherImpl::createDispatcher` function     was  added a code branch to process inline assembler code (the `llvm::IRBuilder<>.CreateCall` function call with the `InlineAsm` object as a parameter).

Closes #1514.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
