### PR TITLE
Replaced --suppress-external-warnings and --all-external-warnings wit…

### DIFF
--- a/test/Feature/ExtCallWarnings.c
+++ b/test/Feature/ExtCallWarnings.c
@@ -1,0 +1,26 @@
+// RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
+
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --external-call-warnings=none %t.bc 2>&1 | FileCheck --check-prefix=CHECK-NONE %s
+
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --external-call-warnings=once-per-function %t.bc 2>&1 | FileCheck --check-prefix=CHECK-ONCE %s
+
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --external-call-warnings=all %t.bc 2>&1 | FileCheck --check-prefix=CHECK-ALL %s
+
+#include "klee/klee.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+  return abs(-5) + abs(6);
+  // CHECK-NONE-NOT: calling external
+
+  // CHECK-ONCE: calling external
+  // CHECK-ONCE-NOT: calling external
+
+  // CHECK-ALL: calling external
+  // CHECK-ALL: calling external
+  // CHECK-ALL-NOT: calling external
+}


### PR DESCRIPTION
…h --external-call-warnings=none|once-per-function|all.

This eliminates the ambiguity when both of the old options were set. Added test for the new option.

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
