### PR TITLE
Fix error with empty EntryPoint

### DIFF
--- a/test/Feature/EntryPoint.c
+++ b/test/Feature/EntryPoint.c
@@ -1,11 +1,17 @@
 // RUN: %clang -emit-llvm -g -c %s -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --entry-point=other_main %t.bc > %t.log
-// RUN: grep "Hello World" %t.log
+// RUN: %klee --output-dir=%t.klee-out --entry-point=other_main %t.bc | FileCheck -check-prefix=CHECK-OTHER_MAIN %s
+
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --entry-point="" %t.bc 2>%t.stderr.log || echo "Exit status must be 0"
+// RUN: FileCheck -check-prefix=CHECK-EMPTY --input-file=%t.stderr.log %s
 
 #include <stdio.h>
 
 int other_main() {
   printf("Hello World\n");
+  // CHECK-OTHER_MAIN: Hello World
   return 0;
 }
+
+// CHECK-EMPTY: KLEE: ERROR: entry-point cannot be empty

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1151,6 +1151,10 @@ int main(int argc, char **argv, char **envp) {
   parseArguments(argc, argv);
   sys::PrintStackTraceOnErrorSignal(argv[0]);
 
+  if (EntryPoint.empty()) {
+    klee_error("entry-point cannot be empty");
+  }
+
   if (Watchdog) {
     if (MaxTime.empty()) {
       klee_error("--watchdog used without --max-time");


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

KLEE crashes, when a user call it with argument `--entry-point=""`. I fix this situation with check that `--entry-point` is non-empty.

Closes #1522 

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
