### PR TITLE
UBSan tests assume debug info in runtime build

### DIFF
--- a/test/Feature/ubsan/ubsan_alignment-assumption.c
+++ b/test/Feature/ubsan/ubsan_alignment-assumption.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=alignment -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_alignment-assumption_with_offset.c
+++ b/test/Feature/ubsan/ubsan_alignment-assumption_with_offset.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=alignment -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_alignment-type-mismatch.c
+++ b/test/Feature/ubsan/ubsan_alignment-type-mismatch.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=alignment -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_array_bounds.c
+++ b/test/Feature/ubsan/ubsan_array_bounds.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=array-bounds -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_bool.c
+++ b/test/Feature/ubsan/ubsan_bool.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=bool -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .invalid_load.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_builtin.c
+++ b/test/Feature/ubsan/ubsan_builtin.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=builtin -w -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .invalid_builtin_use.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_enum.cpp
+++ b/test/Feature/ubsan/ubsan_enum.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx %s -fsanitize=enum -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .invalid_load.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_float_cast_overflow.c
+++ b/test/Feature/ubsan/ubsan_float_cast_overflow.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=float-cast-overflow -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 1
 // RUN: ls %t.klee-out/ | grep .overflow.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_float_divide_by_zero.c
+++ b/test/Feature/ubsan/ubsan_float_divide_by_zero.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=float-divide-by-zero -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 1
 // RUN: ls %t.klee-out/ | grep .div.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_implicit_integer_sign_change.c
+++ b/test/Feature/ubsan/ubsan_implicit_integer_sign_change.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=implicit-integer-sign-change -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .implicit_conversion.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_implicit_signed_integer_truncation.c
+++ b/test/Feature/ubsan/ubsan_implicit_signed_integer_truncation.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=implicit-signed-integer-truncation -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .implicit_truncation.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_implicit_unsigned_integer_truncation.c
+++ b/test/Feature/ubsan/ubsan_implicit_unsigned_integer_truncation.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=implicit-unsigned-integer-truncation -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .implicit_truncation.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_integer_divide_by_zero.c
+++ b/test/Feature/ubsan/ubsan_integer_divide_by_zero.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=integer-divide-by-zero -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --check-div-zero=false %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts --check-div-zero=false %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 1
 // RUN: ls %t.klee-out/ | grep .overflow.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_nonnull_attribute.c
+++ b/test/Feature/ubsan/ubsan_nonnull_attribute.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=nonnull-attribute -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .nullable_attribute.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_null.c
+++ b/test/Feature/ubsan/ubsan_null.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=null -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_nullability_arg.c
+++ b/test/Feature/ubsan/ubsan_nullability_arg.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=nullability-arg -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .nullable_attribute.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_nullability_assign.c
+++ b/test/Feature/ubsan/ubsan_nullability_assign.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=nullability-assign -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_nullability_return.c
+++ b/test/Feature/ubsan/ubsan_nullability_return.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=nullability-return -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .nullable_attribute.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_pointer_overflow-applying_nonzero_offset_to_nonnull_pointer.c
+++ b/test/Feature/ubsan/ubsan_pointer_overflow-applying_nonzero_offset_to_nonnull_pointer.c
@@ -2,7 +2,7 @@
 
 // RUN: %clang %s -fsanitize=pointer-overflow -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_pointer_overflow-applying_nonzero_offset_to_nonnull_pointer_10.c
+++ b/test/Feature/ubsan/ubsan_pointer_overflow-applying_nonzero_offset_to_nonnull_pointer_10.c
@@ -2,7 +2,7 @@
 
 // RUN: %clang %s -fsanitize=pointer-overflow -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_pointer_overflow-applying_nonzero_offset_to_null_pointer.c
+++ b/test/Feature/ubsan/ubsan_pointer_overflow-applying_nonzero_offset_to_null_pointer.c
@@ -2,7 +2,7 @@
 
 // RUN: %clang %s -fsanitize=pointer-overflow -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 1
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_pointer_overflow-applying_zero_offset_to_null_pointer.c
+++ b/test/Feature/ubsan/ubsan_pointer_overflow-applying_zero_offset_to_null_pointer.c
@@ -2,7 +2,7 @@
 
 // RUN: %clang %s -fsanitize=pointer-overflow -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 1
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_pointer_overflow-pointer_arithmetic.c
+++ b/test/Feature/ubsan/ubsan_pointer_overflow-pointer_arithmetic.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=pointer-overflow -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_return.cpp
+++ b/test/Feature/ubsan/ubsan_return.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx %s -fsanitize=return -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 1
 // RUN: ls %t.klee-out/ | grep .missing_return.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_returns_nonnull_attribute.c
+++ b/test/Feature/ubsan/ubsan_returns_nonnull_attribute.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=returns-nonnull-attribute -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .nullable_attribute.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_shift_base.c
+++ b/test/Feature/ubsan/ubsan_shift_base.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=shift-base -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --check-overshift=false %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts --check-overshift=false %t.bc 2>&1 | FileCheck %s
 //
 // There may be 2 or 3 test cases depending on the search heuristic, so we don't check the number of tests.
 // For example, 2 test cases may be as follows:

--- a/test/Feature/ubsan/ubsan_shift_exponent.c
+++ b/test/Feature/ubsan/ubsan_shift_exponent.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=shift-exponent -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --check-overshift=false %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts --check-overshift=false %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .overflow.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_signed_integer_overflow.c
+++ b/test/Feature/ubsan/ubsan_signed_integer_overflow.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=signed-integer-overflow -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 5
 // RUN: ls %t.klee-out/ | grep .overflow.err | wc -l | grep 4
 

--- a/test/Feature/ubsan/ubsan_unreachable.c
+++ b/test/Feature/ubsan/ubsan_unreachable.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=unreachable -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 1
 // RUN: ls %t.klee-out/ | grep .unreachable_call.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_unsigned_integer_overflow.c
+++ b/test/Feature/ubsan/ubsan_unsigned_integer_overflow.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=unsigned-integer-overflow -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 5
 // RUN: ls %t.klee-out/ | grep .overflow.err | wc -l | grep 4
 

--- a/test/Feature/ubsan/ubsan_unsigned_shift_base.c
+++ b/test/Feature/ubsan/ubsan_unsigned_shift_base.c
@@ -2,7 +2,7 @@
 
 // RUN: %clang %s -fsanitize=unsigned-shift-base -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --check-overshift=false %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts --check-overshift=false %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 2
 // RUN: ls %t.klee-out/ | grep .overflow.err | wc -l | grep 1
 

--- a/test/Feature/ubsan/ubsan_vla_bound.c
+++ b/test/Feature/ubsan/ubsan_vla_bound.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -fsanitize=vla-bound -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime --runtime-build=Debug+Asserts %t.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 3
 // RUN: ls %t.klee-out/ | grep .ptr.err | wc -l | grep 1
 // RUN: ls %t.klee-out/ | grep .model.err | wc -l | grep 1


### PR DESCRIPTION
## Summary: 

The tests require debug info which may not be provided in the default runtime build type (as set by `KLEE_RUNTIME_BUILD_TYPE` in CMake). If the tests are run using e.g. the `Release` default runtime build type, they fail as `FileCheck` cannot match the expected output. This PR fixes this by overriding the default using `--runtime-build=Debug+Asserts`.

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
