### PR TITLE
Fixes the concretization of symbolic arguments following an external call, and introduces a new external call policy

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4018,17 +4018,10 @@ void Executor::callExternalFunction(ExecutionState &state,
     if (ExternalCalls == ExternalCallPolicy::All ||
         ExternalCalls == ExternalCallPolicy::OverApprox) {
       *ai = optimizer.optimizeExpr(*ai, true);
-      ref<ConstantExpr> cvalue = getValueFromSeeds(state, *ai);
-      /* If no seed evaluation results in a constant, call the solver */
-      if (!cvalue) {
-        [[maybe_unused]] bool success = solver->getValue(
-            state.constraints, *ai, cvalue, state.queryMetaData);
-        assert(success && "FIXME: Unhandled solver failure");
-      }
-
+      ref<ConstantExpr> cvalue =
+          toConstant(state, *ai, "external call",
+                     ExternalCalls == ExternalCallPolicy::All);
       cvalue->toMemory(&args[wordIndex]);
-      if (ExternalCalls == ExternalCallPolicy::All)
-        addConstraint(state, EqExpr::create(cvalue, *ai));
 
       ObjectPair op;
       // Checking to see if the argument is a pointer to something

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1316,13 +1316,9 @@ ref<Expr> Executor::toUnique(const ExecutionState &state,
   return result;
 }
 
-
-/* Concretize the given expression, and return a possible constant value. 
-   'reason' is just a documentation string stating the reason for concretization. */
-ref<klee::ConstantExpr> 
-Executor::toConstant(ExecutionState &state, 
-                     ref<Expr> e,
-                     const char *reason) {
+ref<klee::ConstantExpr> Executor::toConstant(ExecutionState &state, ref<Expr> e,
+                                             const std::string &reason,
+                                             bool concretize) {
   e = ConstraintManager::simplifyExpr(state.constraints, e);
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(e))
     return CE;
@@ -1344,9 +1340,10 @@ Executor::toConstant(ExecutionState &state,
   if (ExternalCallWarnings == ExtCallWarnings::All)
     klee_warning("%s", os.str().c_str());
   else
-    klee_warning_once(reason, "%s", os.str().c_str());
+    klee_warning_once(reason.c_str(), "%s", os.str().c_str());
 
-  addConstraint(state, EqExpr::create(e, cvalue));
+  if (concretize)
+    addConstraint(state, EqExpr::create(e, cvalue));
 
   return cvalue;
 }

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -387,14 +387,15 @@ private:
   /// value). Otherwise return the original expression.
   ref<Expr> toUnique(const ExecutionState &state, ref<Expr> &e);
 
-  /// Return a constant value for the given expression, forcing it to
-  /// be constant in the given state by adding a constraint if
+  /// Return a constant value for the given expression.  If \param concretize is
+  /// true, the expression is forced to be a constant by adding a constraint if
   /// necessary. Note that this function breaks completeness and
   /// should generally be avoided.
   ///
-  /// \param purpose An identify string to printed in case of concretization.
-  ref<klee::ConstantExpr> toConstant(ExecutionState &state, ref<Expr> e, 
-                                     const char *purpose);
+  /// \param reason A documentation string stating the reason for concretization
+  ref<klee::ConstantExpr> toConstant(ExecutionState &state, ref<Expr> e,
+                                     const std::string &reason,
+                                     bool concretize = true);
 
   /// Evaluate the given expression under each seed, and return the
   /// first one that results in a constant, if such a seed exist.  Otherwise,

--- a/test/Feature/ExtCall.c
+++ b/test/Feature/ExtCall.c
@@ -1,4 +1,3 @@
-// XFAIL: *
 // This test checks that symbolic arguments to a function call are correctly concretized
 // RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
 

--- a/test/Feature/ExtCall.c
+++ b/test/Feature/ExtCall.c
@@ -1,0 +1,24 @@
+// XFAIL: *
+// This test checks that symbolic arguments to a function call are correctly concretized
+// RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
+
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --external-calls=all --exit-on-error %t.bc 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+  int x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_assume(x >= 0);
+
+  int y = abs(x);
+  printf("y = %d\n", y);
+  // CHECK: calling external: abs((ReadLSB w32 0 x))
+
+  assert(x == y);
+}

--- a/test/Feature/ExtCallOverapprox.c
+++ b/test/Feature/ExtCallOverapprox.c
@@ -2,7 +2,7 @@
 
 // RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --external-calls=all %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --external-calls=over-approx %t.bc 2>&1 | FileCheck %s
 
 #include "klee/klee.h"
 

--- a/test/Feature/ExtCallOverapprox.c
+++ b/test/Feature/ExtCallOverapprox.c
@@ -1,0 +1,26 @@
+// This test checks that under using the under-approximate external call policy, the symbolic arguments are left unconstrained by the external call
+
+// RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --external-calls=all %t.bc 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+  int x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+  printf("%d\n", x);
+  // CHECK: calling external: printf
+  if (x > 0) {
+    printf("Yes\n");
+    // CHECK-DAG: Yes
+  } else {
+    printf("No\n");
+    // CHECK-DAG: No
+  }
+}

--- a/test/Feature/ExtCallOverapprox.c
+++ b/test/Feature/ExtCallOverapprox.c
@@ -1,4 +1,4 @@
-// This test checks that under using the under-approximate external call policy, the symbolic arguments are left unconstrained by the external call
+// This test checks that under using the over-approximate external call policy, the symbolic arguments are left unconstrained by the external call
 
 // RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
 // RUN: rm -rf %t.klee-out

--- a/test/Feature/SeedConcretizeExternalCall.c
+++ b/test/Feature/SeedConcretizeExternalCall.c
@@ -24,6 +24,5 @@ int main() {
   klee_make_symbolic(&x, sizeof(x), "x");
   assert(abs(x) == 12345678);
 
-  // CHECK-STATS: 0
-  // No queries, but this will change once https://github.com/klee/klee/pull/1520 is merged
+  // CHECK-STATS: 1
 }


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 

This PR, based on #1520, fixes the concretization of arguments following an external call with symbolic arguments.  

It also introduces a new external call policy, where the symbolic inputs are left unconstrained following such a call, useful for certain external calls such as printf. 

Relevant tests are also added or updated.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
