### PR TITLE
Updates to `unittests/CMakeLists.txt`

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -188,8 +188,7 @@ else()
     )
 
     if (NOT EXISTS "${GTEST_SRC_DIR}")
-      message(FATAL_ERROR "Google Test source directory \"${GTEST_SRC_DIR}\" "
-      "cannot be found.\n"
+      message(FATAL_ERROR "Google Test source directory cannot be found.\n"
       "Try passing -DGTEST_SRC_DIR=<path_to_gtest_source> to CMake where "
       "<path_to_gtest_source> is the path to the Google Test source tree.\n"
       "Alternatively, you can disable unit tests by passing "

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -248,9 +248,6 @@ llvm_config(unittest_main "${USE_LLVM_SHARED}" support)
 target_link_libraries(unittest_main
   PUBLIC
   ${GTEST_TARGET_NAME}
-
-  PRIVATE
-  ${UNITTEST_MAIN_LIBS}
 )
 target_include_directories(unittest_main
   PUBLIC

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -8,36 +8,21 @@
 #===------------------------------------------------------------------------===#
 
 function(add_vanilla_googletest_subdirectory directory)
-  if (POLICY CMP0077)
-    # Prevent Google Test from adding to our install target (Google Test 1.8.0+)
-    # However, this can only be disabled starting with 1.8.1 (a.k.a. 1.9.0)
-    set(INSTALL_GTEST OFF)
+  # Prevent Google Test from adding to our install target (Google Test 1.8.0+)
+  # However, this can only be disabled starting with 1.8.1 (a.k.a. 1.9.0)
+  set(INSTALL_GTEST OFF)
 
-    # Google Mock is currently not used by our tests
-    set(BUILD_GMOCK OFF)
+  # Google Mock is currently not used by our tests
+  set(BUILD_GMOCK OFF)
 
-    # (only) Google Test 1.8.0 with BUILD_GMOCK=OFF needs BUILD_GTEST=ON
-    set(BUILD_GTEST ON)
+  # (only) Google Test 1.8.0 with BUILD_GMOCK=OFF needs BUILD_GTEST=ON
+  set(BUILD_GTEST ON)
 
-    # Make option() in subdirectory respect normal variables (as set above).
-    # NOTE: The enclosing function limits the scope of this policy setting.
-    # FIXME: Remove once all supported Google Test versions require CMake 3.13+
-    #        (or set policy CMP0077 to NEW by themselves)
-    set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-  else()
-    # FIXME: Remove with CMake minimum version 3.13+
-    # Use cache variable workaround as option() ignores normal variables
-
-    # Prevent Google Test from adding to our install target (Google Test 1.8.0+)
-    # However, this can only be disabled starting with 1.8.1 (a.k.a. 1.9.0)
-    set(INSTALL_GTEST OFF CACHE BOOL "disable installing Google Test" FORCE)
-
-    # Google Mock is currently not used by our tests
-    set(BUILD_GMOCK OFF CACHE BOOL "disable building Google Mock" FORCE)
-
-    # (only) Google Test 1.8.0 with BUILD_GMOCK=OFF needs BUILD_GTEST=ON
-    set(BUILD_GTEST ON CACHE BOOL "enable building Google Test" FORCE)
-  endif()
+  # Make option() in subdirectory respect normal variables (as set above).
+  # NOTE: The enclosing function limits the scope of this policy setting.
+  # FIXME: Remove once all supported Google Test versions require CMake 3.13+
+  #        (or set policy CMP0077 to NEW by themselves)
+  set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
   # include Google Test's CMakeLists.txt
   add_subdirectory(${directory} "${CMAKE_CURRENT_BINARY_DIR}/gtest_build")

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -113,14 +113,14 @@ if (TARGET gtest)
       "LLVM from exporting this target.")
   endif()
 
-  # in this case, only include directory has to be set
-  if (LLVM_BUILD_MAIN_SRC_DIR)
-    set(GTEST_INCLUDE_DIR
-      "${LLVM_BUILD_MAIN_SRC_DIR}/utils/unittest/googletest/include"
-      CACHE
-      PATH
-      "Path to Google Test include directory"
-    )
+  # older LLVM versions do not set INTERFACE_INCLUDE_DIRECTORIES for gtest
+  if ("${LLVM_VERSION_MAJOR}" LESS 12)
+    if (IS_DIRECTORY "${LLVM_BUILD_MAIN_SRC_DIR}")
+      target_include_directories(gtest
+        INTERFACE
+        "${LLVM_BUILD_MAIN_SRC_DIR}/utils/unittest/googletest/include"
+      )
+    endif()
   endif()
 else()
   # LLVM's 'gtest' target is not reused
@@ -130,12 +130,6 @@ else()
       # build from LLVM's utils directory
       message(STATUS "Google Test: Building from LLVM's source tree.")
 
-      set(GTEST_INCLUDE_DIR
-        "${LLVM_BUILD_MAIN_SRC_DIR}/utils/unittest/googletest/include"
-        CACHE
-        PATH
-        "Path to Google Test include directory"
-      )
 
       # LLVM replaced Google Test's CMakeLists.txt with its own, which requires
       # add_llvm_library() from AddLLVM.cmake.
@@ -144,6 +138,14 @@ else()
 
       add_subdirectory("${LLVM_BUILD_MAIN_SRC_DIR}/utils/unittest/"
         "${CMAKE_CURRENT_BINARY_DIR}/gtest_build")
+
+      # older LLVM versions do not set INTERFACE_INCLUDE_DIRECTORIES for gtest
+      if ("${LLVM_VERSION_MAJOR}" LESS 12)
+        target_include_directories(gtest
+          INTERFACE
+          "${LLVM_BUILD_MAIN_SRC_DIR}/utils/unittest/googletest/include"
+        )
+      endif()
 
       # add includes for LLVM's modifications
       target_include_directories(gtest BEFORE PRIVATE ${LLVM_INCLUDE_DIRS})
@@ -198,6 +200,12 @@ else()
     message(STATUS "GTEST_SRC_DIR: ${GTEST_SRC_DIR}")
 
     add_vanilla_googletest_subdirectory(${GTEST_SRC_DIR})
+
+    # Google Test versions < 1.8.0 do not set INTERFACE_INCLUDE_DIRECTORIES
+    target_include_directories(gtest
+      INTERFACE
+      ${GTEST_INCLUDE_DIR}
+    )
   endif()
 
   if (NOT GTest_FOUND)
@@ -218,15 +226,6 @@ define_property(GLOBAL
   BRIEF_DOCS "KLEE unit tests"
   FULL_DOCS "KLEE unit tests"
 )
-
-if (NOT GTest_FOUND)
-  # GTEST_INCLUDE_DIR is defined only when we build from sources.
-  if (NOT IS_DIRECTORY "${GTEST_INCLUDE_DIR}")
-    message(FATAL_ERROR
-      "Cannot find Google Test include directory \"${GTEST_INCLUDE_DIR}\"")
-  endif()
-  message(STATUS "GTEST_INCLUDE_DIR: ${GTEST_INCLUDE_DIR}")
-endif()
 
 if (TARGET gtest)
   set(GTEST_TARGET_NAME gtest)
@@ -249,8 +248,7 @@ target_link_libraries(unittest_main
   ${GTEST_TARGET_NAME}
 )
 target_include_directories(unittest_main
-  PUBLIC
-  ${GTEST_INCLUDE_DIR}
+  INTERFACE
   ${KLEE_COMPONENT_EXTRA_INCLUDE_DIRS}
 
   PRIVATE


### PR DESCRIPTION
## Summary: 
This PR removes some obsolete code from `unittests/CMakeLists.txt`:
- policy CMP0077 does not need to be set with CMake 3.16.0 as minimum version (bumped by #1587)
- the `UNITTEST_MAIN_LIBS` variable is no longer set (obsoleted by #1588)

In addition it refactors two things:
- If `GTEST_SRC_DIR` is not found automatically, the error message previously complained that the `Google Test source directory "GTEST_SRC_DIR-NOTFOUND" cannot be found.`
- Most (current) versions of Google Test actually set proper (public) include directories themselves, document and set the include directory ourselves when necessary.

This PR is self-contained in that it only addresses issues in a single file.
**NOTE:** This PR also contains the two commits from #1626 (due to a conflicting change).

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
