### PR TITLE
Concretize values based on seeds when available, remove --zero-seed-extension and improve/fix seeding code

### DIFF
--- a/include/klee/Expr/Assignment.h
+++ b/include/klee/Expr/Assignment.h
@@ -44,7 +44,7 @@ namespace klee {
     }
     
     ref<Expr> evaluate(const Array *mo, unsigned index) const;
-    ref<Expr> evaluate(ref<Expr> e);
+    ref<Expr> evaluate(ref<Expr> e) const;
     ConstraintSet createConstraintsFromAssignment() const;
 
     template<typename InputIterator>
@@ -82,7 +82,7 @@ namespace klee {
     }
   }
 
-  inline ref<Expr> Assignment::evaluate(ref<Expr> e) { 
+  inline ref<Expr> Assignment::evaluate(ref<Expr> e) const { 
     AssignmentEvaluator v(*this);
     return v.visit(e); 
   }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1343,7 +1343,7 @@ Executor::toConstant(ExecutionState &state,
 ref<klee::Expr>
 Executor::getValueFromSeeds(std::vector<SeedInfo> &seeds, ref<Expr> e) {
   assert(!seeds.empty());
-  for (auto seed:seeds) {
+  for (auto const &seed : seeds) {
     auto value = seed.assignment.evaluate(e);
     if (isa<ConstantExpr>(value))
       return value;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4148,24 +4148,30 @@ void Executor::executeAlloc(ExecutionState &state,
     size = optimizer.optimizeExpr(size, true);
 
     ref<ConstantExpr> example;
-    bool success =
-        solver->getValue(state.constraints, size, example, state.queryMetaData);
-    assert(success && "FIXME: Unhandled solver failure");
-    (void) success;
-    
-    // Try and start with a small example.
-    Expr::Width W = example->getWidth();
-    while (example->Ugt(ConstantExpr::alloc(128, W))->isTrue()) {
-      ref<ConstantExpr> tmp = example->LShr(ConstantExpr::alloc(1, W));
-      bool res;
-      bool success =
-          solver->mayBeTrue(state.constraints, EqExpr::create(tmp, size), res,
-                            state.queryMetaData);
-      assert(success && "FIXME: Unhandled solver failure");      
-      (void) success;
-      if (!res)
-        break;
-      example = tmp;
+    // Check if in seed mode, then try to replicate size from a seed
+    ref<Expr> value = nullptr;
+    if (auto found = seedMap.find(&state); found != seedMap.end())
+      value = getValueFromSeeds(found->second, size);
+    /* If no seed evaluation results in a constant, call the solver */
+    if (!value || !(example = dyn_cast<ConstantExpr>(value))) {
+      bool success = solver->getValue(state.constraints, size, example,
+                                      state.queryMetaData);
+      assert(success && "FIXME: Unhandled solver failure");
+      (void)success;
+
+      // Try and start with a small example.
+      Expr::Width W = example->getWidth();
+      while (example->Ugt(ConstantExpr::alloc(128, W))->isTrue()) {
+        ref<ConstantExpr> tmp = example->LShr(ConstantExpr::alloc(1, W));
+        bool res;
+        [[maybe_unused]] bool success =
+            solver->mayBeTrue(state.constraints, EqExpr::create(tmp, size), res,
+                              state.queryMetaData);
+        assert(success && "FIXME: Unhandled solver failure");
+        if (!res)
+          break;
+        example = tmp;
+      }
     }
 
     StatePair fixedSize =
@@ -4192,8 +4198,9 @@ void Executor::executeAlloc(ExecutionState &state,
         // malloc will fail for it, so lets fork and return 0.
         StatePair hugeSize =
             fork(*fixedSize.second,
-                 UltExpr::create(ConstantExpr::alloc(1U << 31, W), size), true,
-                 BranchType::Alloc);
+                 UltExpr::create(
+                     ConstantExpr::alloc(1U << 31, example->getWidth()), size),
+                 true, BranchType::Alloc);
         if (hugeSize.first) {
           klee_message("NOTE: found huge malloc, returning 0");
           bindLocal(target, *hugeSize.first, 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1313,11 +1313,8 @@ Executor::toConstant(ExecutionState &state,
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(e))
     return CE;
 
-  ref<Expr> value;
-  if (auto found = seedMap.find(&state); found != seedMap.end())
-    value = getValueFromSeeds(found->second, e);
   /* If no seed evaluation results in a constant, call the solver */
-  ref<ConstantExpr> cvalue = llvm::dyn_cast_or_null<ConstantExpr>(value);
+  ref<ConstantExpr> cvalue = getValueFromSeeds(state, e);
   if (!cvalue) {
     [[maybe_unused]] bool success =
         solver->getValue(state.constraints, e, cvalue, state.queryMetaData);
@@ -1340,9 +1337,13 @@ Executor::toConstant(ExecutionState &state,
   return cvalue;
 }
 
-ref<klee::Expr>
-Executor::getValueFromSeeds(std::vector<SeedInfo> &seeds, ref<Expr> e) {
-  assert(!seeds.empty());
+ref<klee::ConstantExpr> Executor::getValueFromSeeds(ExecutionState &state,
+                                                    ref<Expr> e) {
+  auto found = seedMap.find(&state);
+  if (found == seedMap.end())
+    return nullptr;
+
+  auto seeds = found->second;
   for (auto const &seed : seeds) {
     auto value = seed.assignment.evaluate(e);
     if (isa<ConstantExpr>(value))
@@ -3901,12 +3902,9 @@ void Executor::callExternalFunction(ExecutionState &state,
        ae = arguments.end(); ai!=ae; ++ai) {
     if (ExternalCalls == ExternalCallPolicy::All) { // don't bother checking uniqueness
       *ai = optimizer.optimizeExpr(*ai, true);
-      ref<ConstantExpr> cvalue;
-      ref<Expr> value = nullptr;
-      if (auto found = seedMap.find(&state); found != seedMap.end())
-        value = getValueFromSeeds(found->second, *ai);
+      ref<ConstantExpr> cvalue = getValueFromSeeds(state, *ai);
       /* If no seed evaluation results in a constant, call the solver */
-      if (!value || !(cvalue = dyn_cast<ConstantExpr>(value))) {
+      if (!cvalue) {
         [[maybe_unused]] bool success = solver->getValue(
             state.constraints, *ai, cvalue, state.queryMetaData);
         assert(success && "FIXME: Unhandled solver failure");
@@ -4139,13 +4137,9 @@ void Executor::executeAlloc(ExecutionState &state,
 
     size = optimizer.optimizeExpr(size, true);
 
-    ref<ConstantExpr> example;
     // Check if in seed mode, then try to replicate size from a seed
-    ref<Expr> value = nullptr;
-    if (auto found = seedMap.find(&state); found != seedMap.end())
-      value = getValueFromSeeds(found->second, size);
-    /* If no seed evaluation results in a constant, call the solver */
-    if (!value || !(example = dyn_cast<ConstantExpr>(value))) {
+    ref<ConstantExpr> example = getValueFromSeeds(state, size);
+    if (!example) {
       bool success = solver->getValue(state.constraints, size, example,
                                       state.queryMetaData);
       assert(success && "FIXME: Unhandled solver failure");

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -402,8 +402,7 @@ private:
   /// first one that results in a constant, if such a seed exist.  Otherwise,
   /// return the non-constant evaluation of the expression under one of the
   /// seeds.
-  ref<klee::Expr> getValueFromSeeds(std::vector<SeedInfo> &seeds,
-                                            ref<Expr> e);
+  ref<klee::ConstantExpr> getValueFromSeeds(ExecutionState &state, ref<Expr> e);
 
   /// Bind a constant value for e to the given target. NOTE: This
   /// function may fork state if the state has multiple seeds.

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -398,6 +398,13 @@ private:
   ref<klee::ConstantExpr> toConstant(ExecutionState &state, ref<Expr> e, 
                                      const char *purpose);
 
+  /// Evaluate the given expression under each seed, and return the
+  /// first one that results in a constant, if such a seed exist.  Otherwise,
+  /// return the non-constant evaluation of the expression under one of the
+  /// seeds.
+  ref<klee::Expr> getValueFromSeeds(std::vector<SeedInfo> &seeds,
+                                            ref<Expr> e);
+
   /// Bind a constant value for e to the given target. NOTE: This
   /// function may fork state if the state has multiple seeds.
   void executeGetValue(ExecutionState &state, ref<Expr> e, KInstruction *target);

--- a/test/Feature/SeedConcretizeExtendFP.c
+++ b/test/Feature/SeedConcretizeExtendFP.c
@@ -8,6 +8,7 @@
 
 // RUN: rm -rf %t.klee-out-2
 // RUN: %klee --exit-on-error --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest --allow-seed-extension %t.bc 2>&1 | FileCheck %s
+// RUN: %klee-stats --print-columns 'SolverQueries' --table-format=csv %t.klee-out-2 | FileCheck --check-prefix=CHECK-STATS %s
 
 #include "klee/klee.h"
 
@@ -30,4 +31,7 @@ int main() {
     // CHECK: concretizing (reason: floating point)
     assert((unsigned) d < 5001);
   }
+
+  // CHECK-STATS: 3
+  // These is similar to SeedConcretizeFP.c (1 query) plus the extra queries due to an incomplete seed
 }

--- a/test/Feature/SeedConcretizeExtendFP.c
+++ b/test/Feature/SeedConcretizeExtendFP.c
@@ -7,7 +7,7 @@
 // RUN: not test -f %t.klee-out/test000002.ktest
 
 // RUN: rm -rf %t.klee-out-2
-// RUN: %klee --exit-on-error --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest --allow-seed-extension --zero-seed-extension %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --exit-on-error --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest --allow-seed-extension %t.bc 2>&1 | FileCheck %s
 
 #include "klee/klee.h"
 

--- a/test/Feature/SeedConcretizeExternalCall.c
+++ b/test/Feature/SeedConcretizeExternalCall.c
@@ -1,0 +1,25 @@
+// RUN: %clang -emit-llvm -c -g %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --entry-point=TestGen %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: not test -f %t.klee-out/test000002.ktest
+
+// RUN: rm -rf %t.klee-out-2
+// RUN: %klee --external-calls=all --exit-on-error --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest %t.bc
+
+#include "klee/klee.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+void TestGen() {
+  int x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_assume(x == 12345678);
+}
+
+int main() {
+  int x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  assert(abs(x) == 12345678);
+}

--- a/test/Feature/SeedConcretizeExternalCall.c
+++ b/test/Feature/SeedConcretizeExternalCall.c
@@ -6,6 +6,7 @@
 
 // RUN: rm -rf %t.klee-out-2
 // RUN: %klee --external-calls=all --exit-on-error --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest %t.bc
+// RUN: %klee-stats --print-columns 'SolverQueries' --table-format=csv %t.klee-out-2 | FileCheck --check-prefix=CHECK-STATS %s
 
 #include "klee/klee.h"
 
@@ -22,4 +23,7 @@ int main() {
   int x;
   klee_make_symbolic(&x, sizeof(x), "x");
   assert(abs(x) == 12345678);
+
+  // CHECK-STATS: 0
+  // No queries, but this will change once https://github.com/klee/klee/pull/1520 is merged
 }

--- a/test/Feature/SeedConcretizeFP.c
+++ b/test/Feature/SeedConcretizeFP.c
@@ -6,6 +6,7 @@
 
 // RUN: rm -rf %t.klee-out-2
 // RUN: %klee --exit-on-error --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest %t.bc 2>&1 | FileCheck %s
+// RUN: %klee-stats --print-columns 'SolverQueries' --table-format=csv %t.klee-out-2 | FileCheck --check-prefix=CHECK-STATS %s
 
 #include "klee/klee.h"
 
@@ -24,4 +25,7 @@ int main() {
   double d = i;
   // CHECK: concretizing (reason: floating point)
   assert((unsigned) d == 12345678);
+
+  // CHECK-STATS: 1
+  // This one query involves the constraint that i == 12345678
 }

--- a/test/Feature/SeedConcretizeFP.c
+++ b/test/Feature/SeedConcretizeFP.c
@@ -1,0 +1,27 @@
+// RUN: %clang -emit-llvm -c -g %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --entry-point=TestGen %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: not test -f %t.klee-out/test000002.ktest
+
+// RUN: rm -rf %t.klee-out-2
+// RUN: %klee --exit-on-error --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest %t.bc 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+void TestGen() {
+  unsigned x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_assume(x == 12345678);
+}
+
+int main() {
+  unsigned i;
+  klee_make_symbolic(&i, sizeof(i), "i");
+  double d = i;
+  // CHECK: concretizing (reason: floating point)
+  assert((unsigned) d == 12345678);
+}

--- a/test/Feature/SeedConcretizeMalloc.c
+++ b/test/Feature/SeedConcretizeMalloc.c
@@ -1,0 +1,32 @@
+// RUN: %clang -emit-llvm -c -g %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --entry-point=SeedGen %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: not test -f %t.klee-out/test000002.ktest
+
+// RUN: rm -rf %t.klee-out-2
+// RUN: %klee --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest %t.bc | FileCheck --allow-empty %s
+
+#include "klee/klee.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void SeedGen() {
+  unsigned x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_assume(x == 100);
+}
+
+int main(int argc, char **argv) {
+  unsigned s;
+  klee_make_symbolic(&s, sizeof(s), "size");
+  char *p = (char *)malloc(s);
+  if (!p)
+    return 0;
+
+  if (s != 100)
+    printf("Error\n");
+    // CHECK-NOT: Error
+}

--- a/test/Feature/SeedConcretizeMalloc.c
+++ b/test/Feature/SeedConcretizeMalloc.c
@@ -6,6 +6,7 @@
 
 // RUN: rm -rf %t.klee-out-2
 // RUN: %klee --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest %t.bc | FileCheck --allow-empty %s
+// RUN: %klee-stats --print-columns 'SolverQueries' --table-format=csv %t.klee-out-2 | FileCheck --check-prefix=CHECK-STATS %s
 
 #include "klee/klee.h"
 
@@ -14,13 +15,13 @@
 #include <stdlib.h>
 
 void SeedGen() {
-  unsigned x;
+  size_t x;
   klee_make_symbolic(&x, sizeof(x), "x");
   klee_assume(x == 100);
 }
 
 int main(int argc, char **argv) {
-  unsigned s;
+  size_t s;
   klee_make_symbolic(&s, sizeof(s), "size");
   char *p = (char *)malloc(s);
   if (!p)
@@ -29,4 +30,7 @@ int main(int argc, char **argv) {
   if (s != 100)
     printf("Error\n");
     // CHECK-NOT: Error
+
+  // CHECK-STATS: 4
+  // These queries are due to the explicit constraint asserting that s is 100 and the implicit one checking if we have a huge malloc
 }

--- a/test/Feature/SeedConcretizePatchedFP.c
+++ b/test/Feature/SeedConcretizePatchedFP.c
@@ -1,0 +1,33 @@
+/* This test checks the case where the seed needs to be patched on re-run */
+
+// RUN: %clang -emit-llvm -c %O0opt -g %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --entry-point=TestGen %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: not test -f %t.klee-out/test000002.ktest
+
+// RUN: rm -rf %t.klee-out-2
+// RUN: %klee --exit-on-error --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest --allow-seed-extension --zero-seed-extension %t.bc 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void TestGen() {
+  uint16_t x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_assume(x == 1234);
+}
+
+int main() {
+  uint32_t i;
+  klee_make_symbolic(&i, sizeof(i), "i");
+
+  if (i < 5000) {
+    double d = i;
+    // CHECK: concretizing (reason: floating point)
+    assert((unsigned) d < 5001);
+  }
+}

--- a/test/Feature/SeedExtension.c
+++ b/test/Feature/SeedExtension.c
@@ -1,0 +1,39 @@
+/* This test checks the case where the seed needs to be patched on re-run */
+
+// RUN: %clang -emit-llvm -c %O0opt -g %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --entry-point=TestGen %t.bc
+// RUN: test -f %t.klee-out/test000001.ktest
+// RUN: not test -f %t.klee-out/test000002.ktest
+
+// RUN: rm -rf %t.klee-out-2
+// RUN: %klee --exit-on-error --output-dir=%t.klee-out-2 --seed-file %t.klee-out/test000001.ktest --allow-seed-extension %t.bc 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void TestGen() {
+  int x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_assume(x == 12345678);
+}
+
+int main() {
+  int i;
+  klee_make_symbolic(&i, sizeof(i), "i");
+  double d = i;
+  // CHECK: concretizing (reason: floating point)
+  assert((unsigned)d == 12345678);
+
+  int j;
+  klee_make_symbolic(&j, sizeof(j), "j");
+  if (j)
+    printf("Yes\n");
+  // CHECK-DAG: Yes
+  else
+    printf("No\n");
+  // CHECK-DAG: No
+}

--- a/test/Runtime/POSIX/SeedAndFail.c
+++ b/test/Runtime/POSIX/SeedAndFail.c
@@ -2,7 +2,7 @@
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --libc=uclibc --posix-runtime %t.bc --sym-files 1 10  2>%t.log
 // RUN: rm -rf %t.klee-out-2
-// RUN: %klee --output-dir=%t.klee-out-2 --seed-dir=%t.klee-out --zero-seed-extension --libc=uclibc --posix-runtime %t.bc --sym-files 1 10 --max-fail 1
+// RUN: %klee --output-dir=%t.klee-out-2 --seed-dir=%t.klee-out --allow-seed-extension --libc=uclibc --posix-runtime %t.bc --sym-files 1 10 --max-fail 1
 // RUN: ls %t.klee-out-2 | grep -c assert | grep 4
 
 #include <string.h>


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Concretize values based on seeds when available.  The three commits handle the cases of concretizing an expression via toConstant, performing an external call with symbolic arguments and calling malloc with a symbolic argument, respectively. 
Each case is accompanied by a test. 

The PR is based on #1117 by @hoangmle 

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
