### PR TITLE
Implement getArrayForUpdate iteratively

### DIFF
--- a/lib/Solver/Z3Builder.cpp
+++ b/lib/Solver/Z3Builder.cpp
@@ -17,6 +17,7 @@
 #include "klee/Support/ErrorHandling.h"
 
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/CommandLine.h"
 
 using namespace klee;
@@ -427,22 +428,31 @@ Z3ASTHandle Z3Builder::getInitialRead(const Array *root, unsigned index) {
 
 Z3ASTHandle Z3Builder::getArrayForUpdate(const Array *root,
                                          const UpdateNode *un) {
-  if (!un) {
-    return (getInitialArray(root));
-  } else {
-    // FIXME: This really needs to be non-recursive.
-    Z3ASTHandle un_expr;
-    bool hashed = _arr_hash.lookupUpdateNodeExpr(un, un_expr);
-
-    if (!hashed) {
-      un_expr = writeExpr(getArrayForUpdate(root, un->next.get()),
-                          construct(un->index, 0), construct(un->value, 0));
-
-      _arr_hash.hashUpdateNodeExpr(un, un_expr);
-    }
-
-    return (un_expr);
+  // Iterate over the update nodes, until we find a cached version of the node,
+  // or no more update nodes remain
+  Z3ASTHandle un_expr;
+  std::vector<const UpdateNode *> update_nodes;
+  for (; un && !_arr_hash.lookupUpdateNodeExpr(un, un_expr);
+       un = un->next.get()) {
+    update_nodes.push_back(un);
   }
+  if (!un) {
+    un_expr = getInitialArray(root);
+  }
+  // `un_expr` now holds an expression for the array - either from cache or by
+  // virtue of being the initial array expression
+
+  // Create and cache solver expressions based on the update nodes starting from
+  // the oldest
+  for (const auto &un :
+       llvm::make_range(update_nodes.crbegin(), update_nodes.crend())) {
+    un_expr =
+        writeExpr(un_expr, construct(un->index, 0), construct(un->value, 0));
+
+    _arr_hash.hashUpdateNodeExpr(un, un_expr);
+  }
+
+  return un_expr;
 }
 
 /** if *width_out!=1 then result is a bitvector,


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
This deals with a long-standing `FIXME` in the KLEE codebase where `getArrayForUpdate` is implemented recursively, which could lead to KLEE crashing. This PR transforms the recursive code into an iterative version.

This of course introduces a potential performance penalty by storing the required information in an explicit stack on the heap instead of the implicit function call stack. While I personally don't think the performance penalty is a problem, queries with a small (but non-zero) amount of uncached update nodes will incur additional `malloc`s now.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
