### PR TITLE
added support for a bounded symbolic-size model

### DIFF
--- a/include/klee/Support/OptionCategories.h
+++ b/include/klee/Support/OptionCategories.h
@@ -31,6 +31,7 @@ namespace klee {
   extern llvm::cl::OptionCategory SearchCat;
   extern llvm::cl::OptionCategory ExecTreeCat;
   extern llvm::cl::OptionCategory SeedingCat;
+  extern llvm::cl::OptionCategory SizeModelCat;
   extern llvm::cl::OptionCategory SolvingCat;
   extern llvm::cl::OptionCategory StatsCat;
   extern llvm::cl::OptionCategory TerminationCat;

--- a/lib/Core/AddressSpace.h
+++ b/lib/Core/AddressSpace.h
@@ -154,6 +154,8 @@ namespace klee {
     /// @return
     bool copyInConcrete(const MemoryObject *mo, const ObjectState *os,
                         uint64_t src_address, bool concretize);
+
+    bool mayPointToMemoryObject(uint64_t address, const MemoryObject *mo) const;
   };
 } // End klee namespace
 

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -162,9 +162,9 @@ void ExecutionState::deallocate(const MemoryObject *mo) {
 
   auto address = reinterpret_cast<void *>(mo->address);
   if (mo->isLocal) {
-    stackAllocator.free(address, std::max(mo->size, mo->alignment));
+    stackAllocator.free(address, std::max(mo->capacity, mo->alignment));
   } else {
-    heapAllocator.free(address, std::max(mo->size, mo->alignment));
+    heapAllocator.free(address, std::max(mo->capacity, mo->alignment));
   }
 }
 
