### PR TITLE
Copy stats to test directory when running tests

### DIFF
--- a/test/Feature/KleeStatsColumns.test
+++ b/test/Feature/KleeStatsColumns.test
@@ -1,4 +1,8 @@
-RUN: %klee-stats --print-all %S/klee-stats/missing_column %S/klee-stats/run %S/klee-stats/additional_column | FileCheck %s
+// sqlite databases must be opened with write permissions, so we copy the test cases to the output dir
+RUN: rm -rf %t.klee-stats
+RUN: mkdir %t.klee-stats
+RUN: cp -r %S/klee-stats/missing_column %S/klee-stats/run %S/klee-stats/additional_column %t.klee-stats/
+RUN %klee-stats --print-all %t.klee-stats/missing_column %t.klee-stats/run %t.klee-stats/additional_column | FileCheck %s
 
 // Path, Instrs, ..., extra_column
 CHECK: {{^}}| missing_column  |        |{{.*}}|             |{{$}}

--- a/test/Feature/KleeStatsCsv.test
+++ b/test/Feature/KleeStatsCsv.test
@@ -1,5 +1,9 @@
-RUN: %klee-stats --table-format=csv %S/klee-stats/run | FileCheck --check-prefix=CHECK-CSV %s
-RUN: %klee-stats --table-format=readable-csv %S/klee-stats/run | FileCheck --check-prefix=CHECK-READABLECSV %s
+// sqlite databases must be opened with write permissions, so we copy the test cases to the output dir
+RUN: rm -rf %t.klee-stats
+RUN: mkdir %t.klee-stats
+RUN: cp -r %S/klee-stats/run %t.klee-stats/
+RUN: %klee-stats --table-format=csv %t.klee-stats/run | FileCheck --check-prefix=CHECK-CSV %s
+RUN: %klee-stats --table-format=readable-csv %t.klee-stats/run | FileCheck --check-prefix=CHECK-READABLECSV %s
 
 CHECK-CSV: Path,Instrs,Time(s),ICov(%),BCov(%),ICount,TSolver(%)
 CHECK-CSV: klee-stats/run,3,0.00,100.00,100.00,3,0.00

--- a/test/Feature/KleeStatsEmpty.test
+++ b/test/Feature/KleeStatsEmpty.test
@@ -1,4 +1,8 @@
-RUN: %klee-stats %S/klee-stats/empty | FileCheck %s
+// sqlite databases must be opened with write permissions, so we copy the test cases to the output dir
+RUN: rm -rf %t.klee-stats
+RUN: mkdir %t.klee-stats
+RUN: cp -r %S/klee-stats/empty %t.klee-stats/
+RUN: %klee-stats %t.klee-stats/empty | FileCheck %s
 
 CHECK: {{^}}|{{ *}}Path{{ *}}|{{$}}
 CHECK: {{^}}|{{.*}}empty{{ *}}|{{$}}


### PR DESCRIPTION
The sqlite3 databases used for the stats are journalled and potentially must be written to. Therefore, the sqlite3 driver used by `klee-stats` requires write permissions on the database files.

By copying the stats files to the test directory, we can now compile and test an out-of-tree build without requiring any write permissions on the source folder at all.

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
