### PR TITLE
RefTest: suppress `-Wself-move`

### DIFF
--- a/unittests/Ref/RefTest.cpp
+++ b/unittests/Ref/RefTest.cpp
@@ -95,8 +95,11 @@ TEST(RefTest, SelfMove) {
     struct Expr *r_e = new Expr();
     ref<Expr> r(r_e);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
     // Check self move
     r = std::move(r);
+#pragma GCC diagnostic pop
     finished = 1;
   }
   EXPECT_EQ(1, finished_counter);


### PR DESCRIPTION
## Summary: 

This commit suppresses the following warning (introduced with GCC 13, clang apparently added this earlier), which warns about precisely the situation that we want to test:
```
[147/164] Building CXX object unittests/Ref/CMakeFiles/RefTest.dir/RefTest.cpp.o
klee/unittests/Ref/RefTest.cpp: In member function ‘virtual void RefTest_SelfMove_Test::TestBody()’:
klee/unittests/Ref/RefTest.cpp:99:7: warning: moving ‘r’ of type ‘klee::ref<Expr>’ to itself [-Wself-move]
   99 |     r = std::move(r);
      |     ~~^~~~~~~~~~~~~~
klee/unittests/Ref/RefTest.cpp:99:7: note: remove ‘std::move’ call
```


## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
