### PR TITLE
Fix `ktest-randgen`: use after free

### DIFF
--- a/tools/ktest-randgen/ktest-randgen.cpp
+++ b/tools/ktest-randgen/ktest-randgen.cpp
@@ -114,7 +114,6 @@ void create_stat(size_t size, struct stat *s) {
 
   if (write(fd, memset(buf, 0, size), size) != (int)size) {
     free(buf);
-    free(filename);
     error_exit("%s:%d: Error writing %s\n", __FILE__, __LINE__, filename);
   }
 #if defined(__has_feature)


### PR DESCRIPTION
## Summary:
Fixes the following compiler warning:
```
tools/ktest-randgen/ktest-randgen.cpp: In function ‘void create_stat(size_t, stat*)’:
tools/ktest-randgen/ktest-randgen.cpp:118:15: warning: pointer ‘filename’ used after ‘void free(void*)’ [-Wuse-after-free]
  118 |     error_exit("%s:%d: Error writing %s\n", __FILE__, __LINE__, filename);
      |     ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tools/ktest-randgen/ktest-randgen.cpp:117:9: note: call to ‘void free(void*)’ here
  117 |     free(filename);
      |     ~~~~^~~~~~~~~~
```

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
