### PR TITLE
Alignment

### DIFF
--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -363,19 +363,7 @@ ref<Expr> ConstantExpr::fromMemory(void *address, Width width) {
 
 void ConstantExpr::toMemory(void *address) {
   auto width = getWidth();
-  switch (width) {
-  default: assert(0 && "invalid type");
-  case  Expr::Bool: *(( uint8_t*) address) = getZExtValue(1); break;
-  case  Expr::Int8: *(( uint8_t*) address) = getZExtValue(8); break;
-  case Expr::Int16: *((uint16_t*) address) = getZExtValue(16); break;
-  case Expr::Int32: *((uint32_t*) address) = getZExtValue(32); break;
-  case Expr::Int64: *((uint64_t*) address) = getZExtValue(64); break;
-  case Expr::Fl80:
-  case Expr::Int128:
-  case Expr::Int256:
-  case Expr::Int512:
-      std::memcpy(address, value.getRawData(), width / 8);
-  }
+  std::memcpy(address, value.getRawData(), (width + 7) / 8);
 }
 
 void ConstantExpr::toString(std::string &Res, unsigned radix) const {

--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -21,6 +21,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstring>
 #include <sstream>
 
 using namespace klee;
@@ -369,14 +370,11 @@ void ConstantExpr::toMemory(void *address) {
   case Expr::Int16: *((uint16_t*) address) = getZExtValue(16); break;
   case Expr::Int32: *((uint32_t*) address) = getZExtValue(32); break;
   case Expr::Int64: *((uint64_t*) address) = getZExtValue(64); break;
-  // FIXME: what about machines without x87 support?
   case Expr::Fl80:
-    *((long double*) address) = *(const long double*) value.getRawData();
-    break;
   case Expr::Int128:
   case Expr::Int256:
   case Expr::Int512:
-      memcpy(address, value.getRawData(), width / 8);
+      std::memcpy(address, value.getRawData(), width / 8);
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
It is not guaranteed that the raw data of an apint has alignment sufficient for a long double. Using `std::memcpy` instead of trying to do a copy using a C-style `reinterpret_cast` removes this problem and simplifies the code. (Note that `klee::Expr::Fl80` has the value 80.)

There is no functional change in calling `memcpy` by its proper name `std::memcpy`. (If it compiled for you before, it will still compile now.)

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
