### PR TITLE
Change assert fail to klee_error, in case the entry function not found in module

### DIFF
--- a/test/Runtime/Uclibc/FunctionNotFound.c
+++ b/test/Runtime/Uclibc/FunctionNotFound.c
@@ -1,0 +1,9 @@
+// RUN: %clang %s -emit-llvm %O0opt -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: not %klee --entry-point=main --output-dir=%t.klee-out --libc=uclibc --exit-on-error %t1.bc 2>&1 | FileCheck %s
+
+int foo(int argc, char *argv[]) {
+  return 0;
+}
+
+// CHECK: KLEE: ERROR: Entry function 'main' not found in module.

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1042,7 +1042,11 @@ createLibCWrapper(std::vector<std::unique_ptr<llvm::Module>> &modules,
   // argv), since it does not explicitly take an envp argument.
   auto &ctx = modules[0]->getContext();
   Function *userMainFn = modules[0]->getFunction(intendedFunction);
-  assert(userMainFn && "unable to get user main");
+  if (!userMainFn) {
+    klee_error("Entry function '%s' not found in module.",
+               intendedFunction.str().c_str());
+  }
+
   // Rename entry point using a prefix
   userMainFn->setName("__user_" + intendedFunction);
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Change `assert` to `klee_error`, in case the entry function not found in module when use `-libc=uclibc`

closed #1572 

## Checklist:
- [ ] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [ ] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [ ] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [ ] Each commit has a meaningful message documenting what it does.
- [ ] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [ ] The code is commented OR not applicable/necessary.
- [ ] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [ ] There are test cases for the code you added or modified OR no such test cases are required.
