### PR TITLE
Compare LLVM_VERSION_SHORT to "140" rather than "14".

### DIFF
--- a/scripts/build/p-libcxx.inc
+++ b/scripts/build/p-libcxx.inc
@@ -38,14 +38,14 @@ build_libcxx() {
    "-DCMAKE_INSTALL_PREFIX=${LIBCXX_INSTALL}"
   )
 
-  # Static ABI libraries are not supported under OS X
-  if [[ "${LLVM_VERSION_SHORT}" -ge "14" ]]; then
+  if [[ "${LLVM_VERSION_SHORT}" -ge "140" ]]; then
     cmake_flags+=("-DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi")
     cmake_flags+=("-DLLVM_ENABLE_PROJECTS=")
     cmake_flags+=("-DLLVM_ENABLE_PROJECTS_USED:BOOL=ON")
   else
     cmake_flags+=("-DLLVM_ENABLE_PROJECTS=libcxx;libcxxabi")
   fi
+  # Static ABI libraries are not supported under OS X
   if [[ "${OS}" == "osx" ]]; then
     cmake_flags+=("-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY:BOOL=OFF")
   else
@@ -59,7 +59,7 @@ build_libcxx() {
     export LLVM_COMPILER_PATH="$(dirname "${BITCODE_CC}")"
 
     cmake "${cmake_flags[@]}" "${LIBCXX_SRC}/llvm"
-   if [[ "${LLVM_VERSION_SHORT}" -ge "14" ]]; then
+   if [[ "${LLVM_VERSION_SHORT}" -ge "140" ]]; then
      make runtimes "-j$(nproc)" || make runtimes || return 1
    else
      make cxx "-j$(nproc)" || make cxx || return 1
@@ -75,7 +75,7 @@ install_libcxx() {
     export LLVM_COMPILER=clang
     export LLVM_COMPILER_PATH="$(dirname "${BITCODE_CC}")"
 
-    if [[ "${LLVM_VERSION_SHORT}" -ge "14" ]]; then
+    if [[ "${LLVM_VERSION_SHORT}" -ge "140" ]]; then
       cd "${LIBCXX_BUILD}/runtimes" || return 1
       make install || return 1
     else

--- a/scripts/build/p-llvm.inc
+++ b/scripts/build/p-llvm.inc
@@ -183,7 +183,7 @@ configure_llvm() {
         "-DLLVM_BUILD_STATIC:BOOL=OFF"
         "-DLIBCLANG_BUILD_STATIC:BOOL=OFF"
     )
-    if [[ "${LLVM_VERSION_SHORT}" -ge "14" ]]; then
+    if [[ "${LLVM_VERSION_SHORT}" -ge "140" ]]; then
       CONFIG+=("-DLLVM_ENABLE_PROJECTS=${ENABLED_LLVM_PROJECTS}")
       CONFIG+=("-DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi")
     else


### PR DESCRIPTION
## Summary: 

In commit 2b07721, support was added to p-libcxx.inc & p-llvm.inc for LLVM versions 14+ (in which, apparently, certain build flags were changed). To detect these recent versions, the variable LLVM_VERSION_SHORT was compared numerically to "14"-- the intent obviously being to express "LLVM version 14 or later".

However, in both v-clang.inc & v-llvm.inc, LLVM_VERSION_SHORT is defined as the concatenation of LLVM_VERSION_MAJOR and LLVM_VERSION_MINOR. Therefore, on a machine with, say, LLVM 13.0 installed, LLVM_VERSION_SHORT will be "130" which compares as larger than "14".

This patch changes the comparison to be against "140" which I believe captures the original intent.

## Checklist:

- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [ ] There are test cases for the code you added or modified OR no such test cases are required.

RE the final checkbox-- I've tested this on my machine locally by building libcxx. I'm not sure what formal tests might be feasible. Since this is my first PR for klee, I'm going to be watching your CI pipeline with interest ;)
