### PR TITLE
fix FileCheck cmd of VarArgByVal test

### DIFF
--- a/test/Feature/VarArgByVal.c
+++ b/test/Feature/VarArgByVal.c
@@ -4,8 +4,9 @@
 // RUN: %clang %s -emit-llvm %O0opt -c -g -o %t1.bc
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --exit-on-error --output-dir=%t.klee-out %t1.bc
-// RUN FileCheck %s klee-last/assembly.ll
-// CHECK: @test(i32 -1, %struct.bar* byval
+// RUN: FileCheck %s --input-file=%t.klee-out/assembly.ll
+// CHECK: @test1({{.*}}, i32 -1, %struct.foo* byval{{.*}} %struct.bar* byval
+// CHECK: @test2({{.*}}, %struct.foo* byval{{.*}} %struct.bar* byval
 
 #include <stdarg.h>
 #include <assert.h>


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

This PR fixes the test `Feature/VarArgByVal.c`. The test was passing but not checking anything since
since the following `RUN` FileCheck-directive was missing a colon and thus was never executed:

https://github.com/klee/klee/blob/667ce0f1ef33c32fbe2d1836fc1b334066e244ca/test/Feature/VarArgByVal.c#L7

The `FileCheck` command is also broken since `FileCheck` takes only one positional argument and `klee-last/assembly.ll` is not found.

Besides fixing these issues, the `CHECK` directive was extended to actually match the intended lines.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
