### PR TITLE
Change `llvm_map_components_to_libnames` to `llvm_config` CMake function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,11 @@ if (NOT EXISTS "${LLVM_AS}")
   message(FATAL_ERROR "Failed to find llvm-as at \"${LLVM_AS}\"")
 endif()
 
+# Check for dynamic linking
+if (LLVM_LINK_LLVM_DYLIB)
+  set(USE_LLVM_SHARED USE_SHARED)
+endif()
+
 ################################################################################
 # C++ version
 ################################################################################

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -11,8 +11,7 @@ add_library(kleeBasic
   Statistics.cpp
 )
 
-llvm_map_components_to_libnames(llvm_libs support)
-target_link_libraries(kleeBasic PRIVATE ${llvm_libs})
+llvm_config(kleeBasic "${USE_LLVM_SHARED}" support)
 target_compile_options(kleeBasic PRIVATE ${KLEE_COMPONENT_CXX_FLAGS})
 target_compile_definitions(kleeBasic PRIVATE ${KLEE_COMPONENT_CXX_DEFINES})
 

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -36,8 +36,8 @@ target_link_libraries(kleeCore PRIVATE
   kleeSupport
 )
 
-llvm_map_components_to_libnames(llvm_libs core executionengine mcjit native support)
-target_link_libraries(kleeCore PRIVATE ${llvm_libs} ${SQLITE3_LIBRARIES})
+llvm_config(kleeCore "${USE_LLVM_SHARED}" core executionengine mcjit native support)
+target_link_libraries(kleeCore PRIVATE ${SQLITE3_LIBRARIES})
 target_include_directories(kleeCore PRIVATE ${KLEE_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS} ${SQLITE3_INCLUDE_DIRS})
 target_compile_options(kleeCore PRIVATE ${KLEE_COMPONENT_CXX_FLAGS})
 target_compile_definitions(kleeCore PRIVATE ${KLEE_COMPONENT_CXX_DEFINES})

--- a/lib/Expr/CMakeLists.txt
+++ b/lib/Expr/CMakeLists.txt
@@ -26,8 +26,7 @@ add_library(kleaverExpr
   Updates.cpp
 )
 
-llvm_map_components_to_libnames(llvm_libs support)
-target_link_libraries(kleaverExpr PRIVATE ${llvm_libs})
+llvm_config(kleaverExpr "${USE_LLVM_SHARED}" support)
 target_include_directories(kleaverExpr PRIVATE ${KLEE_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS})
 target_compile_options(kleaverExpr PRIVATE ${KLEE_COMPONENT_CXX_FLAGS})
 target_compile_definitions(kleaverExpr PRIVATE ${KLEE_COMPONENT_CXX_DEFINES})

--- a/lib/Module/CMakeLists.txt
+++ b/lib/Module/CMakeLists.txt
@@ -26,7 +26,8 @@ add_library(kleeModule
   ${KLEE_MODULE_COMPONENT_SRCS}
 )
 
