### PR TITLE
Fix reusing LLVM's Google Test target & source

### DIFF
--- a/README-CMake.md
+++ b/README-CMake.md
@@ -58,8 +58,8 @@ cmake -DCMAKE_BUILD_TYPE=Release /path/to/klee/src
 * `ENABLE_ZLIB` (BOOLEAN) - Enable zlib support.
 
 * `GTEST_SRC_DIR` (STRING) - Path to Google Test source tree. If it is not
-   specified and `USE_CMAKE_FIND_PACKAGE_LLVM` is used, CMake will try to reuse
-   the version included within the LLVM source tree.
+   specified, CMake will try to reuse the version included within the LLVM
+   source tree or find a system installation of Google Test.
 
 * `GTEST_INCLUDE_DIR` (STRING) - Path to Google Test include directory,
    if it is not under `GTEST_SRC_DIR`.

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -141,11 +141,8 @@ else()
   # LLVM's 'gtest' target is not reused
 
   if (NOT GTEST_SRC_DIR)
-    if (USE_CMAKE_FIND_PACKAGE_LLVM AND LLVM_BUILD_MAIN_SRC_DIR)
+    if (IS_DIRECTORY "${LLVM_BUILD_MAIN_SRC_DIR}")
       # build from LLVM's utils directory
-      # NOTE: This can only be done using USE_CMAKE_FIND_PACKAGE_LLVM as
-      #       LLVM replaced Google Test's CMakeLists.txt with its own,
-      #       requiring add_llvm_library() from AddLLVM.cmake.
       message(STATUS "Google Test: Building from LLVM's source tree.")
 
       set(GTEST_INCLUDE_DIR
@@ -154,6 +151,11 @@ else()
         PATH
         "Path to Google Test include directory"
       )
+
+      # LLVM replaced Google Test's CMakeLists.txt with its own, which requires
+      # add_llvm_library() from AddLLVM.cmake.
+      list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+      include(AddLLVM)
 
       add_subdirectory("${LLVM_BUILD_MAIN_SRC_DIR}/utils/unittest/"
         "${CMAKE_CURRENT_BINARY_DIR}/gtest_build")

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -43,44 +43,99 @@ function(add_vanilla_googletest_subdirectory directory)
   add_subdirectory(${directory} "${CMAKE_CURRENT_BINARY_DIR}/gtest_build")
 endfunction()
 
-if (TARGET gtest)
-  # try to reuse LLVM's 'gtest' target
+function(ensure_valid_llvm_gtest_target)
+  block(SCOPE_FOR VARIABLES)
+  if ("${LLVM_VERSION_MAJOR}" LESS 13)
+    list(FIND LLVM_EXPORTED_TARGETS "gtest" _GTEST_INDEX)
+    if (${_GTEST_INDEX} GREATER -1)
+      return()
+    endif()
+  else()
+    # use that LLVM's Google Test always depends on LLVM's own support library
 
-  message(WARNING "LLVM exports its 'gtest' CMake target (for Google Test), so "
-    "KLEE cannot create its own. Thus, KLEE will reuse the existing one. This "
-    "is, however, only recommended if LLVM and KLEE were built using the same "
+    # if LLVM was built using "BUILD_SHARED_LIBS=ON", we need to collect
+    # IMPORTED_LINK_DEPENDENT_LIBRARIES[_<CONFIGURATION>] for the target
+    get_target_property(_GTEST_DEPENDENCIES gtest
+      IMPORTED_LINK_DEPENDENT_LIBRARIES)
+    if (NOT _GTEST_DEPENDENCIES)
+      set(_GTEST_DEPENDENCIES "")
+    endif()
+    get_target_property(_GTEST_CONFIGS gtest IMPORTED_CONFIGURATIONS)
+    foreach(_GTEST_CONFIG "${_GTEST_CONFIGS}")
+      get_target_property(_GTEST_DEP_CONFIG gtest
+        IMPORTED_LINK_DEPENDENT_LIBRARIES_${_GTEST_CONFIG})
+      if (_GTEST_DEP_CONFIG)
+        list(APPEND _GTEST_DEPENDENCIES "${_GTEST_DEP_CONFIG}")
+      endif()
+    endforeach()
+
+    # PUBLIC and INTERFACE link dependencies (when LLVM uses static linking)
+    get_target_property(_GTEST_LINK_LIBS gtest INTERFACE_LINK_LIBRARIES)
+    if (_GTEST_LINK_LIBS)
+        list(APPEND _GTEST_DEPENDENCIES "${_GTEST_LINK_LIBS}")
+    endif()
+
+    # determine the name of the library offering LLVM's support
+    if ("${LLVM_LINK_LLVM_DYLIB}")
+      set(_SUPPORT_DEPENDENCY "LLVM")
+    else()
+      llvm_map_components_to_libnames(_SUPPORT_DEPENDENCY support)
+    endif()
+
+    # check if this support library is among the dependencies of gtest
+    list(FIND _GTEST_DEPENDENCIES "${_SUPPORT_DEPENDENCY}" _SUPPORT_INDEX)
+    if (${_SUPPORT_INDEX} GREATER -1)
+      return()
+    endif()
+  endif()
+
+  message(FATAL_ERROR "An existing 'gtest' CMake target was imported. This "
+    "prevents KLEE from defining its own 'gtest' target (for Google Test).\n"
+    "KLEE has support for reusing the 'gtest' target exported by LLVM, but "
+    "the 'gtest' target imported does not appear to originate from LLVM.\n"
+    "Please make sure that no KLEE dependency (included with `find_package`) "
+    "exports a 'gtest' target in your configuration.")
+  endblock()
+endfunction()
+
+if (TARGET gtest)
+  # Google Test target is already defined, we cannot include Google Test twice.
+  # Thus, we try to reuse the 'gtest' target if it originates from LLVM.
+  # Otherwise, we fail with an error (and ask user to fix their configuration).
+
+  message(STATUS "Google Test: Reusing 'gtest' target.")
+  ensure_valid_llvm_gtest_target()
+
+  message(WARNING "LLVM exports its 'gtest' CMake target (for Google Test), "
+    "which is imported by KLEE (via `find_package`). This prevents KLEE from "
+    "defining its own 'gtest' target (for Google Test).\n"
+    "Thus, KLEE will reuse the imported 'gtest' target from LLVM. This is, "
+    "however, only recommended if LLVM and KLEE are built using the same "
     "compiler and linker flags (to prevent compatibility issues).\n"
     "To prevent CMake from reusing the target or to use a different version "
     "of Google Test, try either of the following:\n"
     "- Point LLVM_DIR to the directory containing the `LLVMConfig.cmake` file "
     "of an installed copy of LLVM instead of a build tree.\n"
-    "- Pass -DLLVM_INCLUDE_TESTS=OFF to CMake when building LLVM. This "
-    "prevents building unit tests in LLVM (but not in KLEE) and exporting the "
-    "target to the build tree.")
+    "- Pass -DLLVM_INCLUDE_TESTS=OFF to the CMake invocation used for building "
+    "LLVM. This prevents building unit tests in LLVM (but not in KLEE) and "
+    "exporting the target from LLVM's build tree.")
 
   if (GTEST_SRC_DIR)
     message(FATAL_ERROR "Cannot use GTEST_SRC_DIR when target 'gtest' is"
       "already defined.\n"
-      "Either reuse LLVM's Google Test setup by not setting GTEST_SRC_DIR or "
-      "choose one of the options to prevent LLVM from exporting this target.")
+      "Either let KLEE reuse LLVM's Google Test setup by not setting "
+      "GTEST_SRC_DIR explicitly or choose one of the options above to prevent"
+      "LLVM from exporting this target.")
   endif()
 
