### PR TITLE
Fix a problem about -make-concrete-symbolic

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4054,7 +4054,6 @@ ref<Expr> Executor::replaceReadWithSymbolic(ExecutionState &state,
   ref<Expr> res = Expr::createTempRead(array, e->getWidth());
   ref<Expr> eq = NotOptimizedExpr::create(EqExpr::create(e, res));
   llvm::errs() << "Making symbolic: " << eq << "\n";
-  state.addConstraint(eq);
   return res;
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Fix a problem about -make-concrete-symbolic. The problem is decribed in https://github.com/klee/klee/issues/1679#issue-2069726267

## Checklist:
- [ ] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [ ] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [ ] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [ ] Each commit has a meaningful message documenting what it does.
- [ ] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [ ] The code is commented OR not applicable/necessary.
- [ ] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [ ] There are test cases for the code you added or modified OR no such test cases are required.