@@ -333,7 +333,7 @@ bool ExecutionState::merge(const ExecutionState &b) {
     assert(otherOS);
 
     ObjectState *wos = addressSpace.getWriteable(mo, os);
-    for (unsigned i=0; i<mo->size; i++) {
+    for (unsigned i = 0; i < mo->capacity; i++) {
       ref<Expr> av = wos->read8(i);
       ref<Expr> bv = otherOS->read8(i);
       wos->write(i, SelectExpr::create(inA, av, bv));

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -260,6 +260,11 @@ private:
                     ExactResolutionList &results,
                     const std::string &name);
 
+  bool shouldHandleSymbolicSizeObjects() const;
+
+  bool addCapacityConstraint(ExecutionState &state, ref<Expr> size,
+                             uint64_t &capacity);
+
   /// Allocate and bind a new object in a particular state. NOTE: This
   /// function may fork.
   ///

--- a/lib/Core/MemoryManager.h
+++ b/lib/Core/MemoryManager.h
@@ -11,6 +11,7 @@
 #define KLEE_MEMORYMANAGER_H
 
 #include "klee/KDAlloc/kdalloc.h"
+#include "klee/Expr/Expr.h"
 
 #include <cstddef>
 #include <set>
@@ -54,13 +55,21 @@ public:
    * Returns memory object which contains a handle to real virtual process
    * memory.
    */
+  MemoryObject *allocate(ref<Expr> size, uint64_t capacity, bool isLocal,
+                         bool isGlobal, ExecutionState *state,
+                         const llvm::Value *allocSite, size_t alignment);
+
   MemoryObject *allocate(uint64_t size, bool isLocal, bool isGlobal,
                          ExecutionState *state, const llvm::Value *allocSite,
                          size_t alignment);
+
   MemoryObject *allocateFixed(uint64_t address, uint64_t size,
                               const llvm::Value *allocSite);
+
   void markFreed(MemoryObject *mo);
+
   bool markMappingsAsUnneeded();
+
   ArrayCache *getArrayCache() const { return arrayCache; }
 
   /*

--- a/lib/Core/SeedInfo.cpp
+++ b/lib/Core/SeedInfo.cpp
@@ -22,7 +22,14 @@
 using namespace klee;
 
 KTestObject *SeedInfo::getNextInput(const MemoryObject *mo,
-                                   bool byName) {
+                                    bool byName) {
+  if (!mo->hasConcreteSize()) {
+    klee_warning("no support for symbolic size");
+    return nullptr;
+  }
+
+  unsigned concreteSize = mo->getConcreteSize();
+
   if (byName) {
     unsigned i;
     
@@ -40,7 +47,7 @@ KTestObject *SeedInfo::getNextInput(const MemoryObject *mo,
         break;
     if (i<input->numObjects) {
       KTestObject *obj = &input->objects[i];
-      if (obj->numBytes == mo->size) {
+      if (obj->numBytes == concreteSize) {
         used.insert(obj);
         klee_warning_once(mo, "using seed input %s[%d] for: %s (no name match)",
                           obj->name, obj->numBytes, mo->name.c_str());

--- a/test/Feature/SymbolicSize.c
+++ b/test/Feature/SymbolicSize.c
@@ -1,0 +1,25 @@
+// RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --size-model=range --capacity=10 %t.bc 2>&1 | FileCheck %s
+
+// CHECK: KLEE: allocating symbolic size (capacity = 10,{{.*}})
+// CHECK: KLEE: done: completed paths = 2
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "klee/klee.h"
+
+void nop() { }
+
+int main(int argc, char** argv) {
+  unsigned n;
+  klee_make_symbolic(&n, sizeof(n), "n");
+
+  char *s = malloc(n);
+  if (n > 1) {
+    nop();
+  }
+
+  return 0;
+}

--- a/test/Feature/SymbolicSizeIncreasingCapacity.c
+++ b/test/Feature/SymbolicSizeIncreasingCapacity.c
@@ -1,0 +1,21 @@
+// RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --size-model=range --capacity=10 %t.bc 2>&1 | FileCheck %s
+
+// CHECK: KLEE: allocating symbolic size (capacity = 20,{{.*}})
+// CHECK: KLEE: done: completed paths = 1
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "klee/klee.h"
+
+int main(int argc, char** argv) {
+  unsigned n;
+  klee_make_symbolic(&n, sizeof(n), "n");
+  klee_assume(n > 10);
+
+  char *s = malloc(n);
+
+  return 0;
+}

--- a/test/Feature/SymbolicSizeLoop.c
+++ b/test/Feature/SymbolicSizeLoop.c
@@ -1,0 +1,23 @@
+// RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --size-model=range --capacity=10 %t.bc 2>&1 | FileCheck %s
+
+// CHECK: KLEE: allocating symbolic size (capacity = 10,{{.*}})
+// CHECK: KLEE: done: completed paths = 11
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "klee/klee.h"
+
+int main(int argc, char** argv) {
+  unsigned n;
+  klee_make_symbolic(&n, sizeof(n), "n");
+
+  char *s = malloc(n);
+  for (unsigned i = 0; i < n; i++) {
+    s[i] = 0;
+  }
+
+  return 0;
+}

--- a/test/Replay/libkleeruntest/replay_symbolic_size.c
+++ b/test/Replay/libkleeruntest/replay_symbolic_size.c
@@ -1,0 +1,18 @@
+// RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --size-model=range --capacity=10 %t.bc
+// RUN: %cc %s %libkleeruntest -Wl,-rpath %libkleeruntestdir -o %t_runner
+// RUN: env KTEST_FILE=%t.klee-out/test000001.ktest %t_runner 2>&1
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "klee/klee.h"
+
+int main(int argc, char** argv) {
+  unsigned n;
+  klee_make_symbolic(&n, sizeof(n), "n");
+  char *s = malloc(n);
+
+  return 0;
+}

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1122,7 +1122,7 @@ int main(int argc, char **argv, char **envp) {
   KCommandLine::KeepOnlyCategories(
      {&ChecksCat,      &DebugCat,    &ExtCallsCat, &ExprCat,     &LinkCat,
       &MemoryCat,      &MergeCat,    &MiscCat,     &ModuleCat,   &ReplayCat,
-      &SearchCat,      &SeedingCat,  &SolvingCat,  &StartCat,    &StatsCat,
+      &SearchCat,      &SeedingCat,  &SizeModelCat, &SolvingCat,  &StartCat, &StatsCat,
       &TerminationCat, &TestCaseCat, &TestGenCat,  &ExecTreeCat, &ExecTreeCat});
   llvm::InitializeNativeTarget();
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 
This is a PR for the following issue: https://github.com/klee/klee/issues/1721.

The main goal is to add support for symbolic size allocations.
Here, a memory object has a (concrete or symbolic) size and a concrete capacity.
If the size is symbolic, then it is limited by the capacity.
Otherwise, the size and the capacity are equal.
In both cases,
the size of the SMT array that is used to represent the contents of a memory object (ObjectState) is equal to the capacity.

The following command-line options were added:
_size-model:_
- concrete (default behavior of KLEE)
- range (bounded symbolic-size model)

_capacity:_
- Sets the capacity of the memory objects.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
