### PR TITLE
Improve the message for when large arrays become symbolic.  Only prin…

### DIFF
--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -375,19 +375,23 @@ ref<Expr> ObjectState::read8(unsigned offset) const {
 }
 
 ref<Expr> ObjectState::read8(ref<Expr> offset) const {
-  assert(!isa<ConstantExpr>(offset) && "constant offset passed to symbolic read8");
+  assert(!isa<ConstantExpr>(offset) &&
+         "constant offset passed to symbolic read8");
   unsigned base, size;
   fastRangeCheckOffset(offset, &base, &size);
   flushRangeForRead(base, size);
 
-  if (size>4096) {
+  if (size > 4096) {
     std::string allocInfo;
     object->getAllocInfo(allocInfo);
-    klee_warning_once(0, "flushing %d bytes on read, may be slow and/or crash: %s", 
-                      size,
-                      allocInfo.c_str());
+    klee_warning_once(
+        nullptr,
+        "Symbolic memory access will send the following array of %d bytes to "
+        "the constraint solver -- large symbolic arrays may cause significant "
+        "performance issues: %s",
+        size, allocInfo.c_str());
   }
-  
+
   return ReadExpr::create(getUpdates(), ZExtExpr::create(offset, Expr::Int32));
 }
 
@@ -413,19 +417,23 @@ void ObjectState::write8(unsigned offset, ref<Expr> value) {
 }
 
 void ObjectState::write8(ref<Expr> offset, ref<Expr> value) {
-  assert(!isa<ConstantExpr>(offset) && "constant offset passed to symbolic write8");
+  assert(!isa<ConstantExpr>(offset) &&
+         "constant offset passed to symbolic write8");
   unsigned base, size;
   fastRangeCheckOffset(offset, &base, &size);
   flushRangeForWrite(base, size);
 
-  if (size>4096) {
+  if (size > 4096) {
     std::string allocInfo;
     object->getAllocInfo(allocInfo);
-    klee_warning_once(0, "flushing %d bytes on read, may be slow and/or crash: %s", 
-                      size,
-                      allocInfo.c_str());
+    klee_warning_once(
+        nullptr,
+        "Symbolic memory access will send the following array of %d bytes to "
+        "the constraint solver -- large symbolic arrays may cause significant "
+        "performance issues: %s",
+        size, allocInfo.c_str());
   }
-  
+
   updates.extend(ZExtExpr::create(offset, Expr::Int32), value);
 }
 

--- a/test/Feature/LargeArrayBecomesSym.c
+++ b/test/Feature/LargeArrayBecomesSym.c
@@ -1,0 +1,33 @@
+/* This test checks that KLEE emits a warning when a large (> 4096) 
+   concrete array becomes symbolic. */
+
+// RUN: %clang %s -emit-llvm %O0opt -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+/* The solver timeout is needed as some solvers, such as metaSMT+CVC4, time out here. */
+// RUN: %klee --max-solver-time=2 --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+#define N 4100
+
+int main() {
+  char a[N] = {
+      1,
+      2,
+  };
+
+  unsigned k;
+  klee_make_symbolic(&k, sizeof(k), "k");
+  klee_assume(k < N);
+  a[k] = 3;
+  // CHECK: KLEE: WARNING ONCE: Symbolic memory access will send the following array of 4100 bytes to the constraint solver
+
+  unsigned i;
+  klee_make_symbolic(&i, sizeof(i), "i");
+  klee_assume(i < N);
+  if (a[i] == 2)
+    assert(i == 1);
+}


### PR DESCRIPTION
…t this warning once per array.  Add test case.

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
