### PR TITLE
include cstdint for *int*_t

### DIFF
--- a/include/klee/Core/Interpreter.h
+++ b/include/klee/Core/Interpreter.h
@@ -9,6 +9,7 @@
 #ifndef KLEE_INTERPRETER_H
 #define KLEE_INTERPRETER_H
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>

--- a/include/klee/Statistics/Statistic.h
+++ b/include/klee/Statistics/Statistic.h
@@ -10,6 +10,7 @@
 #ifndef KLEE_STATISTIC_H
 #define KLEE_STATISTIC_H
 
+#include <cstdint>
 #include <string>
 
 namespace klee {


### PR DESCRIPTION
Otherwise we see errors like this with gcc13:
include/klee/Statistics/Statistic.h:31:10: error: no type named 'uint32_t' in namespace 'std'