### PR TITLE
fix file-creator.c: feature test macro for nftw

### DIFF
--- a/tools/klee-replay/file-creator.c
+++ b/tools/klee-replay/file-creator.c
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define _XOPEN_SOURCE 500
+
 #include "klee-replay.h"
 
 #include <assert.h>


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

Recently, when compiling `tools/klee-replay/file-creator.c`, I was greeted by the following error:
```
../klee/tools/klee-replay/file-creator.c:443:48: warning: ‘struct FTW’ declared inside parameter list will not be visible outside of this definition or declaration
  443 |                 __attribute__((unused)) struct FTW *ftwbuf) {
      |                                                ^~~
../klee/tools/klee-replay/file-creator.c: In function ‘replay_delete_files’:
../klee/tools/klee-replay/file-creator.c:453:7: warning: implicit declaration of function ‘nftw’; did you mean ‘ftw’? [-Wimplicit-function-declaration]
  453 |   if (nftw(replay_dir, remove_callback, FOPEN_MAX,
      |       ^~~~
      |       ftw
../klee/tools/klee-replay/file-creator.c:454:12: error: ‘FTW_DEPTH’ undeclared (first use in this function)
  454 |            FTW_DEPTH | FTW_PHYS) == -1) {
      |            ^~~~~~~~~
../klee/tools/klee-replay/file-creator.c:454:12: note: each undeclared identifier is reported only once for each function it appears in
../klee/tools/klee-replay/file-creator.c:454:24: error: ‘FTW_PHYS’ undeclared (first use in this function); did you mean ‘FTW_NS’?
  454 |            FTW_DEPTH | FTW_PHYS) == -1) {
      |                        ^~~~~~~~
      |                        FTW_NS
```

According to the [glibc man page](https://man7.org/linux/man-pages/man3/nftw.3.html) `nftw` requires `_XOPEN_SOURCE >= 500`. I'm not sure why this has not been an issue before.

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
