### PR TITLE
Fix `fstatat()` null-path detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,11 +405,15 @@ else()
   set(HAVE_SELINUX 0)
 endif()
 
+try_compile (FSTATAT_PATH_ACCEPTS_NULL
+  ${CMAKE_BINARY_DIR}
+  ${PROJECT_SOURCE_DIR}/cmake/fstatat.c
+)
+
 ################################################################################
 # KLEE runtime support
 ################################################################################
 # This is set here and not in `runtime` because `config.h` needs to be generated.
-
 
 set(available_klee_runtime_build_types
   "Release"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,13 +107,14 @@ option(KLEE_ENABLE_TIMESTAMP "Add timestamps to KLEE sources" OFF)
 # Include useful CMake functions
 ################################################################################
 include(GNUInstallDirs)
+include(CheckCSourceCompiles)
 include(CheckCXXSymbolExists)
+include(CheckFunctionExists)
 include(CheckIncludeFile)
 include(CheckIncludeFileCXX)
+include(CheckLibraryExists)
 include(CheckPrototypeDefinition)
 include(CMakePushCheckState)
-include(CheckFunctionExists)
-include(CheckLibraryExists)
 
 ################################################################################
 # Find LLVM
@@ -405,10 +406,20 @@ else()
   set(HAVE_SELINUX 0)
 endif()
 
-try_compile (FSTATAT_PATH_ACCEPTS_NULL
-  ${CMAKE_BINARY_DIR}
-  ${PROJECT_SOURCE_DIR}/cmake/fstatat.c
-)
+cmake_push_check_state()
+check_c_source_compiles("
+        #include <fcntl.h>
+        #include <stddef.h>
+        #include <sys/stat.h>
+
+        int main(void) {
+          struct stat buf;
+          #pragma GCC diagnostic error \"-Wnonnull\"
+          fstatat(0, NULL, &buf, 0);
+        }
+        "
+        FSTATAT_PATH_ACCEPTS_NULL)
+cmake_pop_check_state()
 
 ################################################################################
 # KLEE runtime support

--- a/cmake/fstatat.c
+++ b/cmake/fstatat.c
@@ -1,9 +1,0 @@
-#include <fcntl.h>
-#include <stddef.h>
-#include <sys/stat.h>
-
-int main(void) {
-  struct stat buf;
-  #pragma GCC diagnostic error "-Wnonnull"
-  fstatat(0, NULL, &buf, 0);
-}

--- a/include/klee/Config/config.h.cmin
+++ b/include/klee/Config/config.h.cmin
@@ -13,6 +13,9 @@
 /* Using Z3 Solver backend */
 #cmakedefine ENABLE_Z3 @ENABLE_Z3@
 
+/* Define if fstatat() accepts NULL as pathname argument. */
+#cmakedefine FSTATAT_PATH_ACCEPTS_NULL 1
+
 /* Does the platform use __ctype_b_loc, etc. */
 #cmakedefine HAVE_CTYPE_EXTERNALS @HAVE_CTYPE_EXTERNALS@
 

--- a/runtime/POSIX/CMakeLists.txt
+++ b/runtime/POSIX/CMakeLists.txt
@@ -20,11 +20,6 @@ set(SRC_FILES
         stubs.c
         )
 
-try_compile (FSTATAT_PATH_ACCEPTS_NULL
-        ${CMAKE_BINARY_DIR}
-        ${PROJECT_SOURCE_DIR}/cmake/fstatat.c
-        )
-
 # Build it
 include("${CMAKE_SOURCE_DIR}/cmake/compile_bitcode_library.cmake")
 prefix_with_path("${SRC_FILES}" "${CMAKE_CURRENT_SOURCE_DIR}/" prefixed_files)


### PR DESCRIPTION
## Summary: 
In #1484, @251 successfully fixed a compiler warning. If I understand his changes correctly, however, the second part of keeping the old implementation for header files that do not assume `pathname` to be `nonnull`, seems to have not worked out so well... :wink: 

In short: #1484 introduced a CMake variable `FSTATAT_PATH_ACCEPTS_NULL` and acts on its value via `#ifdef` in 
https://github.com/klee/klee/blob/8301eecbd0ba1ada6cfb3a1fd9da195b6be0ee16/runtime/POSIX/fd.c#L571-L576
However, the value never makes it from CMake into C, as there is no corresponding `#cmakedefine` in `config.h`.
This PR fixes this problem and refactors the code slightly to use `check_c_source_compiles()` instead of a separate file.

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
