### PR TITLE
clean up includes

### DIFF
--- a/include/klee/Core/Interpreter.h
+++ b/include/klee/Core/Interpreter.h
@@ -9,6 +9,7 @@
 #ifndef KLEE_INTERPRETER_H
 #define KLEE_INTERPRETER_H
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>

--- a/include/klee/Statistics/Statistic.h
+++ b/include/klee/Statistics/Statistic.h
@@ -10,6 +10,7 @@
 #ifndef KLEE_STATISTIC_H
 #define KLEE_STATISTIC_H
 
+#include <cstdint>
 #include <string>
 
 namespace klee {

--- a/include/klee/Statistics/Statistics.h
+++ b/include/klee/Statistics/Statistics.h
@@ -12,143 +12,141 @@
 
 #include "Statistic.h"
 
-#include <vector>
+#include <cstdint>
+#include <cstring>
 #include <string>
-#include <string.h>
+#include <vector>
 
 namespace klee {
-  class Statistic;
-  class StatisticRecord {
-    friend class StatisticManager;
+class Statistic;
+class StatisticRecord {
+  friend class StatisticManager;
 
-  private:
-    uint64_t *data;
+private:
+  std::uint64_t *data;
 
-  public:    
-    StatisticRecord();
-    StatisticRecord(const StatisticRecord &s);
-    ~StatisticRecord() { delete[] data; }
-    
-    void zero();
+public:
+  StatisticRecord();
+  StatisticRecord(const StatisticRecord &s);
+  ~StatisticRecord() { delete[] data; }
 
-    uint64_t getValue(const Statistic &s) const; 
-    void incrementValue(const Statistic &s, uint64_t addend) const;
-    StatisticRecord &operator =(const StatisticRecord &s);
-    StatisticRecord &operator +=(const StatisticRecord &sr);
-  };
+  void zero();
 
-  class StatisticManager {
-  private:
-    bool enabled;
-    std::vector<Statistic*> stats;
-    uint64_t *globalStats;
-    uint64_t *indexedStats;
-    StatisticRecord *contextStats;
-    unsigned index;
+  std::uint64_t getValue(const Statistic &s) const;
+  void incrementValue(const Statistic &s, std::uint64_t addend) const;
+  StatisticRecord &operator=(const StatisticRecord &s);
+  StatisticRecord &operator+=(const StatisticRecord &sr);
+};
 
-  public:
-    StatisticManager();
-    ~StatisticManager();
+class StatisticManager {
+private:
+  bool enabled;
+  std::vector<Statistic *> stats;
+  std::uint64_t *globalStats;
+  std::uint64_t *indexedStats;
+  StatisticRecord *contextStats;
+  unsigned index;
 
-    void useIndexedStats(unsigned totalIndices);
+public:
+  StatisticManager();
+  ~StatisticManager();
 
-    StatisticRecord *getContext();
-    void setContext(StatisticRecord *sr); /* null to reset */
+  void useIndexedStats(unsigned totalIndices);
 
-    void setIndex(unsigned i) { index = i; }
-    unsigned getIndex() { return index; }
-    unsigned getNumStatistics() { return stats.size(); }
-    Statistic &getStatistic(unsigned i) { return *stats[i]; }
-    
-    void registerStatistic(Statistic &s);
-    void incrementStatistic(Statistic &s, uint64_t addend);
-    uint64_t getValue(const Statistic &s) const;
-    void incrementIndexedValue(const Statistic &s, unsigned index, 
-                               uint64_t addend) const;
-    uint64_t getIndexedValue(const Statistic &s, unsigned index) const;
-    void setIndexedValue(const Statistic &s, unsigned index, uint64_t value);
-    int getStatisticID(const std::string &name) const;
-    Statistic *getStatisticByName(const std::string &name) const;
-  };
+  StatisticRecord *getContext();
+  void setContext(StatisticRecord *sr); /* null to reset */
 
-  extern StatisticManager *theStatisticManager;
+  void setIndex(unsigned i) { index = i; }
+  unsigned getIndex() { return index; }
+  unsigned getNumStatistics() { return stats.size(); }
+  Statistic &getStatistic(unsigned i) { return *stats[i]; }
 
-  inline void StatisticManager::incrementStatistic(Statistic &s, 
-                                                   uint64_t addend) {
-    if (enabled) {
-      globalStats[s.id] += addend;
-      if (indexedStats) {
-        indexedStats[index*stats.size() + s.id] += addend;
-        if (contextStats)
-          contextStats->data[s.id] += addend;
-      }
+  void registerStatistic(Statistic &s);
+  void incrementStatistic(Statistic &s, std::uint64_t addend);
+  std::uint64_t getValue(const Statistic &s) const;
+  void incrementIndexedValue(const Statistic &s, unsigned index,
+                             std::uint64_t addend) const;
+  std::uint64_t getIndexedValue(const Statistic &s, unsigned index) const;
+  void setIndexedValue(const Statistic &s, unsigned index, std::uint64_t value);
+  int getStatisticID(const std::string &name) const;
+  Statistic *getStatisticByName(const std::string &name) const;
+};
+
+extern StatisticManager *theStatisticManager;
+
+inline void StatisticManager::incrementStatistic(Statistic &s,
+                                                 std::uint64_t addend) {
+  if (enabled) {
+    globalStats[s.id] += addend;
+    if (indexedStats) {
+      indexedStats[index * stats.size() + s.id] += addend;
+      if (contextStats)
+        contextStats->data[s.id] += addend;
     }
   }
-
-  inline StatisticRecord *StatisticManager::getContext() {
-    return contextStats;
-  }
-  inline void StatisticManager::setContext(StatisticRecord *sr) {
-    contextStats = sr;
-  }
-
-  inline void StatisticRecord::zero() {
-    ::memset(data, 0, sizeof(*data)*theStatisticManager->getNumStatistics());
-  }
-
-  inline StatisticRecord::StatisticRecord() 
-    : data(new uint64_t[theStatisticManager->getNumStatistics()]) {
-    zero();
-  }
-
-  inline StatisticRecord::StatisticRecord(const StatisticRecord &s) 
-    : data(new uint64_t[theStatisticManager->getNumStatistics()]) {
-    ::memcpy(data, s.data, 
-             sizeof(*data)*theStatisticManager->getNumStatistics());
-  }
-
-  inline StatisticRecord &StatisticRecord::operator=(const StatisticRecord &s) {
-    ::memcpy(data, s.data, 
-             sizeof(*data)*theStatisticManager->getNumStatistics());
-    return *this;
-  }
-
-  inline void StatisticRecord::incrementValue(const Statistic &s, 
-                                              uint64_t addend) const {
-    data[s.id] += addend;
-  }
-  inline uint64_t StatisticRecord::getValue(const Statistic &s) const { 
-    return data[s.id]; 
-  }
-
-  inline StatisticRecord &
-  StatisticRecord::operator +=(const StatisticRecord &sr) {
-    unsigned nStats = theStatisticManager->getNumStatistics();
-    for (unsigned i=0; i<nStats; i++)
-      data[i] += sr.data[i];
-    return *this;
-  }
-
-  inline uint64_t StatisticManager::getValue(const Statistic &s) const {
-    return globalStats[s.id];
-  }
-
-  inline void StatisticManager::incrementIndexedValue(const Statistic &s, 
-                                                      unsigned index,
-                                                      uint64_t addend) const {
-    indexedStats[index*stats.size() + s.id] += addend;
-  }
-
-  inline uint64_t StatisticManager::getIndexedValue(const Statistic &s, 
-                                                    unsigned index) const {
-    return indexedStats[index*stats.size() + s.id];
-  }
-
-  inline void StatisticManager::setIndexedValue(const Statistic &s, 
-                                                unsigned index,
-                                                uint64_t value) {
-    indexedStats[index*stats.size() + s.id] = value;
-  }
 }
+
+inline StatisticRecord *StatisticManager::getContext() { return contextStats; }
+inline void StatisticManager::setContext(StatisticRecord *sr) {
+  contextStats = sr;
+}
+
+inline void StatisticRecord::zero() {
+  std::memset(data, 0, sizeof(*data) * theStatisticManager->getNumStatistics());
+}
+
+inline StatisticRecord::StatisticRecord()
+    : data(new std::uint64_t[theStatisticManager->getNumStatistics()]) {
+  zero();
+}
+
+inline StatisticRecord::StatisticRecord(const StatisticRecord &s)
+    : data(new std::uint64_t[theStatisticManager->getNumStatistics()]) {
+  std::memcpy(data, s.data,
+              sizeof(*data) * theStatisticManager->getNumStatistics());
+}
+
+inline StatisticRecord &StatisticRecord::operator=(const StatisticRecord &s) {
+  std::memcpy(data, s.data,
+              sizeof(*data) * theStatisticManager->getNumStatistics());
+  return *this;
+}
+
+inline void StatisticRecord::incrementValue(const Statistic &s,
+                                            std::uint64_t addend) const {
+  data[s.id] += addend;
+}
+inline std::uint64_t StatisticRecord::getValue(const Statistic &s) const {
+  return data[s.id];
+}
+
+inline StatisticRecord &StatisticRecord::operator+=(const StatisticRecord &sr) {
+  unsigned nStats = theStatisticManager->getNumStatistics();
+  for (unsigned i = 0; i < nStats; i++)
+    data[i] += sr.data[i];
+  return *this;
+}
+
+inline std::uint64_t StatisticManager::getValue(const Statistic &s) const {
+  return globalStats[s.id];
+}
+
+inline void
+StatisticManager::incrementIndexedValue(const Statistic &s, unsigned index,
+                                        std::uint64_t addend) const {
+  indexedStats[index * stats.size() + s.id] += addend;
+}
+
+inline std::uint64_t StatisticManager::getIndexedValue(const Statistic &s,
+                                                       unsigned index) const {
+  return indexedStats[index * stats.size() + s.id];
+}
+
+inline void StatisticManager::setIndexedValue(const Statistic &s,
+                                              unsigned index,
+                                              std::uint64_t value) {
+  indexedStats[index * stats.size() + s.id] = value;
+}
+} // namespace klee
 
 #endif /* KLEE_STATISTICS_H */


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
This is #1586 rebased on master, but also ensures `Statistics.h` uses `<cstdint>` instead of `<stdint.h>` and `<cstring>` instead of `<string.h>`.
