### PR TITLE
Kdalloc location info

### DIFF
--- a/include/klee/KDAlloc/allocator.h
+++ b/include/klee/KDAlloc/allocator.h
@@ -348,8 +348,8 @@ public:
     }
   }
 
-  LocationInfo location_info(void const *const ptr,
-                             std::size_t const size) const noexcept {
+  LocationInfo locationInfo(void const *const ptr,
+                            std::size_t const size) const noexcept {
     assert(*this && "Invalid allocator");
 
     if (!ptr || reinterpret_cast<std::uintptr_t>(ptr) < 4096) {

--- a/include/klee/KDAlloc/suballocators/cow_ptr.h
+++ b/include/klee/KDAlloc/suballocators/cow_ptr.h
@@ -87,41 +87,26 @@ public:
   /// Accesses an existing object.
   /// Must not be called when `*this` is in an empty state.
   T const &operator*() const noexcept {
-    assert(ptr && "the `CoWPtr` must not be empty");
-    return get();
+    assert(!isEmpty() && "the `CoWPtr` must not be empty");
+    return *get();
   }
 
   /// Accesses an existing object.
   /// Must not be called when `*this` is in an empty state.
   T const *operator->() const noexcept {
-    assert(ptr && "the `CoWPtr` must not be empty");
-    return &get();
+    assert(!isEmpty() && "the `CoWPtr` must not be empty");
+    return get();
   }
 
-  /// Accesses an existing object.
-  /// Must not be called when `*this` is in an empty state.
-  T const &get() const noexcept {
-    assert(ptr && "the `CoWPtr` must not be empty");
-    return ptr->data;
-  }
+  /// Gets a pointer to the managed object.
+  /// Returns `nullptr` if no object is currently managed.
+  T const *get() const noexcept { return ptr ? &ptr->data : nullptr; }
 
-  /// Accesses an existing, owned object.
+  /// Gets a pointer to an existing, owned object.
   /// Must not be called when `*this` does not hold CoW ownership.
-  T &getOwned() noexcept {
+  T *getOwned() noexcept {
     assert(isOwned() && "the `CoWPtr` must be owned");
-    return ptr->data;
-  }
-
-  /// Accesses an existing, owned object.
-  /// Must not be called when `*this` does not hold CoW ownership.
-  ///
-  /// Note: This function is included for completeness' sake. Instead of calling
-  /// `getOwned` on a constant, one should probably just call `get` as it
-  /// produces the same result without requiring the target object to hold
-  /// ownership of the data.
-  T const &getOwned() const noexcept {
-    assert(isOwned() && "the `CoWPtr` must be owned");
-    return ptr->data;
+    return &ptr->data;
   }
 
   /// Acquires CoW ownership of an existing object and returns a reference to
@@ -132,7 +117,7 @@ public:
     assert(ptr->referenceCount > 0);
     if (ptr->referenceCount > 1) {
       --ptr->referenceCount;
-      ptr = new Wrapper(*ptr);
+      ptr = new Wrapper{*ptr};
       ptr->referenceCount = 1;
     }
     assert(ptr->referenceCount == 1);

--- a/include/klee/KDAlloc/suballocators/sized_regions.h
+++ b/include/klee/KDAlloc/suballocators/sized_regions.h
@@ -162,7 +162,7 @@ public:
   [[nodiscard]] std::size_t getSize(char const *const address) const noexcept {
     assert(root && "Cannot get size from an empty treap");
 
-    Node const *currentNode = &*root;
+    Node const *currentNode = root.get();
     Node const *closestPredecessor = nullptr;
     Node const *closestSuccessor = nullptr;
     while (currentNode) {
@@ -170,12 +170,12 @@ public:
         assert(!closestSuccessor || currentNode->getBaseAddress() <
                                         closestSuccessor->getBaseAddress());
         closestSuccessor = currentNode;
-        currentNode = &*currentNode->lhs;
+        currentNode = currentNode->lhs.get();
       } else {
         assert(!closestPredecessor || currentNode->getBaseAddress() >
                                           closestPredecessor->getBaseAddress());
         closestPredecessor = currentNode;
-        currentNode = &*currentNode->rhs;
+        currentNode = currentNode->rhs.get();
       }
     }
 
@@ -195,7 +195,7 @@ public:
                                       std::size_t const size) const noexcept {
     assert(root && "Cannot compute location info for an empty treap");
 
-    Node const *currentNode = &*root;
+    Node const *currentNode = root.get();
     Node const *closestPredecessor = nullptr;
     for (;;) {
       if (currentNode->getBaseAddress() <= address) {
@@ -213,7 +213,7 @@ public:
                     closestPredecessor->getBaseAddress() +
                         closestPredecessor->getSize()};
           }
-          currentNode = &*currentNode->rhs;
+          currentNode = currentNode->rhs.get();
         }
       } else {
         assert(closestPredecessor &&
@@ -229,7 +229,7 @@ public:
                   closestPredecessor->getBaseAddress() +
                       closestPredecessor->getSize()};
         }
-        currentNode = &*currentNode->lhs;
+        currentNode = currentNode->lhs.get();
       }
     }
   }
