### PR TITLE
.clang-format: c++17

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
 ---
-BasedOnStyle:  LLVM
-Standard: Cpp11
+BasedOnStyle: LLVM
+Standard: c++17
 ...


### PR DESCRIPTION
## Summary: 
I noticed that the `.clang-format` file still references C++11; however, [the documentation of `clang-format`](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#standard) told me that this is actually not quite true anymore:

- "`Cpp11` is a deprecated alias for `Latest`"
- `Latest`: "Parse and format using the latest supported language version." (for some time already: C++20)

I'm not sure how relevant this really is, but since I stumbled on it anyway, I've just set the value to `c++17` to make it fixed to the currently supported C++ version which I believe was also the intention before.

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
