### PR TITLE
Rewrote and fixed has_permission in the POSIX runtime

### DIFF
--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -106,32 +106,18 @@ mode_t umask(mode_t mask) {
 
 
 /* Returns 1 if the process has the access rights specified by 'flags'
-   to the file with stat 's'.  Returns 0 otherwise*/
+   to the file with stat 's', and returns 0 otherwise. 
+   We allow access if any user has access to the file, so we ignore 
+   s->st_uid / geteuid() and s->st_gid / getegid(). */
 static int has_permission(int flags, struct stat64 *s) {
-  int write_access, read_access;
   mode_t mode = s->st_mode;
-  
-  if (flags & O_RDONLY || flags & O_RDWR)
-    read_access = 1;
-  else read_access = 0;
+  int read_request = ((flags & O_RDONLY) | (flags & O_RDWR)) ? 1 : 0;
+  int write_request = ((flags & O_WRONLY) | (flags & O_RDWR)) ? 1 : 0;
 
-  if (flags & O_WRONLY || flags & O_RDWR)
-    write_access = 1;
-  else write_access = 0;
-
-  /* XXX: We don't worry about process uid and gid for now. 
-     We allow access if any user has access to the file. */
-#if 0
-  uid_t uid = s->st_uid;
-  uid_t euid = geteuid();
-  gid_t gid = s->st_gid;
-  gid_t egid = getegid();
-#endif  
-
-  if (read_access && ((mode & S_IRUSR) | (mode & S_IRGRP) | (mode & S_IROTH)))
-    return 0;
-
-  if (write_access && !((mode & S_IWUSR) | (mode & S_IWGRP) | (mode & S_IWOTH)))
+  /* It is important to do this check using only bitwise operators so that we 
+     return 0 a single time in symbolic execution mode. */
+  if ((read_request  & !((mode & S_IRUSR) | (mode & S_IRGRP) | (mode & S_IROTH))) |
+      (write_request & !((mode & S_IWUSR) | (mode & S_IWGRP) | (mode & S_IWOTH))))
     return 0;
 
   return 1;

--- a/test/Runtime/POSIX/FilePerm.c
+++ b/test/Runtime/POSIX/FilePerm.c
@@ -1,21 +1,26 @@
+/* This test checks that when opening a symbolic file in R/W mode, we return exactly twice: 
+   once successfully, and the other time with a permission error */
+
 // RUN: %clang %s -emit-llvm %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --posix-runtime %t.bc --sym-files 1 10 --sym-stdout 2>%t.log 
+// RUN: %klee --output-dir=%t.klee-out --posix-runtime %t.bc --sym-files 1 10 | FileCheck %s
 // RUN: test -f %t.klee-out/test000001.ktest
 // RUN: test -f %t.klee-out/test000002.ktest
-// RUN: test -f %t.klee-out/test000003.ktest
+// RUN: not test -f %t.klee-out/test000003.ktest
 
 #include <stdio.h>       
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 int main(int argc, char** argv) {
   int fd = open("A", O_RDWR);
   if (fd != -1)
-    fprintf(stderr, "File 'A' opened successfully\n");
-  else fprintf(stderr, "Cannot open file 'A'\n");
-
+    printf("File 'A' opened successfully\n");
+  // CHECK-DAG: File 'A' opened successfully
+  else printf("Cannot open file 'A'\n");
+  // CHECK-DAG: Cannot open file 'A'
   if (fd != -1)
     close(fd);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Rewrote has_permission in the POSIX runtime. We now only return with permission error a single time in symbolic execution mode.
The rewrite also fixes a bug reported in #1230.
Rewrote the FilePerm.c test accordingly.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
