### PR TITLE
Perform CI runs with additional solvers and metasmt backends

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ env:
   USE_TCMALLOC: 1
   USE_LIBCXX: 1
   Z3_VERSION: 4.8.14
+  ADDITIONAL_TEST_ARGS: ""
 
 jobs:
   Linux:
@@ -110,11 +111,13 @@ jobs:
               SOLVERS: metaSMT
               METASMT_DEFAULT: STP
               REQUIRES_RTTI: 1
+              ADDITIONAL_TEST_ARGS: "--solvers=metasmt --metasmt-backends=btor:z3:yices2:cvc4"
           - name: "metaSMT Boolector"
             env:
               SOLVERS: metaSMT
               METASMT_DEFAULT: BTOR
               REQUIRES_RTTI: 1
+              ADDITIONAL_TEST_ARGS: "--solvers=metasmt --metasmt-backends=stp:z3:yices2:cvc4"
           # Test we can build against STP master
           - name: "STP master"
             env:
@@ -141,7 +144,7 @@ jobs:
         env: ${{ matrix.env }}
         run: scripts/build/build.sh klee --docker --create-final-image
       - name: Run tests
-        run: scripts/build/run-tests.sh --run-docker --debug
+        run: scripts/build/run-tests.sh --run-docker --debug ${ADDITIONAL_TEST_ARGS}
 
   macOS:
     runs-on: macos-latest
@@ -174,10 +177,11 @@ jobs:
     env:
       ENABLE_OPTIMIZED: 0
       COVERAGE: 1
+      SOLVERS: STP:Z3
     steps:
       - name: Checkout KLEE source code
         uses: actions/checkout@v2
       - name: Build KLEE
         run: scripts/build/build.sh klee --docker --create-final-image
       - name: Run tests
-        run: scripts/build/run-tests.sh --coverage --upload-coverage --run-docker --debug
+        run: scripts/build/run-tests.sh --coverage --upload-coverage --run-docker --debug --solvers=STP:Z3


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
This PR ensures that the coverage CI run exercises both the STP and Z3 backends. It is currently configured to do so in addition to the default solver backend (which is STP).

The test script now processes two new arguments `-solvers=` and `-metasmt-backends=`, both of which add additional test runs with the configured solvers, and backends. Note that the default solver backend is always exercised and that the metasmt backends are only exercised if the metasmt solver is explicitly tested.

This also reenables testing of metasmt backends which already existed in the test script, but was not exercised as the relevant environment variable was not active when the tests are dockerized.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
