### PR TITLE
Modify names of SMT variables to use underscores instead of dashes

### DIFF
--- a/test/Solver/2016-04-12-array-parsing-bug.kquery
+++ b/test/Solver/2016-04-12-array-parsing-bug.kquery
@@ -1,8 +1,8 @@
 # RUN: %kleaver %s > %t
 # RUN: %kleaver --clear-array-decls-after-query %s > %t
 
-array A-data[8] : w32 -> w8 = symbolic
-array A-data-stat[144] : w32 -> w8 = symbolic
+array A_data[8] : w32 -> w8 = symbolic
+array A_data_stat[144] : w32 -> w8 = symbolic
 array arg0[3] : w32 -> w8 = symbolic
 array arg1[3] : w32 -> w8 = symbolic
 array const_arr1[768] : w32 -> w8 = [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 3 32 2 32 2 32 2 32 2 32 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 2 0 1 96 4 192 4 192 4 192 4 192 4 192 4 192 4 192 4 192 4 192 4 192 4 192 4 192 4 192 4 192 4 192 8 216 8 216 8 216 8 216 8 216 8 216 8 216 8 216 8 216 8 216 4 192 4 192 4 192 4 192 4 192 4 192 4 192 8 213 8 213 8 213 8 213 8 213 8 213 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 8 197 4 192 4 192 4 192 4 192 4 192 4 192 8 214 8 214 8 214 8 214 8 214 8 214 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 8 198 4 192 4 192 4 192 4 192 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
@@ -11,9 +11,9 @@ array model_version[4] : w32 -> w8 = symbolic
 array n_args[4] : w32 -> w8 = symbolic
 array n_args_1[4] : w32 -> w8 = symbolic
 array stdin[8] : w32 -> w8 = symbolic
-array stdin-stat[144] : w32 -> w8 = symbolic
+array stdin_stat[144] : w32 -> w8 = symbolic
 array stdout[1024] : w32 -> w8 = symbolic
-array stdout-stat[144] : w32 -> w8 = symbolic
+array stdout_stat[144] : w32 -> w8 = symbolic
 (query [(Ult N0:(ReadLSB w32 0 n_args)
               2)
          (Eq false (Slt 0 N0))
@@ -23,21 +23,21 @@ array stdout-stat[144] : w32 -> w8 = symbolic
          (Slt 1 N1)
          (Eq false
              (Eq 0
-                 (And w64 (ReadLSB w64 8 A-data-stat)
+                 (And w64 (ReadLSB w64 8 A_data_stat)
                           2147483647)))
-         (Ult (ReadLSB w64 56 A-data-stat)
+         (Ult (ReadLSB w64 56 A_data_stat)
               65536)
          (Eq false
              (Eq 0
-                 (And w64 (ReadLSB w64 8 stdin-stat)
+                 (And w64 (ReadLSB w64 8 stdin_stat)
                           2147483647)))
-         (Ult (ReadLSB w64 56 stdin-stat)
+         (Ult (ReadLSB w64 56 stdin_stat)
               65536)
          (Eq false
              (Eq 0
-                 (And w64 (ReadLSB w64 8 stdout-stat)
+                 (And w64 (ReadLSB w64 8 stdout_stat)
                           2147483647)))
-         (Ult (ReadLSB w64 56 stdout-stat)
+         (Ult (ReadLSB w64 56 stdout_stat)
               65536)
          (Eq 1
              (ReadLSB w32 0 model_version))
@@ -83,25 +83,25 @@ array stdout-stat[144] : w32 -> w8 = symbolic
          n_args_1
          arg0
          arg1
-         A-data
-         A-data-stat
+         A_data
+         A_data_stat
          stdin
-         stdin-stat
+         stdin_stat
          stdout
-         stdout-stat
+         stdout_stat
          model_version])
 
-array A-data[8] : w32 -> w8 = symbolic
-array A-data-stat[144] : w32 -> w8 = symbolic
+array A_data[8] : w32 -> w8 = symbolic
+array A_data_stat[144] : w32 -> w8 = symbolic
 array arg0[11] : w32 -> w8 = symbolic
 array arg1[3] : w32 -> w8 = symbolic
 array model_version[4] : w32 -> w8 = symbolic
 array n_args[4] : w32 -> w8 = symbolic
 array n_args_1[4] : w32 -> w8 = symbolic
 array stdin[8] : w32 -> w8 = symbolic
-array stdin-stat[144] : w32 -> w8 = symbolic
+array stdin_stat[144] : w32 -> w8 = symbolic
 array stdout[1024] : w32 -> w8 = symbolic
-array stdout-stat[144] : w32 -> w8 = symbolic
+array stdout_stat[144] : w32 -> w8 = symbolic
 (query [(Ult N0:(ReadLSB w32 0 n_args)
               2)
          (Slt 0 N0)
@@ -111,21 +111,21 @@ array stdout-stat[144] : w32 -> w8 = symbolic
          (Eq false (Slt 1 N1))
          (Eq false
              (Eq 0
-                 (And w64 (ReadLSB w64 8 A-data-stat)
+                 (And w64 (ReadLSB w64 8 A_data_stat)
                           2147483647)))
-         (Ult (ReadLSB w64 56 A-data-stat)
+         (Ult (ReadLSB w64 56 A_data_stat)
               65536)
          (Eq false
              (Eq 0
-                 (And w64 (ReadLSB w64 8 stdin-stat)
+                 (And w64 (ReadLSB w64 8 stdin_stat)
                           2147483647)))
-         (Ult (ReadLSB w64 56 stdin-stat)
+         (Ult (ReadLSB w64 56 stdin_stat)
               65536)
          (Eq false
              (Eq 0
-                 (And w64 (ReadLSB w64 8 stdout-stat)
+                 (And w64 (ReadLSB w64 8 stdout_stat)
                           2147483647)))
-         (Ult (ReadLSB w64 56 stdout-stat)
+         (Ult (ReadLSB w64 56 stdout_stat)
               65536)
          (Eq 1
              (ReadLSB w32 0 model_version))
@@ -218,10 +218,10 @@ array stdout-stat[144] : w32 -> w8 = symbolic
          arg0
          n_args_1
          arg1
-         A-data
-         A-data-stat
+         A_data
+         A_data_stat
          stdin
-         stdin-stat
+         stdin_stat
          stdout
-         stdout-stat
+         stdout_stat
          model_version])

--- a/test/Solver/FastCexSolver.kquery
+++ b/test/Solver/FastCexSolver.kquery
@@ -4,7 +4,7 @@
 array arr1[4] : w32 -> w8 = symbolic
 (query [] (Not (Eq 4096 (ReadLSB w32 0 arr1))))
 
-array A-data[2] : w32 -> w8 = symbolic
-(query [(Ule (Add w8 208 N0:(Read w8 0 A-data))
+array A_data[2] : w32 -> w8 = symbolic
+(query [(Ule (Add w8 208 N0:(Read w8 0 A_data))
              9)]
        (Eq 52 N0))

--- a/test/regression/2016-03-22-independence-solver-missing-objects-for-assignment.kquery
+++ b/test/regression/2016-03-22-independence-solver-missing-objects-for-assignment.kquery
@@ -1,15 +1,15 @@
 # RUN: %kleaver %s 2>&1 | FileCheck %s
 array n_args[4] : w32 -> w8 = symbolic
 array n_args_1[4] : w32 -> w8 = symbolic
-array A-data-stat[144] : w32 -> w8 = symbolic
-array stdin-stat[144] : w32 -> w8 = symbolic
+array A_data_stat[144] : w32 -> w8 = symbolic
+array stdin_stat[144] : w32 -> w8 = symbolic
 (query [(Ult N0:(ReadLSB w32 0 n_args) 2)
 (Slt 0 N0)
 (Ult N1:(ReadLSB w32 0 n_args_1) 3)
 (Slt 0 N1)
 (Slt 1 N1)
-(Eq false (Eq 0 (And w64 (ReadLSB w64 8 A-data-stat) 2147483647)))
-(Ult (ReadLSB w64 56 A-data-stat) 65536)
-(Eq false (Eq 0 (And w64 (ReadLSB w64 8 stdin-stat) 2147483647)))]
-(Eq false (Ult (ReadLSB w64 56 stdin-stat) 65536)) [] [n_args])
+(Eq false (Eq 0 (And w64 (ReadLSB w64 8 A_data_stat) 2147483647)))
+(Ult (ReadLSB w64 56 A_data_stat) 65536)
+(Eq false (Eq 0 (And w64 (ReadLSB w64 8 stdin_stat) 2147483647)))]
+(Eq false (Ult (ReadLSB w64 56 stdin_stat) 65536)) [] [n_args])
 # CHECK: INVALID

--- a/tools/ktest-gen/ktest-gen.cpp
+++ b/tools/ktest-gen/ktest-gen.cpp
@@ -139,8 +139,8 @@ int main(int argc, char *argv[]) {
   }
 
   if (file_counter > 0) {
-    char filename[7] = "A-data";
-    char statname[12] = "A-data-stat";
+    char filename[7] = "A_data";
+    char statname[12] = "A_data_stat";
     char sym_file_name = 'A';
     FILE *fp[file_counter];
     unsigned char *file_content[file_counter];
@@ -222,7 +222,7 @@ int main(int argc, char *argv[]) {
     FILE *fp;
     struct stat64 file_stat;
     char filename[6] = "stdin";
-    char statname[11] = "stdin-stat";
+    char statname[11] = "stdin_stat";
 #if defined(__has_feature)
 #if __has_feature(memory_sanitizer)
     memset(&file_stat, 0, sizeof(struct stat64));
@@ -265,7 +265,7 @@ int main(int argc, char *argv[]) {
     struct stat64 file_stat;
     unsigned char file_content[1024];
     char filename[7] = "stdout";
-    char statname[12] = "stdout-stat";
+    char statname[12] = "stdout_stat";
 
 #if defined(__has_feature)
 #if __has_feature(memory_sanitizer)

--- a/tools/ktest-randgen/ktest-randgen.cpp
+++ b/tools/ktest-randgen/ktest-randgen.cpp
@@ -242,8 +242,8 @@ int main(int argc, char *argv[]) {
   }
 
   for (i = 0; i < total_files; ++i) {
-    char filename[] = "A-data";
-    char file_stat[] = "A-data-stat";
+    char filename[] = "A_data";
+    char file_stat[] = "A_data_stat";
     unsigned nbytes;
     struct stat s;
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Modify names of SMT variables to use underscores instead of dashes in the ktest-(rand) gen tools and tests.  This is a follow-up of #1152, where the renaming was incomplete.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
