### PR TITLE
Re-enable `StackTraceOutput.c` test

### DIFF
--- a/test/Feature/StackTraceOutput.c
+++ b/test/Feature/StackTraceOutput.c
@@ -1,4 +1,3 @@
-// REQUIRES: geq-llvm-7.0
 // RUN: %clang %s -emit-llvm %O0opt -g -c -fdiscard-value-names -o %t.bc
 // RUN: rm -rf %t.klee-out-d
 // RUN: %klee --output-dir=%t.klee-out-d %t.bc
@@ -16,10 +15,10 @@
 void foo(int i, int k) {
   ++i; ++k;
   assert(0);
-  // CHECK-DISCARD: {{.*}} in foo(symbolic, 12) at {{.*}}.c:18
-  // CHECK-DISCARD: {{.*}} in main() at {{.*}}.c:28
-  // CHECK-NODISCARD: {{.*}} in foo(i=symbolic, k=12) at {{.*}}.c:18
-  // CHECK-NODISCARD: {{.*}} in main() at {{.*}}.c:28
+  // CHECK-DISCARD: {{.*}} in foo(symbolic, 12) at {{.*}}.c:17
+  // CHECK-DISCARD: {{.*}} in main() at {{.*}}.c:27
+  // CHECK-NODISCARD: {{.*}} in foo(i=symbolic, k=12) at {{.*}}.c:17
+  // CHECK-NODISCARD: {{.*}} in main() at {{.*}}.c:27
 }
 
 int main(void) {

--- a/test/Feature/StackTraceOutput.c
+++ b/test/Feature/StackTraceOutput.c
@@ -13,16 +13,19 @@
 #include <assert.h>
 
 void foo(int i, int k) {
-  ++i; ++k;
+  ++i;
+  ++k;
+
+  // CHECK-DISCARD: {{.*}} in foo(symbolic, 12) at {{.*}}.c:[[@LINE+2]]
+  // CHECK-NODISCARD: {{.*}} in foo(i=symbolic, k=12) at {{.*}}.c:[[@LINE+1]]
   assert(0);
-  // CHECK-DISCARD: {{.*}} in foo(symbolic, 12) at {{.*}}.c:17
-  // CHECK-DISCARD: {{.*}} in main() at {{.*}}.c:27
-  // CHECK-NODISCARD: {{.*}} in foo(i=symbolic, k=12) at {{.*}}.c:17
-  // CHECK-NODISCARD: {{.*}} in main() at {{.*}}.c:27
 }
 
 int main(void) {
-  int i, k=12;
+  int i, k = 12;
   klee_make_symbolic(&i, sizeof(i), "i");
-  foo(i,k);
+
+  // CHECK-DISCARD: {{.*}} in main() at {{.*}}.c:[[@LINE+2]]
+  // CHECK-NODISCARD: {{.*}} in main() at {{.*}}.c:[[@LINE+1]]
+  foo(i, k);
 }


### PR DESCRIPTION
## Summary: 

This test previously had a REQUIRES line with `geq-llvm-7.0`. Because LLVM version 7.0 is no longer "known" (`test/lit.cfg`), the required feature is not available and the test is discarded as unsupported by `llvm-lit`.
The additional commit cleans the test up a bit (use of `@LINE`, rearrange `CHECK`s, `clang-format`).

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
