### PR TITLE
Use LLVM 11 for FreeBSD testing (package llvm90 is not available anym…

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,13 +6,13 @@ task:
   deps_script:
     - sed -i.bak -e 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
     - env ASSUME_ALWAYS_YES=yes pkg update -f
-    - env ASSUME_ALWAYS_YES=yes pkg install -y llvm90 gmake z3 cmake pkgconf google-perftools python3 py39-sqlite3 py39-tabulate
+    - env ASSUME_ALWAYS_YES=yes pkg install -y llvm11 gmake z3 cmake pkgconf google-perftools python3 py39-sqlite3 py39-tabulate
   build_script:
     - mkdir build
     - cd build
-    - cmake -DLLVM_CONFIG_BINARY=/usr/local/bin/llvm-config90 -DMAKE_BINARY=/usr/local/bin/gmake -DENABLE_TCMALLOC:BOOL=true -DENABLE_POSIX_RUNTIME:BOOL=ON -DENABLE_SOLVER_Z3:BOOL=true -DENABLE_SYSTEM_TESTS:BOOL=ON ..
+    - cmake -DLLVM_CONFIG_BINARY=/usr/local/bin/llvm-config11 -DMAKE_BINARY=/usr/local/bin/gmake -DENABLE_TCMALLOC:BOOL=true -DENABLE_POSIX_RUNTIME:BOOL=ON -DENABLE_SOLVER_Z3:BOOL=true -DENABLE_SYSTEM_TESTS:BOOL=ON ..
     - gmake
   test_script:
-    - sed -i.bak -e 's/lit\./lit90\./' test/lit.cfg
+    - sed -i.bak -e 's/lit\./lit11\./' test/lit.cfg
     - cd build
     - gmake check

--- a/test/Runtime/FreeStanding/memcpy_chk_err.c
+++ b/test/Runtime/FreeStanding/memcpy_chk_err.c
@@ -9,6 +9,9 @@
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out %t2.bc
 
+// RUN: FileCheck --check-prefix=CHECK-BC --input-file %t.klee-out/assembly.ll %s
+// CHECK-BC: @__memcpy_chk
+
 // RUN: test -f %t.klee-out/test000001.ptr.err
 // RUN: FileCheck --input-file %t.klee-out/test000001.ptr.err %s
 // CHECK: memcpy overflow

--- a/test/Runtime/FreeStanding/memcpy_chk_err.c
+++ b/test/Runtime/FreeStanding/memcpy_chk_err.c
@@ -1,9 +1,10 @@
 // This test checks that __memcpy_chk find the kind of errors it was
 // designed to find
 
-// It requires clang >= 10, otherwise a direct call to memcpy is
-// emitted instead of to __memcpy_chk
+// It requires clang >= 10 and not FreeBSD, otherwise a direct call to
+// memcpy is emitted instead of to __memcpy_chk
 // REQUIRES: geq-llvm-10.0
+// REQUIRES: not-freebsd
 
 // RUN: %clang %s -emit-llvm -O2 -g -c -D_FORTIFY_SOURCE=1 -o %t2.bc
 // RUN: rm -rf %t.klee-out
@@ -24,7 +25,7 @@
 
 int main() {
   char d[5];
-  char* s = "1234567890";
+  char *s = "1234567890";
 
   memcpy(d, s, 10);
 }


### PR DESCRIPTION
…ore)

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Use LLVM 11 for FreeBSD testing (package llvm90 is not available anymore

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
