### PR TITLE
Fix some inconsistent execution tree options

### DIFF
--- a/lib/Core/ExecutionTree.cpp
+++ b/lib/Core/ExecutionTree.cpp
@@ -29,7 +29,7 @@ llvm::cl::OptionCategory
 
 namespace {
 llvm::cl::opt<bool> CompressExecutionTree(
-    "compress-execution-tree",
+    "compress-exec-tree",
     llvm::cl::desc("Remove intermediate nodes in the execution "
                    "tree whenever possible (default=false)"),
     llvm::cl::init(false), llvm::cl::cat(ExecTreeCat));

--- a/lib/Core/ExecutionTreeWriter.cpp
+++ b/lib/Core/ExecutionTreeWriter.cpp
@@ -17,9 +17,9 @@
 
 namespace {
 llvm::cl::opt<unsigned> BatchSize(
-    "ptree-batch-size", llvm::cl::init(100U),
+    "exec-tree-batch-size", llvm::cl::init(100U),
     llvm::cl::desc("Number of execution tree nodes to batch for writing, "
-                   "see --write-execution-tree (default=100)"),
+                   "see --write-exec-tree (default=100)"),
     llvm::cl::cat(klee::ExecTreeCat));
 } // namespace
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

Rename `ptree-batch-size` to `exec-tree-batch-size`, and `compress-execution-tree` to `compress-exec-tree`.  Fix an incorrect reference to `--write-exec-tree`.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
