### PR TITLE
Fix `BatchingSearcher` ignoring disabled time budget

### DIFF
--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -423,7 +423,7 @@ ExecutionState &BatchingSearcher::selectState() {
         (time::getWallTime() - lastStartTime) > timeBudget)) ||
       ((instructionBudget > 0) &&
        (stats::instructions - lastStartInstructions) > instructionBudget)) {
-    if (lastState) {
+    if (lastState && timeBudget.toSeconds() > 0) {
       time::Span delta = time::getWallTime() - lastStartTime;
       auto t = timeBudget;
       t *= 1.1;

--- a/lib/Core/Searcher.h
+++ b/lib/Core/Searcher.h
@@ -243,12 +243,17 @@ namespace klee {
   /// of instructions.
   class BatchingSearcher final : public Searcher {
     std::unique_ptr<Searcher> baseSearcher;
+    bool timeBudgetEnabled;
     time::Span timeBudget;
+    bool instructionBudgetEnabled;
     unsigned instructionBudget;
 
     ExecutionState *lastState {nullptr};
     time::Point lastStartTime;
     unsigned lastStartInstructions;
+
+    bool withinTimeBudget() const;
+    bool withinInstructionBudget() const;
 
   public:
     /// \param baseSearcher The underlying searcher (takes ownership).

--- a/test/regression/2020-04-11-batching-search-zero-time-budget.c
+++ b/test/regression/2020-04-11-batching-search-zero-time-budget.c
@@ -1,0 +1,16 @@
+// RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --use-batching-search --batch-time=0 --batch-instructions=1 %t.bc 2>&1 | FileCheck %s
+
+#include <time.h>
+
+#include "klee/klee.h"
+
+int main(void) {
+  for (int i = 0; i < 10; ++i) {
+    struct timespec ts = {.tv_sec = 0, .tv_nsec = 10000000}; // 10 ms
+    nanosleep(&ts, NULL);
+  }
+  // CHECK-NOT: increased time budget
+  return 0;
+}


### PR DESCRIPTION
## Summary: 
`BatchingSearcher` has a feature that automatically adjusts the time budget if too much time has passed between two `selectState()` calls. However, there is a bug: The budget is also increased when it was initially disabled (set to 0). Through the increase, the time budget is enabled and thus, `BatchingSearcher` effectively picks a very arbitrary time budget on its own.
Because I believe that the hard-to-read implementation of the function contributed to this bug being introduced, I also refactored it and hopefully made it more readable.

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
