### PR TITLE
Fixed some memory leaks.

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3439,6 +3439,12 @@ void Executor::doDumpStates() {
   updateStates(nullptr);
 }
 
+void Executor::cleanUpStates() {
+  for (const auto &state : states) {
+    delete state;
+  }
+}
+
 void Executor::run(ExecutionState &initialState) {
   bindModuleConstants();
 
@@ -3538,6 +3544,7 @@ void Executor::run(ExecutionState &initialState) {
   searcher = nullptr;
 
   doDumpStates();
+  cleanUpStates();
 }
 
 std::string Executor::getAddressInfo(ExecutionState &state, 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3544,7 +3544,9 @@ void Executor::run(ExecutionState &initialState) {
   searcher = nullptr;
 
   doDumpStates();
-  cleanUpStates();
+  if(haltExecution) {
+    cleanUpStates();
+  }
 }
 
 std::string Executor::getAddressInfo(ExecutionState &state, 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -475,6 +475,8 @@ private:
   void printDebugInstructions(ExecutionState &state);
   void doDumpStates();
 
+  void cleanUpStates();
+
   /// Only for debug purposes; enable via debugger or klee-control
   void dumpStates();
   void dumpPTree();

--- a/lib/Core/PTree.cpp
+++ b/lib/Core/PTree.cpp
@@ -36,6 +36,10 @@ PTree::PTree(ExecutionState *initialState)
   initialState->ptreeNode = root.getPointer();
 }
 
+PTree::~PTree() {
+  delete root.getPointer();
+}
+
 void PTree::attach(PTreeNode *node, ExecutionState *leftState,
                    ExecutionState *rightState, BranchType reason) {
   assert(node && !node->left.getPointer() && !node->right.getPointer());

--- a/lib/Core/PTree.cpp
+++ b/lib/Core/PTree.cpp
@@ -36,9 +36,7 @@ PTree::PTree(ExecutionState *initialState)
   initialState->ptreeNode = root.getPointer();
 }
 
-PTree::~PTree() {
-  delete root.getPointer();
-}
+PTree::~PTree() { delete root.getPointer(); }
 
 void PTree::attach(PTreeNode *node, ExecutionState *leftState,
                    ExecutionState *rightState, BranchType reason) {

--- a/lib/Core/PTree.h
+++ b/lib/Core/PTree.h
@@ -46,7 +46,7 @@ namespace klee {
   public:
     PTreeNodePtr root;
     explicit PTree(ExecutionState *initialState);
-    ~PTree() = default;
+    ~PTree();
 
     void attach(PTreeNode *node, ExecutionState *leftState,
                 ExecutionState *rightState, BranchType reason);


### PR DESCRIPTION
Fixed memory leaks found while running test/regression/2020-02-24-count-paths-nodump.c test.
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