-  # check if it's really LLVM that exports the 'gtest' target
-  list(FIND LLVM_EXPORTED_TARGETS "gtest" _GTEST_INDEX)
-  if (${_GTEST_INDEX} GREATER -1)
-    message(STATUS "Google Test: Reusing LLVM's 'gtest' target.")
-    # in this case, only include directory has to be set
-    if (LLVM_BUILD_MAIN_SRC_DIR)
-      set(GTEST_INCLUDE_DIR
-        "${LLVM_BUILD_MAIN_SRC_DIR}/utils/unittest/googletest/include"
-        CACHE
-        PATH
-        "Path to Google Test include directory"
-      )
-    endif()
-  else()
-    message(FATAL_ERROR "Reusing Google Test (target) from LLVM failed:"
-      "LLVM_EXPORTED_TARGETS does not contain 'gtest'.")
+  # in this case, only include directory has to be set
+  if (LLVM_BUILD_MAIN_SRC_DIR)
+    set(GTEST_INCLUDE_DIR
+      "${LLVM_BUILD_MAIN_SRC_DIR}/utils/unittest/googletest/include"
+      CACHE
+      PATH
+      "Path to Google Test include directory"
+    )
   endif()
 else()
   # LLVM's 'gtest' target is not reused


### PR DESCRIPTION
## Summary: 
This PR restores the ability to reuse a `gtest` target exported by LLVM's build tree. This feature was broken by #1569 which removed `AddLLVM.cmake` (required for building LLVM's version of Google Test) globally. After #1569 and this PR, the `gtest` target now needs to be reused whenever `LLVM_DIR` is pointed to an LLVM build tree (think: the result of `make` instead of `make install`) and `LLVM_INCLUDE_TESTS` is `ON` (the default). In particular, this corner of KLEE's build system is no longer hidden behind the `USE_CMAKE_FIND_PACKAGE_LLVM` flag (obsoleted by #1569 and removed in the last spot by this PR). Without this PR, one will instead be just greeted by an error when KLEE tries to build Google Test (the `gtest` target is already defined). When `LLVM_INCLUDE_TESTS` is `OFF`, KLEE does now by default (without `GTEST_SRC_DIR` set) reuse the Google Test copy from the LLVM source tree (if available).

Additionally, in LLVM 13, the previously used `LLVM_EXPORTED_TARGETS` variable is no longer exported. This variable was used to check if the `gtest` target is indeed exported by LLVM. Although the new check is slightly more involved (yet more heuristic), I am for keeping it as debugging the issues that might result from blindly reusing any random `gtest` target (possibly imported by further dependencies in a fork of KLEE) might be more pain than maintaining this piece of code from time to time. To make this easier, I moved the "LLVM target" check to a new function and improved the involved messages and comments a bit.

I tested these changes locally with LLVM 14.0.6 and the following settings (all having an influence on the dependencies of/between `gtest` and `support`):
- default (includes `LLVM_INCLUDE_TESTS=ON`)
- `LLVM_LINK_LLVM_DYLIB=ON`
- `BUILD_SHARED_LIBS=ON`
- `LLVM_INCLUDE_TESTS=OFF` (to ensure building from LLVM's source tree still works)

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
