### PR TITLE
Add information about variable concretization

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3811,6 +3811,7 @@ void Executor::callExternalFunction(ExecutionState &state,
       assert(success && "FIXME: Unhandled solver failure");
       (void) success;
       ce->toMemory(&args[wordIndex]);
+      addConstraint(state, EqExpr::create(ce, *ai));
       ObjectPair op;
       // Checking to see if the argument is a pointer to something
       if (ce->getWidth() == Context::get().getPointerWidth() &&

--- a/test/regression/2022-06-15-concretization-effects.c
+++ b/test/regression/2022-06-15-concretization-effects.c
@@ -1,0 +1,19 @@
+// RUN: %clang %s -emit-llvm %O0opt -c -g -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --external-calls=all --exit-on-error --output-dir=%t.klee-out %t.bc > %t.output.log 2>&1
+
+#include <assert.h>
+#include <stdlib.h>
+
+int main() {
+
+  int x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+  if (x >= 0) {
+    int y = abs(x);
+    assert(x == y);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

Added a constraint that a symbolic variable must be equal to its concretization in the `externalCallFunction` function.

Closes #1519.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
