### PR TITLE
Run ShellCheck on `*.inc` shell scripts

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -28,4 +28,5 @@ jobs:
         uses: redhat-plumbers-in-action/differential-shellcheck@v4
         with:
           severity: warning
+          include-path: scripts/**.inc
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary: 

This change will ensure that the ShellCheck action will scan `.inc` shell scripts.

The feature was added via:
- https://github.com/redhat-plumbers-in-action/differential-shellcheck/pull/232

Follow-up to https://github.com/klee/klee/pull/1548#issuecomment-1481632582

/cc @MartinNowack 