@@ -307,7 +307,7 @@ private:
       target = &targetNode.lhs;
     }
 
-    update.getOwned().rhs = std::move(rhs);
+    update.getOwned()->rhs = std::move(rhs);
     *target = std::move(update);
   }
 
@@ -324,7 +324,7 @@ private:
       target = &targetNode.rhs;
     }
 
-    update.getOwned().lhs = std::move(lhs);
+    update.getOwned()->lhs = std::move(lhs);
     *target = std::move(update);
   }
 
@@ -423,9 +423,8 @@ public:
     CoWPtr<Node> *closestSuccessor = nullptr;
     for (;;) {
       if (address < (*currentNode)->getBaseAddress()) {
-        assert(!closestSuccessor ||
-               (*currentNode)->getBaseAddress() <
-                   (*closestSuccessor)->getBaseAddress());
+        assert(!closestSuccessor || (*currentNode)->getBaseAddress() <
+                                        (*closestSuccessor)->getBaseAddress());
         closestSuccessor = currentNode;
         if ((*currentNode)->lhs) {
           currentNode = &currentNode->acquire().lhs;

--- a/include/klee/KDAlloc/suballocators/sized_regions.h
+++ b/include/klee/KDAlloc/suballocators/sized_regions.h
@@ -193,7 +193,7 @@ public:
   /// the beginning and end and in between any two allocations.
   inline LocationInfo getLocationInfo(char const *const address,
                                       std::size_t const size) const noexcept {
-    assert(root && "Cannot compute location_info for an empty treap");
+    assert(root && "Cannot compute location info for an empty treap");
 
     Node const *currentNode = &*root;
     Node const *closestPredecessor = nullptr;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4255,9 +4255,9 @@ void Executor::resolveExact(ExecutionState &state,
     if (MemoryManager::isDeterministic && CE) {
       using kdalloc::LocationInfo;
       auto ptr = reinterpret_cast<void *>(CE->getZExtValue());
-      auto locinfo = unbound->heapAllocator.location_info(ptr, 1);
-      if (locinfo == LocationInfo::LI_AllocatedOrQuarantined &&
-          locinfo.getBaseAddress() == ptr && name == "free") {
+      auto li = unbound->heapAllocator.locationInfo(ptr, 1);
+      if (li == LocationInfo::LI_AllocatedOrQuarantined &&
+          li.getBaseAddress() == ptr && name == "free") {
         terminateStateOnProgramError(*unbound, "memory error: double free",
                                      StateTerminationType::Ptr,
                                      getAddressInfo(*unbound, p));
@@ -4400,7 +4400,7 @@ void Executor::executeMemoryOperation(ExecutionState &state,
           return;
         } else if (MemoryManager::isDeterministic) {
           using kdalloc::LocationInfo;
-          auto li = unbound->heapAllocator.location_info(ptr, bytes);
+          auto li = unbound->heapAllocator.locationInfo(ptr, bytes);
           if (li == LocationInfo::LI_AllocatedOrQuarantined) {
             // In case there is no size mismatch (checked by resolving for base
             // address), the object is quarantined.

--- a/unittests/KDAlloc/randomtest.cpp
+++ b/unittests/KDAlloc/randomtest.cpp
@@ -78,16 +78,16 @@ public:
       auto choice = std::uniform_int_distribution<std::size_t>(
           0, allocations.size() - 1)(rng);
 #if defined(USE_KDALLOC)
-      assert(allocator.location_info(allocations[choice].first, 1) ==
+      assert(allocator.locationInfo(allocations[choice].first, 1) ==
              klee::kdalloc::LocationInfo::LI_AllocatedOrQuarantined);
-      assert(allocator.location_info(allocations[choice].first,
-                                     allocations[choice].second) ==
+      assert(allocator.locationInfo(allocations[choice].first,
+                                    allocations[choice].second) ==
              klee::kdalloc::LocationInfo::LI_AllocatedOrQuarantined);
       allocator.free(allocations[choice].first, allocations[choice].second);
-      assert(allocator.location_info(allocations[choice].first, 1) ==
+      assert(allocator.locationInfo(allocations[choice].first, 1) ==
              klee::kdalloc::LocationInfo::LI_Unallocated);
-      assert(allocator.location_info(allocations[choice].first,
-                                     allocations[choice].second) ==
+      assert(allocator.locationInfo(allocations[choice].first,
+                                    allocations[choice].second) ==
              klee::kdalloc::LocationInfo::LI_Unallocated);
 #else
       free(allocations[choice].first);

--- a/unittests/KDAlloc/randomtest.cpp
+++ b/unittests/KDAlloc/randomtest.cpp
@@ -78,7 +78,17 @@ public:
       auto choice = std::uniform_int_distribution<std::size_t>(
           0, allocations.size() - 1)(rng);
 #if defined(USE_KDALLOC)
+      assert(allocator.location_info(allocations[choice].first, 1) ==
+             klee::kdalloc::LocationInfo::LI_AllocatedOrQuarantined);
+      assert(allocator.location_info(allocations[choice].first,
+                                     allocations[choice].second) ==
+             klee::kdalloc::LocationInfo::LI_AllocatedOrQuarantined);
       allocator.free(allocations[choice].first, allocations[choice].second);
+      assert(allocator.location_info(allocations[choice].first, 1) ==
+             klee::kdalloc::LocationInfo::LI_Unallocated);
+      assert(allocator.location_info(allocations[choice].first,
+                                     allocations[choice].second) ==
+             klee::kdalloc::LocationInfo::LI_Unallocated);
 #else
       free(allocations[choice].first);
 #endif
@@ -152,7 +162,7 @@ int main() {
   auto start = std::chrono::steady_clock::now();
 
   RandomTest tester;
-  tester.run(10'000'000);
+  tester.run(1'000'000);
 
   auto stop = std::chrono::steady_clock::now();
   std::cout << std::dec


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
This MR adds a few checks on the returned `LocationInfo`s in KDAllocs random test. As these checks fail, we then reimplement the LOH location info functionality in the same style as its (newer) `getSize` functionality. This makes the improved test pass again =).

The bugs that this PR should fix revolve around potential null pointer dereferences (in the treap, we used to do `&*node->lhs` in the hope that it returns a null pointer if `node->lhs` does not hold a value, which it does not) and wrong assumptions (the predecessor is only guaranteed to exist at the very end).

This change makes `getSize` and `getLocationInfo` look very similar for the treap. They are not quite the same, as they look up slightly different information. At the moment we have no use for a combined function that would perform the lookup only once.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
