### PR TITLE
Use `klee` user to install system dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,25 +47,23 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt -y --no-install-recommends 
 # Copy across source files needed for build
 COPY --chown=klee:klee . /tmp/klee_src/
 
+USER klee
+WORKDIR /home/klee
 # Build and set klee user to be owner
-RUN /tmp/klee_src/scripts/build/build.sh --debug --install-system-deps klee && chown -R klee:klee /tmp/klee_build* && pip3 install flask wllvm && \
-    rm -rf /var/lib/apt/lists/*
+RUN /tmp/klee_src/scripts/build/build.sh --debug --install-system-deps klee && pip3 install flask wllvm && \
+    sudo rm -rf /var/lib/apt/lists/*
 
-# Install tabulate for klee-stats
-RUN pip3 install tabulate
 
-ENV PATH="$PATH:/tmp/llvm-110-install_O_D_A/bin:/home/klee/klee_build/bin"
+ENV PATH="$PATH:/tmp/llvm-110-install_O_D_A/bin:/home/klee/klee_build/bin:/home/klee/.local/bin"
 ENV BASE=/tmp
 
 # Add KLEE header files to system standard include folder
-RUN /bin/bash -c 'ln -s ${BASE}/klee_src/include/klee /usr/include/'
+RUN sudo /bin/bash -c 'ln -s /tmp/klee_src/include/klee /usr/include/'
 
-USER klee
-WORKDIR /home/klee
 ENV LD_LIBRARY_PATH /home/klee/klee_build/lib/
 
 # Add KLEE binary directory to PATH
-RUN /bin/bash -c 'ln -s ${BASE}/klee_src /home/klee/ && ln -s ${BASE}/klee_build* /home/klee/klee_build' 
+RUN /bin/bash -c 'ln -s ${BASE}/klee_src /home/klee/ && ln -s ${BASE}/klee_build* /home/klee/klee_build'
 
 # TODO Remove when STP is fixed
 RUN /bin/bash -c 'echo "export LD_LIBRARY_PATH=$(cd ${BASE}/metaSMT-*-deps/stp-git-basic/lib/ && pwd):$LD_LIBRARY_PATH" >> /home/klee/.bashrc'


### PR DESCRIPTION
As a follow-up to recent build script enhancements
(https://github.com/klee/klee/commit/818275b7249250780ddd5ed021cae64288514270),
finally build KLEE inside of the Docker image as artefact owned by the
`klee` user, including user-installed Python3 modules.

This fixes issues with non-writable build directories.

In addition `$HOME/.local/bin` directory is made available in search path.

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
