### PR TITLE
Prefer `std::unique_ptr` within `IndependentSolver`

### DIFF
--- a/lib/Solver/IndependentSolver.cpp
+++ b/lib/Solver/IndependentSolver.cpp
@@ -259,9 +259,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 
 // Breaks down a constraint into all of it's individual pieces, returning a
 // list of IndependentElementSets or the independent factors.
-//
-// Caller takes ownership of returned std::list.
-static std::list<IndependentElementSet>*
+static std::unique_ptr<std::list<IndependentElementSet>>
 getAllIndependentConstraintsSets(const Query &query) {
   std::list<IndependentElementSet> *factors = new std::list<IndependentElementSet>();
   ConstantExpr *CE = dyn_cast<ConstantExpr>(query.expr);
@@ -316,7 +314,7 @@ getAllIndependentConstraintsSets(const Query &query) {
     factors = done;
   } while (!doneLoop);
 
-  return factors;
+  return std::unique_ptr<std::list<IndependentElementSet>>(factors);
 }
 
 static 
@@ -479,9 +477,8 @@ bool IndependentSolver::computeInitialValues(const Query& query,
   // This is important in case we don't have any constraints but
   // we need initial values for requested array objects.
   hasSolution = true;
-  // FIXME: When we switch to C++11 this should be a std::unique_ptr so we don't need
-  // to remember to manually call delete
-  std::list<IndependentElementSet> *factors = getAllIndependentConstraintsSets(query);
+  
+  std::unique_ptr<std::list<IndependentElementSet>> factors = getAllIndependentConstraintsSets(query);
 
   //Used to rearrange all of the answers into the correct order
   std::map<const Array*, std::vector<unsigned char> > retMap;
@@ -499,11 +496,9 @@ bool IndependentSolver::computeInitialValues(const Query& query,
     if (!solver->impl->computeInitialValues(Query(tmp, ConstantExpr::alloc(0, Expr::Bool)),
                                             arraysInFactor, tempValues, hasSolution)){
       values.clear();
-      delete factors;
       return false;
     } else if (!hasSolution){
       values.clear();
-      delete factors;
       return true;
     } else {
       assert(tempValues.size() == arraysInFactor.size() &&
@@ -542,7 +537,6 @@ bool IndependentSolver::computeInitialValues(const Query& query,
     }
   }
   assert(assertCreatedPointEvaluatesToTrue(query, objects, values, retMap) && "should satisfy the equation");
-  delete factors;
   return true;
 }
 


### PR DESCRIPTION
## Summary: 

Fixing [this FIXME](https://github.com/klee/klee/blob/master/lib/Solver/IndependentSolver.cpp#L482) - replacing raw pointers with `std::unique_ptr` within `IndependentSolver` and removing all `delete`s. I also refactored `getAllIndependentConstraintsSets` in this way but if that is too big of a change, happy to revert to https://github.com/klee/klee/pull/1727/commits/87b23e6d434f34d325a4ef1abf004a8284517119 instead.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
