### PR TITLE
Fix bug that disabled the CI tests for the Linux targets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -130,7 +130,7 @@ jobs:
         env: ${{ matrix.env }}
         run: scripts/build/build.sh klee --docker --create-final-image
       - name: Run tests
-        run: # XXX: Workaround for https://github.com/llvm/llvm-project/issues/78354
+        run: | # XXX: Workaround for https://github.com/llvm/llvm-project/issues/78354
              sudo sysctl vm.mmap_rnd_bits=28
              scripts/build/run-tests.sh --run-docker --debug
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week. 

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 
Fixed bug that disabled the CI tests for the Linux targets.
Without the `|`, the two run lines were concatenated and the merged line errored -- while `sysctl` emitted an error, the exit code was still 0, which hid the issue. 

Introduced in https://github.com/klee/klee/pull/1707/

Thanks to @ocelaiwo for reporting it.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