-llvm_map_components_to_libnames(llvm_libs bitreader
+llvm_config(kleeModule "${USE_LLVM_SHARED}"
+  bitreader
   bitwriter
   codegen
   ipo
@@ -41,8 +42,6 @@ llvm_map_components_to_libnames(llvm_libs bitreader
   mc
   binaryformat
   )
-
-target_link_libraries(kleeModule PRIVATE ${llvm_libs})
 
 target_link_libraries(kleeModule PRIVATE
   kleeSupport

--- a/lib/Solver/CMakeLists.txt
+++ b/lib/Solver/CMakeLists.txt
@@ -32,12 +32,12 @@ add_library(kleaverSolver
   Z3Solver.cpp
 )
 
-llvm_map_components_to_libnames(llvm_libs support)
+llvm_config(kleaverSolver "${USE_LLVM_SHARED}" support)
 target_link_libraries(kleaverSolver PRIVATE
   kleeBasic
   kleaverExpr
   kleeSupport
-  ${KLEE_SOLVER_LIBRARIES} ${llvm_libs})
+  ${KLEE_SOLVER_LIBRARIES})
 target_include_directories(kleaverSolver PRIVATE ${KLEE_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS} ${KLEE_SOLVER_INCLUDE_DIRS})
 target_compile_options(kleaverSolver PRIVATE ${KLEE_COMPONENT_CXX_FLAGS})
 target_compile_definitions(kleaverSolver PRIVATE ${KLEE_COMPONENT_CXX_DEFINES})

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -18,9 +18,9 @@ add_library(kleeSupport
   TreeStream.cpp
 )
 
-llvm_map_components_to_libnames(llvm_libs support)
+llvm_config(kleeSupport "${USE_LLVM_SHARED}" support)
 
-target_link_libraries(kleeSupport PRIVATE ${llvm_libs} ${ZLIB_LIBRARIES} ${TCMALLOC_LIBRARIES})
+target_link_libraries(kleeSupport PRIVATE ${ZLIB_LIBRARIES} ${TCMALLOC_LIBRARIES})
 target_include_directories(kleeSupport PRIVATE ${KLEE_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS} ${TCMALLOC_INCLUDE_DIR})
 target_compile_options(kleeSupport PRIVATE ${KLEE_COMPONENT_CXX_FLAGS})
 target_compile_definitions(kleeSupport PRIVATE ${KLEE_COMPONENT_CXX_DEFINES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,7 +96,7 @@ if (DOWNLOAD_FILECHECK_SOURCE)
   add_executable(FileCheck
     ${FILECHECK_SRC_FILE}
   )
-  llvm_map_components_to_libnames(FILECHECK_NEEDED_LIBS support)
+  llvm_config(FileCheck "${USE_LLVM_SHARED}" support)
   target_include_directories(FileCheck PRIVATE ${LLVM_INCLUDE_DIRS})
   target_link_libraries(FileCheck PRIVATE ${FILECHECK_NEEDED_LIBS})
 endif()
@@ -117,7 +117,7 @@ if (DOWNLOAD_NOT_SOURCE)
   add_executable("not"
     ${NOT_SRC_FILE}
   )
-  llvm_map_components_to_libnames(NOT_NEEDED_LIBS support)
+  llvm_config("not" "${USE_LLVM_SHARED}" support)
   target_include_directories("not" PRIVATE ${LLVM_INCLUDE_DIRS})
   target_link_libraries("not" PRIVATE ${NOT_NEEDED_LIBS})
 endif()

--- a/tools/kleaver/CMakeLists.txt
+++ b/tools/kleaver/CMakeLists.txt
@@ -10,9 +10,9 @@ add_executable(kleaver
   main.cpp
 )
 
-llvm_map_components_to_libnames(llvm_libs core support)
+llvm_config(kleaver "${USE_LLVM_SHARED}" core support)
 
-target_link_libraries(kleaver kleaverSolver ${llvm_libs})
+target_link_libraries(kleaver PRIVATE kleaverSolver)
 target_include_directories(kleaver PRIVATE ${KLEE_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS})
 target_compile_options(kleaver PRIVATE ${KLEE_COMPONENT_CXX_FLAGS})
 target_compile_definitions(kleaver PRIVATE ${KLEE_COMPONENT_CXX_DEFINES})

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -201,7 +201,7 @@ endif()
 
 add_library(unittest_main)
 target_sources(unittest_main PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/TestMain.cpp")
-llvm_map_components_to_libnames(UNITTEST_MAIN_LIBS support)
+llvm_config(unittest_main "${USE_LLVM_SHARED}" support)
 
 target_link_libraries(unittest_main
   PUBLIC


### PR DESCRIPTION
With recent LLVM versions, this should allow to link against dynamic LLVM libraries.

Let's if this builds with our setup, i.e. through all LLVM versions.

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [ ] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [ ] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [ ] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [ ] Each commit has a meaningful message documenting what it does.
- [ ] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [ ] The code is commented OR not applicable/necessary.
- [ ] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [ ] There are test cases for the code you added or modified OR no such test cases are required.
