### PR TITLE
Pass llvm.experimental.noalias.scope.decl to IntrinsicLowering so that it strips out these intrinsics

### DIFF
--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -349,6 +349,9 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
       case Intrinsic::exp2:
       case Intrinsic::exp:
       case Intrinsic::expect:
+#if LLVM_VERSION_CODE >= LLVM_VERSION(12, 0)
+      case Intrinsic::experimental_noalias_scope_decl:
+#endif
       case Intrinsic::floor:
       case Intrinsic::flt_rounds:
       case Intrinsic::frameaddress:

--- a/test/Intrinsics/noalias-scope-decl.ll
+++ b/test/Intrinsics/noalias-scope-decl.ll
@@ -1,0 +1,57 @@
+; REQUIRES: geq-llvm-12.0
+; RUN: rm -rf %t.klee-out
+; RUN: %klee -exit-on-error --output-dir=%t.klee-out --optimize=false %s 2>&1 | FileCheck %s
+
+; Check that IntrinsicCleaner strips out intrinsic
+; CHECK-NOT: KLEE: WARNING ONCE: unsupported intrinsic llvm.experimental.noalias.scope.decl
+
+; Check that Executor doesn't notice stripped intrinsic
+; CHECK-NOT: KLEE: WARNING: unimplemented intrinsic: llvm.experimental.noalias.scope.decl
+; CHECK-NOT: KLEE: ERROR: (location information missing) unimplemented intrinsic
+; CHECK-NOT: KLEE: WARNING: unimplemented intrinsic: llvm.experimental.noalias.scope.decl
+
+; Check that Executor explores all paths
+; CHECK: KLEE: done: completed paths = 1
+; CHECK: KLEE: done: partially completed paths = 0
+; CHECK: KLEE: done: generated tests = 1
+
+
+
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture, i8* nocapture, i64, i1) nounwind
+declare void @llvm.experimental.noalias.scope.decl(metadata)
+declare void @abort() noreturn nounwind
+
+define void @test1(i8* %P, i8* %Q) nounwind {
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !0)
+  tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* %P, i8* %Q, i64 1, i1 false)
+  ret void
+}
+
+define dso_local i32 @main() local_unnamed_addr {
+  %1 = alloca i32, align 4
+  %2 = alloca i8, align 1
+  %3 = alloca i8, align 1
+  store i32 0, i32* %1, align 4
+  store i8 0, i8* %2, align 1
+  store i8 1, i8* %3, align 1
+
+  call void @test1(i8* %2, i8* %3)
+
+  %4 = load i8, i8* %2, align 1
+  %5 = sext i8 %4 to i32
+  %6 = load i8, i8* %3, align 1
+  %7 = sext i8 %6 to i32
+  %8 = icmp eq i32 %5, %7
+  br i1 %8, label %exit.block, label %abort.block
+
+  exit.block:
+    ret i32 0
+
+  abort.block:
+    call void @abort()
+    unreachable
+}
+
+!0 = !{ !1 }
+!1 = distinct !{ !1, !2, !"test1: var" }
+!2 = distinct !{ !2, !"test1" }


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

New `llvm.experimental.noalias.scope.decl` intrinsic [appeared](https://llvm.org/docs/LangRef.html#llvm-experimental-noalias-scope-decl-intrinsic) in LLVM 12.0 which purposes to identify where a noalias scope is declared and accepts `metadata` as an argument. Execution of that call usually causes an error as shown in the example of stacktrace below:

```
klee: /mnt/c/Work/klee-simd-runtime/lib/Core/Executor.cpp:1232: const klee::Cell &klee::Executor::eval(klee::KInstruction *, unsigned int, klee::ExecutionState &) const: Assertion `vnumber != -1 && "Invalid operand to eval(), not a value or constant!"' failed.
 #0 0x00007fa241a35ef3 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/lib/x86_64-linux-gnu/libLLVM-12.so.1+0xbd8ef3)
 #1 0x00007fa241a341e2 llvm::sys::RunSignalHandlers() (/lib/x86_64-linux-gnu/libLLVM-12.so.1+0xbd71e2)
 #2 0x00007fa241a3655f (/lib/x86_64-linux-gnu/libLLVM-12.so.1+0xbd955f)
 #3 0x00007fa240960090 (/lib/x86_64-linux-gnu/libc.so.6+0x43090)
 #4 0x00007fa24096000b raise /build/glibc-SzIz7B/glibc-2.31/signal/../sysdeps/unix/sysv/linux/raise.c:51:1
 #5 0x00007fa24093f859 abort /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81:7
 #6 0x00007fa24093f729 get_sysdep_segment_value /build/glibc-SzIz7B/glibc-2.31/intl/loadmsgcat.c:509:8
 #7 0x00007fa24093f729 _nl_load_domain /build/glibc-SzIz7B/glibc-2.31/intl/loadmsgcat.c:970:34
 #8 0x00007fa240950fd6 (/lib/x86_64-linux-gnu/libc.so.6+0x33fd6)
 #9 0x000000000044a853 klee::Executor::eval(klee::KInstruction*, unsigned int, klee::ExecutionState&) const /mnt/c/Work/klee-simd-runtime/lib/Core/Executor.cpp:1235:15
#10 0x0000000000452ad3 klee::Executor::executeInstruction(klee::ExecutionState&, klee::KInstruction*) /mnt/c/Work/klee-simd-runtime/lib/Core/Executor.cpp:2411:27
#11 0x000000000045b037 klee::Executor::run(klee::ExecutionState&) /mnt/c/Work/klee-simd-runtime/lib/Core/Executor.cpp:3528:5
#12 0x000000000045e271 klee::Executor::runFunctionAsMain(llvm::Function*, int, char**, char**) /mnt/c/Work/klee-simd-runtime/lib/Core/Executor.cpp:4440:3
#13 0x00000000004274a2 main /mnt/c/Work/klee-simd-runtime/tools/klee/main.cpp:1530:19
#14 0x00007fa240941083 __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:342:3
#15 0x000000000042200e _start (/mnt/c/Work/klee-simd-runtime/cmake-build-debug/bin/klee+0x42200e)
Aborted
```


Fortunately, `IntrinsicLowering` is able to strip those out along with `assume` and `var_annotation` intrinsics as shown in the snippet of code from `llvm/lib/CodeGen/IntrinsicLowering.cpp` below:

```cpp
case Intrinsic::assume:
case Intrinsic::experimental_noalias_scope_decl:
case Intrinsic::var_annotation:
  break;   // Strip out these intrinsics
```

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
