### PR TITLE
Fixed a compilation error on some platforms: 

### DIFF
--- a/include/klee/Support/FloatEvaluation.h
+++ b/include/klee/Support/FloatEvaluation.h
@@ -20,6 +20,7 @@
 #include "llvm/Support/MathExtras.h"
 
 #include <cassert>
+#include <cstring>
 
 namespace klee {
 namespace floats {
@@ -134,9 +135,9 @@ inline uint64_t mod(uint64_t l, uint64_t r, unsigned inWidth) {
 inline bool isNaN(uint64_t l, unsigned inWidth) {
   switch( inWidth ) {
   case FLT_BITS:
-    return std::isnan(UInt64AsFloat(l));
+    return isnan(UInt64AsFloat(l));
   case DBL_BITS:
-    return std::isnan(UInt64AsDouble(l));
+    return isnan(UInt64AsDouble(l));
   default: llvm::report_fatal_error("unsupported floating point width");
   }
 }


### PR DESCRIPTION
`FloatEvaluation.h:138:17: error: expected unqualified-id`
(Adding `#include <cmath>` does not fix this)
This was triggered by the switch to C++17.

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
