### PR TITLE
Simplify KDAlloc tests

### DIFF
--- a/unittests/KDAlloc/CMakeLists.txt
+++ b/unittests/KDAlloc/CMakeLists.txt
@@ -5,7 +5,7 @@ add_klee_unit_test(KDAllocTest
   rusage.cpp
   sample.cpp
   stacktest.cpp)
-target_compile_definitions(KDAllocTest PRIVATE KDALLOC_CHECKED USE_KDALLOC USE_GTEST_INSTEAD_OF_MAIN)
+target_compile_definitions(KDAllocTest PRIVATE USE_GTEST_INSTEAD_OF_MAIN)
 target_compile_definitions(KDAllocTest PRIVATE ${KLEE_COMPONENT_CXX_DEFINES})
 target_compile_options(KDAllocTest PRIVATE ${KLEE_COMPONENT_CXX_FLAGS})
 target_include_directories(KDAllocTest PRIVATE ${KLEE_INCLUDE_DIRS})

--- a/unittests/KDAlloc/allocate.cpp
+++ b/unittests/KDAlloc/allocate.cpp
@@ -18,11 +18,7 @@
 #include <iomanip>
 #include <iostream>
 
-#if defined(USE_GTEST_INSTEAD_OF_MAIN)
-int allocate_sample_test() {
-#else
-int main() {
-#endif
+void allocate_sample_test() {
   // initialize a factory and an associated allocator (1 MiB and no quarantine)
   klee::kdalloc::AllocatorFactory factory(static_cast<std::size_t>(1) << 20, 0);
   klee::kdalloc::Allocator allocator = factory.makeAllocator();
@@ -62,4 +58,6 @@ int main() {
 TEST(KDAllocDeathTest, AllocateSample) {
   ASSERT_EXIT(allocate_sample_test(), ::testing::ExitedWithCode(0), "");
 }
+#else
+int main() { allocate_sample_test(); }
 #endif

--- a/unittests/KDAlloc/randomtest.cpp
+++ b/unittests/KDAlloc/randomtest.cpp
@@ -15,7 +15,6 @@
 #endif
 
 #include <cassert>
-#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -126,18 +125,8 @@ public:
 } // namespace
 
 void random_test() {
-  auto start = std::chrono::steady_clock::now();
-
   RandomTest tester;
   tester.run(1'000'000);
-
-  auto stop = std::chrono::steady_clock::now();
-  std::cout << std::dec
-            << std::chrono::duration_cast<std::chrono::milliseconds>(stop -
-                                                                     start)
-                   .count()
-            << " ms\n";
-  std::cout << "\n";
 
   std::cout << "Allocations: " << tester.allocation_count << "\n";
   std::cout << "Deallocations: " << tester.deallocation_count << "\n";

--- a/unittests/KDAlloc/reuse.cpp
+++ b/unittests/KDAlloc/reuse.cpp
@@ -19,11 +19,7 @@
 #include <iostream>
 #include <unordered_set>
 
-#if defined(USE_GTEST_INSTEAD_OF_MAIN)
-int reuse_test() {
-#else
-int main() {
-#endif
+void reuse_test() {
   {
     static const std::size_t size = 8;
     static const std::uint32_t quarantine = 0;
@@ -131,4 +127,6 @@ int main() {
 TEST(KDAllocDeathTest, Reuse) {
   ASSERT_EXIT(reuse_test(), ::testing::ExitedWithCode(0), "");
 }
+#else
+int main() { reuse_test(); }
 #endif

--- a/unittests/KDAlloc/sample.cpp
+++ b/unittests/KDAlloc/sample.cpp
@@ -15,11 +15,7 @@
 
 #include <cassert>
 
-#if defined(USE_GTEST_INSTEAD_OF_MAIN)
-int sample_test() {
-#else
-int main() {
-#endif
+void sample_test() {
   // initialize a factory and an associated allocator (1 TiB and no quarantine)
   klee::kdalloc::AllocatorFactory factory(static_cast<std::size_t>(1) << 40, 0);
   klee::kdalloc::Allocator allocator = factory.makeAllocator();
@@ -64,4 +60,6 @@ int main() {
 TEST(KDAllocDeathTest, Sample) {
   ASSERT_EXIT(sample_test(), ::testing::ExitedWithCode(0), "");
 }
+#else
+int main() { sample_test(); }
 #endif

--- a/unittests/KDAlloc/stacktest.cpp
+++ b/unittests/KDAlloc/stacktest.cpp
@@ -15,7 +15,6 @@
 #endif
 
 #include <cassert>
-#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -111,18 +110,8 @@ public:
 } // namespace
 
 void stack_test() {
-  auto start = std::chrono::steady_clock::now();
-
   RandomTest tester;
   tester.run(10'000'000);
-
-  auto stop = std::chrono::steady_clock::now();
-  std::cout << std::dec
-            << std::chrono::duration_cast<std::chrono::milliseconds>(stop -
-                                                                     start)
-                   .count()
-            << " ms\n";
-  std::cout << "\n";
 
   std::cout << "Allocations: " << tester.allocation_count << "\n";
   std::cout << "Deallocations: " << tester.deallocation_count << "\n";


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Simplifies KDAlloc tests by:
1. Removing the ability to use them for simple benchmarks against `std::malloc`. (Rationale: We use KLEE runs to compare against the `std::malloc` based allocator, reduces complexity)
2. Removing an unused define (`KDALLOC_CHECKED` is not honored anymore, as all checks are now asserts, as per the merge of KDAlloc into mainline KLEE)
3. Reorganizing the use of `USE_GTEST_INSTEAD_OF_MAIN` to be more localized.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
