### PR TITLE
add pythonpath to lit forwarded env vars

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -78,6 +78,10 @@ addEnv('TSAN_OPTIONS')
 addEnv('C_INCLUDE_PATH')
 addEnv('CPLUS_INCLUDE_PATH')
 
+# Without an appropriate `PYTHONPATH`, the various python-based tools, such as
+# `klee-stats` might not be able to resolve the python packages they depend on
+addEnv('PYTHONPATH')
+
 # Check that the object root is known.
 if config.test_exec_root is None:
   lit_config.fatal('test execution root not set!')


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
If the tabulate library is looked up via `PYTHONPATH`, we need to forward that variable through `lit` to the tests, so that `klee-stats` can find it.

This came up during investigation of the nix building issues mentioned in #1690, but is not necessary to solve those (making sure that the "right" python is first in `PATH` already does the trick).

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
