### PR TITLE
change some obsolete KDAlloc comments

### DIFF
--- a/include/klee/KDAlloc/allocator.h
+++ b/include/klee/KDAlloc/allocator.h
@@ -29,7 +29,8 @@
 #include <type_traits>
 
 namespace klee::kdalloc {
-/// Wraps a mapping that is shared with other allocators.
+/// Wraps a mapping and delegates allocation to one of 8 sized-bin slot
+/// allocators (size < 4096) or a large object allocator (size >= 4096).
 class Allocator final : public TaggedLogger<Allocator> {
 public:
   class Control final {

--- a/unittests/KDAlloc/allocate.cpp
+++ b/unittests/KDAlloc/allocate.cpp
@@ -23,8 +23,7 @@ int allocate_sample_test() {
 #else
 int main() {
 #endif
-  // initialize a factory and an associated allocator (using the location "0"
-  // gives an OS-assigned location)
+  // initialize a factory and an associated allocator (1 MiB and no quarantine)
   klee::kdalloc::AllocatorFactory factory(static_cast<std::size_t>(1) << 20, 0);
   klee::kdalloc::Allocator allocator = factory.makeAllocator();
 

--- a/unittests/KDAlloc/rusage.cpp
+++ b/unittests/KDAlloc/rusage.cpp
@@ -35,10 +35,8 @@ std::size_t write_to_allocations(std::vector<void *> &allocations) {
 }
 
 TEST(KDAllocTest, Rusage) {
-  // initialize a factory and an associated allocator (using the location "0"
-  // gives an OS-assigned location)
-  klee::kdalloc::AllocatorFactory factory(static_cast<std::size_t>(1) << 30,
-                                          0); // 1 GB
+  // initialize a factory and an associated allocator (1 GiB and no quarantine)
+  klee::kdalloc::AllocatorFactory factory(static_cast<std::size_t>(1) << 30, 0);
   klee::kdalloc::Allocator allocator = factory.makeAllocator();
 
   std::vector<void *> allocations;

--- a/unittests/KDAlloc/sample.cpp
+++ b/unittests/KDAlloc/sample.cpp
@@ -20,8 +20,7 @@ int sample_test() {
 #else
 int main() {
 #endif
-  // initialize a factory and an associated allocator (using the location "0"
-  // gives an OS-assigned location)
+  // initialize a factory and an associated allocator (1 TiB and no quarantine)
   klee::kdalloc::AllocatorFactory factory(static_cast<std::size_t>(1) << 40, 0);
   klee::kdalloc::Allocator allocator = factory.makeAllocator();
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

Not a very major issue, but I noticed a few confusing / outdated comments in KDAlloc code, which I propose to change.
Summary:
- mappings were only shared in a former version of KDAlloc
- `AllocationFactory(std::size_t, std::uint32_t)`'s second parameter is used for quarantine size, not the location of the mapping

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
