### PR TITLE
Fix brittleness in Feature/VarArgByVal test

### DIFF
--- a/test/Feature/VarArgByVal.c
+++ b/test/Feature/VarArgByVal.c
@@ -9,7 +9,7 @@
 //
 // TODO: Make noundef unconditional when LLVM 14 is the oldest supported version.
 // CHECK: call void (ptr, i32, ...) @test1(ptr sret(%struct.foo) align 8 {{.*}}, i32 noundef -1, ptr noundef byval(%struct.foo) align 8 {{.*}}, ptr noundef byval(%struct.bar) align 8 {{.*}})
-// CHECK: call void (ptr, i32, i64, ...) @test2(ptr sret(%struct.foo) align 8 %tmp, i32 noundef {{.*}}, i64 noundef {{.*}}, i32 noundef {{.*}}, ptr noundef byval(%struct.foo) align 8 {{.*}}, i64 noundef {{.*}}, ptr noundef byval(%struct.bar) align 8 {{.*}}, ptr noundef byval(%struct.foo) align 8 {{.*}}, ptr noundef byval(%struct.bar) align 8 {{.*}})
+// CHECK: call void (ptr, i32, i64, ...) @test2(ptr sret(%struct.foo) align 8 {{.*}}, i32 noundef {{.*}}, i64 noundef {{.*}}, i32 noundef {{.*}}, ptr noundef byval(%struct.foo) align 8 {{.*}}, i64 noundef {{.*}}, ptr noundef byval(%struct.bar) align 8 {{.*}}, ptr noundef byval(%struct.foo) align 8 {{.*}}, ptr noundef byval(%struct.bar) align 8 {{.*}})
 #include <stdarg.h>
 #include <assert.h>
 #include <stdio.h>


### PR DESCRIPTION
I ran a bunch of KLEE builds with LLVM 15 and 16, and got a bunch of test failures like the following:

```
$ ":" "RUN: at line 8"
$ "FileCheck" "/klee/test/Feature/VarArgByVal.c" "--input-file=/klee/build/test/Feature/Output/VarArgByVal.c.tmp.klee-out/assembly.ll"
# command stderr:
/klee/test/Feature/VarArgByVal.c:12:11: error: CHECK: expected string not found in input
// CHECK: call void (ptr, i32, i64, ...) @test2(ptr sret(%struct.foo) align 8 %tmp, i32 noundef {{.*}}, i64 noundef {{.*}}, i32 noundef {{.*}}, ptr noundef byval(%struct.foo) align 8 {{.*}}, i64 noundef {{.*}}, ptr noundef byval(%struct.bar) align 8 {{.*}}, ptr noundef byval(%struct.foo) align 8 {{.*}}, ptr noundef byval(%struct.bar) align 8 {{.*}})
          ^
/klee/build/test/Feature/Output/VarArgByVal.c.tmp.klee-out/assembly.ll:645:170: note: scanning from here
 call void (ptr, i32, ...) @test1(ptr sret(%struct.foo) align 8 %3, i32 noundef -1, ptr noundef byval(%struct.foo) align 8 %1, ptr noundef byval(%struct.bar) align 8 %2), !dbg !373
                                                                                                                                                                         ^
Input file: /klee/build/test/Feature/Output/VarArgByVal.c.tmp.klee-out/assembly.ll
Check file: /klee/test/Feature/VarArgByVal.c
-dump-input=help explains the following input dump.
Input was:
<<<<<<
          .
          .
          .
        640:  %14 = getelementptr inbounds %struct.bar, ptr %2, i32 0, i32 3, !dbg !370 
        641:  store i8 14, ptr %14, align 8, !dbg !370 
        642:  %15 = getelementptr inbounds %struct.bar, ptr %2, i32 0, i32 4, !dbg !370 
        643:  store i64 15, ptr %15, align 8, !dbg !370 
        644:  call void @llvm.dbg.declare(metadata ptr %3, metadata !371, metadata !DIExpression()), !dbg !372 
        645:  call void (ptr, i32, ...) @test1(ptr sret(%struct.foo) align 8 %3, i32 noundef -1, ptr noundef byval(%struct.foo) align 8 %1, ptr noundef byval(%struct.bar) align 8 %2), !dbg !373 
check:12                                                                                                                                                                              X~~~~~~~~~~~ error: no match found
        646:  %16 = getelementptr inbounds %struct.foo, ptr %3, i32 0, i32 0, !dbg !374 
check:12     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        647:  %17 = load i8, ptr %16, align 8, !dbg !374 
check:12     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        648:  %18 = sext i8 %17 to i32, !dbg !374 
check:12     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        649:  %19 = icmp eq i32 %18, 2, !dbg !374 
check:12     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        650:  br i1 %19, label %21, label %20, !dbg !377 
check:12     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          .
          .
          .
>>>>>>
error: command failed with exit status: 1
```

Checking the `assembly.ll`, the issue seems to be that the call to `@test2` looks slightly different:

```
Expected: call void (ptr, i32, i64, ...) @test2(ptr sret(%struct.foo) align 8 %tmp, i32 noundef {{.*}}, i64 noundef {{.*}}, i32 noundef {{.*}}, ptr noundef byval(%struct.foo) align 8 {{.*}}, i64 noundef {{.*}}, ptr noundef byval(%struct.bar) align 8 {{.*}}, ptr noundef byval(%struct.foo) align 8 {{.*}}, ptr noundef byval(%struct.bar) align 8 {{.*}})
Actual:   call void (ptr, i32, i64, ...) @test2(ptr sret(%struct.foo) align 8 %8, i32 noundef %67, i64 noundef %68, i32 noundef %69, ptr noundef byval(%struct.foo) align 8 %1, i64 noundef %70, ptr noundef byval(%struct.bar) align 8 %2, ptr noundef byval(%struct.foo) align 8 %6, ptr noundef byval(%struct.bar) align 8 %7), !dbg !418
```

This PR replaces the `%tmp` with an regex to ignore its actual name, similar to how many other names are handled here.