### PR TITLE
Change some tests to assume KDAlloc and make KDAlloc the default memory allocator.

### DIFF
--- a/lib/Core/MemoryManager.cpp
+++ b/lib/Core/MemoryManager.cpp
@@ -49,8 +49,8 @@ llvm::cl::OptionCategory MemoryCat("Memory management options",
 
 llvm::cl::opt<bool, true> DeterministicAllocation(
     "kdalloc",
-    llvm::cl::desc("Allocate memory deterministically (default=false)"),
-    llvm::cl::location(MemoryManager::isDeterministic), llvm::cl::init(false),
+    llvm::cl::desc("Allocate memory deterministically (default=true)"),
+    llvm::cl::location(MemoryManager::isDeterministic), llvm::cl::init(true),
     llvm::cl::cat(MemoryCat));
 
 llvm::cl::opt<bool> DeterministicAllocationMarkAsUnneeded(

--- a/test/Feature/DoubleFree.c
+++ b/test/Feature/DoubleFree.c
@@ -1,12 +1,14 @@
 // RUN: %clang %s -emit-llvm %O0opt -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --kdalloc %t1.bc 2>&1 | FileCheck %s
 // RUN: test -f %t.klee-out/test000001.ptr.err
 
+#include <stdlib.h>
+
 int main() {
-  int *x = malloc(4);
+  int *x = malloc(sizeof(*x));
   free(x);
-  // CHECK: memory error: invalid pointer: free
+  // CHECK: memory error: double free
   free(x);
   return 0;
 }

--- a/test/Feature/MultipleFreeResolution.c
+++ b/test/Feature/MultipleFreeResolution.c
@@ -1,8 +1,10 @@
 // RUN: %clang %s -g -emit-llvm %O0opt -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors %t1.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --kdalloc --emit-all-errors %t1.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 4
 // RUN: ls %t.klee-out/ | grep .err | wc -l | grep 3
+
+#include "klee/klee.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -34,9 +36,9 @@ int main() {
   free(buf[s]);
 
   for (i = 0; i < 3; i++) {
-    // CHECK: MultipleFreeResolution.c:[[@LINE+3]]: memory error: out of bound pointer
-    // CHECK: MultipleFreeResolution.c:[[@LINE+2]]: memory error: out of bound pointer
-    // CHECK: MultipleFreeResolution.c:[[@LINE+1]]: memory error: out of bound pointer
+    // CHECK: MultipleFreeResolution.c:[[@LINE+3]]: memory error: use after free
+    // CHECK: MultipleFreeResolution.c:[[@LINE+2]]: memory error: use after free
+    // CHECK: MultipleFreeResolution.c:[[@LINE+1]]: memory error: use after free
     printf("*buf[%d] = %d\n", i, *buf[i]);
   }
 

--- a/test/Feature/OneFreeError.c
+++ b/test/Feature/OneFreeError.c
@@ -1,12 +1,14 @@
 // RUN: %clang %s -g -emit-llvm %O0opt -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out %t1.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --kdalloc %t1.bc 2>&1 | FileCheck %s
 // RUN: test -f %t.klee-out/test000001.ptr.err
 
+#include <stdlib.h>
+
 int main() {
-  int *x = malloc(4);
+  int *x = malloc(sizeof(*x));
   free(x);
-  // CHECK: OneFreeError.c:[[@LINE+1]]: memory error: out of bound pointer
+  // CHECK: OneFreeError.c:[[@LINE+1]]: memory error: use after free
   x[0] = 1;
   return 0;
 }

--- a/test/regression/2007-10-11-illegal-access-after-free-and-branch.c
+++ b/test/regression/2007-10-11-illegal-access-after-free-and-branch.c
@@ -1,21 +1,21 @@
 // RUN: %clang %s -emit-llvm -g -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --optimize %t1.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --kdalloc --optimize %t1.bc 2>&1 | FileCheck %s
 // RUN: test -f %t.klee-out/test000001.ptr.err
 
+#include "klee/klee.h"
+
 #include <stdlib.h>
-#include <stdio.h>
-#include <assert.h>
 
 int main(int argc, char **argv) {
   unsigned char *buf = malloc(3);
   klee_make_symbolic(buf, 3, "buf");
-  if (buf[0]>4) klee_silent_exit(0);
+  if (buf[0] > 4)
+    klee_silent_exit(0);
   unsigned char x = buf[1];
   free(buf);
-  if (x)
-  {
-    // CHECK: 2007-10-11-illegal-access-after-free-and-branch.c:19: memory error: out of bound pointer
+  if (x) {
+    // CHECK: 2007-10-11-illegal-access-after-free-and-branch.c:[[@LINE+1]]: memory error: use after free
     return buf[2];
   }
   klee_silent_exit(0);


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Changed some tests to assume KDAlloc and made KDAlloc the default memory allocator.
Based on the recent experiments with KDAlloc in the group, I think we are ready to make it the default option!

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
