### PR TITLE
replace deprecated (as of c++20) std::is_pod with std::trivial && std::is_standard_layout

### DIFF
--- a/include/klee/KDAlloc/suballocators/slot_allocator.h
+++ b/include/klee/KDAlloc/suballocators/slot_allocator.h
@@ -25,8 +25,7 @@
 
 namespace klee::kdalloc::suballocators {
 namespace slotallocator {
-template<bool UnlimitedQuarantine>
-class SlotAllocator;
+template <bool UnlimitedQuarantine> class SlotAllocator;
 
 struct Data final {
   /// The reference count.
@@ -51,8 +50,7 @@ struct Data final {
 };
 
 class Control final : public TaggedLogger<Control> {
-  template<bool UnlimitedQuarantine>
-  friend class SlotAllocator;
+  template <bool UnlimitedQuarantine> friend class SlotAllocator;
 
   /// pointer to the start of the range managed by this allocator
   char *baseAddress = nullptr;
@@ -161,12 +159,14 @@ public:
   }
 };
 
-template<>
+template <>
 class SlotAllocator<false> final : public TaggedLogger<SlotAllocator<false>> {
   static_assert(static_cast<std::size_t>(-1) == ~static_cast<std::size_t>(0),
                 "-1 must be ~0 for size_t");
 
-  static_assert(std::is_pod<Data>::value, "Data must be POD");
+  static_assert(std::is_trivial<Data>::value &&
+                    std::is_standard_layout<Data>::value,
+                "Data must be POD");
 
   Data *data = nullptr;
 
@@ -533,8 +533,7 @@ public:
   }
 };
 
-
-template<>
+template <>
 class SlotAllocator<true> final : public TaggedLogger<SlotAllocator<true>> {
   std::size_t next;
 


### PR DESCRIPTION

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
This just removes a warning in C++20 compilers and should have no impact on behavior at all.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
