### PR TITLE
Fixed some leaks in klee-replay

### DIFF
--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -311,10 +311,12 @@ int main(int argc, char** argv) {
 
       prg_argc = input->numArgs;
       prg_argv = input->args;
-      prg_argv[0] = argv[1];
+      free(prg_argv[0]);
+      prg_argv[0] = strdup(argv[1]);
       klee_init_env(&prg_argc, &prg_argv);
 
       replay_create_files(&__exe_fs);
+      kTest_free(input);
       return 0;
     }
 
@@ -366,8 +368,11 @@ int main(int argc, char** argv) {
     obj_index = 0;
     prg_argc = input->numArgs;
     prg_argv = input->args;
-    prg_argv[0] = argv[optind];
+    free(prg_argv[0]);
+    prg_argv[0] = strdup(argv[optind]);
+
     klee_init_env(&prg_argc, &prg_argv);
+
     if (idx > 2)
       fputc('\n', stderr);
     fprintf(stderr, "KLEE-REPLAY: NOTE: Test file: %s\n"
@@ -385,6 +390,7 @@ int main(int argc, char** argv) {
     /* Run the test case machinery in a subprocess, eventually this parent
        process should be a script or something which shells out to the actual
        execution tool. */
+
     int pid = fork();
     if (pid < 0) {
       perror("fork");
@@ -408,6 +414,9 @@ int main(int argc, char** argv) {
         perror("waitpid");
         _exit(66);
       }
+
+      free(prg_argv);
+      kTest_free(input);
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
These fixes some leaks in klee-replay reported in #1512.
While these particular leaks are not important, we should get to a stage where LSan & ASan runs pass. 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
