### PR TITLE
ktest-gen: remove unused function

### DIFF
--- a/tools/ktest-gen/ktest-gen.cpp
+++ b/tools/ktest-gen/ktest-gen.cpp
@@ -36,17 +36,6 @@ static void push_obj(KTest *b, const char *name, unsigned total_bytes,
   memcpy(o->bytes, bytes, total_bytes);
 }
 
-static void push_range(KTest *b, const char *name, unsigned value) {
-  KTestObject *o = &b->objects[b->numObjects++];
-  assert(b->numObjects < MAX);
-
-  o->name = strdup(name);
-  o->numBytes = 4;
-  o->bytes = (unsigned char *)malloc(o->numBytes);
-
-  *(unsigned *)o->bytes = value;
-}
-
 void print_usage_and_exit(char *program_name) {
   fprintf(stderr,
     "%s: Tool for generating a ktest file from concrete input, e.g., for using a concrete crashing input as a ktest seed.\n"


### PR DESCRIPTION
The current build throws a warning with gcc 13:

```
klee/tools/ktest-gen/ktest-gen.cpp:39:13: warning: ‘void push_range(KTest*, const char*, unsigned int)’ defined but not used [-Wunused-function]
   39 | static void push_range(KTest *b, const char *name, unsigned value) {
      |             ^~~~~~~~~~
```

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
