### PR TITLE
fix unused variable warning

### DIFF
--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -830,8 +830,6 @@ int __fd_getdents(unsigned int fd, struct dirent64 *dirp, unsigned int count) {
       return bytes;
     } else {
       off64_t os_pos = f->off - 4096;
-      int res;
-      off64_t s = 0;
 
       /* For reasons which I really don't understand, if I don't
          memset this then sometimes the kernel returns d_ino==0 for
@@ -841,9 +839,10 @@ int __fd_getdents(unsigned int fd, struct dirent64 *dirp, unsigned int count) {
          Even more bizarre, interchanging the memset and the seek also
          case strange behavior. Really should be debugged properly. */
       memset(dirp, 0, count);
-      s = syscall(__NR_lseek, f->fd, os_pos, SEEK_SET);
+      off64_t s = syscall(__NR_lseek, f->fd, os_pos, SEEK_SET);
+      (void)s;
       assert(s != (off64_t) -1);
-      res = syscall(__NR_getdents64, f->fd, dirp, count);
+      int res = syscall(__NR_getdents64, f->fd, dirp, count);
       if (res > -1) {
         int pos = 0;
         f->off = syscall(__NR_lseek, f->fd, 0, SEEK_CUR);


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Fixes an unused variable warning that occurs for configurations in which asserts are disabled for the runtime.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
