### PR TITLE
Change the behaviour of klee-stats --table-format to give an error me…

### DIFF
--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -463,11 +463,12 @@ def main():
 
     parser.add_argument('dir', nargs='+', help='KLEE output directory')
 
+    tableFormatArg = parser.add_argument('--table-format',
+                                         choices=['klee', 'csv', 'readable-csv'],
+                                         dest='tableFormat', default='klee',
+                                         help='Table format for the summary.')
     if tabulate_available:
-        parser.add_argument('--table-format',
-                            choices=['klee', 'csv', 'readable-csv'] + list(_table_formats.keys()),
-                            dest='tableFormat', default='klee',
-                            help='Table format for the summary.')
+        tableFormatArg.choices += list(_table_formats.keys())
 
     parser.add_argument('--to-csv',
                         action='store_true', dest='toCsv',


### PR DESCRIPTION
…ssage about missing the tabulate package rather than complaining that the option does not exist.

Right now, if `tabulate` is not installed, using the option `--table-format` leads to the error:
```
klee-stats: error: unrecognized arguments: --table-format=csv
```
which is confusing, as this is a option that exists (for instance, one might have a script that uses that option).  This patch changes the error message to:
```
Error: Package "tabulate" required for table formatting. Please install it using "pip" or your package manager.You can still use --grafana and --to-csv without tabulate.
```
which I believe is better.

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
