### PR TITLE
Add _Exit function handler

### DIFF
--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -83,6 +83,7 @@ static constexpr std::array handlerInfo = {
   addDNR("_assert", handleAssert),
   addDNR("abort", handleAbort),
   addDNR("_exit", handleExit),
+  addDNR("_Exit", handleExit),
   SpecialFunctionHandler::HandlerInfo{ "exit", &SpecialFunctionHandler::handleExit, true, false, true },
   addDNR("klee_abort", handleAbort),
   addDNR("klee_silent_exit", handleSilentExit),

--- a/test/Runtime/POSIX/_exit.c
+++ b/test/Runtime/POSIX/_exit.c
@@ -1,0 +1,28 @@
+// RUN: %clang %s -g -emit-llvm %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --posix-runtime --libc=klee   %t.bc 2>&1 | FileCheck %s
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --posix-runtime --libc=uclibc %t.bc 2>&1 | FileCheck %s
+#include "klee/klee.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void foo() { printf("called foo\n"); }
+
+int main() {
+  atexit(foo);
+
+  int x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+  // CHECK-NOT: called foo
+
+  if (x == 0) {
+    _exit(0);
+  } else {
+    _Exit(0);
+  }
+
+  // CHECK: KLEE: done: completed paths = 2
+}

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -753,6 +753,7 @@ static const char *modelledExternals[] = {
   "__error",
   "calloc",
   "_exit",
+  "_Exit",
   "exit",
   "free",
   "abort",


### PR DESCRIPTION
## Summary: 

This adds a handler for `_Exit` to handle it the same way `_exit` is handled, and also a test case.
Previously, calling `_Exit` would result in an external call, terminating KLEE.

While `_Exit` was initially introduced with C99, it's now also [part of POSIX.1-2008](https://www.man7.org/linux/man-pages/man2/exit.2.html)

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
