### PR TITLE
Improve code which ignores STP failures

### DIFF
--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -38,8 +38,8 @@ llvm::cl::opt<bool> DebugDumpSTPQueries(
     llvm::cl::desc("Dump every STP query to stderr (default=false)"),
     llvm::cl::cat(klee::SolvingCat));
 
-llvm::cl::opt<bool> IgnoreSolverFailures(
-    "ignore-solver-failures", llvm::cl::init(false),
+llvm::cl::opt<bool> IgnoreSTPFailures(
+    "ignore-stp-failures", llvm::cl::init(false),
     llvm::cl::desc("Ignore any STP solver failures (default=false)"),
     llvm::cl::cat(klee::SolvingCat));
 
@@ -327,7 +327,7 @@ runAndGetCexForked(::VC vc, STPBuilder *builder, ::VCExpr q,
 
     if (res < 0) {
       klee_warning("waitpid() for STP failed");
-      if (!IgnoreSolverFailures)
+      if (!IgnoreSTPFailures)
         exit(1);
       return SolverImpl::SOLVER_RUN_STATUS_WAITPID_FAILED;
     }
@@ -338,7 +338,7 @@ runAndGetCexForked(::VC vc, STPBuilder *builder, ::VCExpr q,
     if (WIFSIGNALED(status) || !WIFEXITED(status)) {
       klee_warning("STP did not return successfully.  Most likely you forgot "
                    "to run 'ulimit -s unlimited'");
-      if (!IgnoreSolverFailures) {
+      if (!IgnoreSTPFailures) {
         exit(1);
       }
       return SolverImpl::SOLVER_RUN_STATUS_INTERRUPTED;
@@ -374,7 +374,7 @@ runAndGetCexForked(::VC vc, STPBuilder *builder, ::VCExpr q,
 
     // unknown return code
     klee_warning("STP did not return a recognized code");
-    if (!IgnoreSolverFailures)
+    if (!IgnoreSTPFailures)
       exit(1);
     return SolverImpl::SOLVER_RUN_STATUS_UNEXPECTED_EXIT_CODE;
   }


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 
Rename --ignore-solver-failures to --ignore-stp-failures as this is an STP-specific option.
Exit with klee_error when --ignore-stp-failures is not set, as opposed to confusingly displaying only a warning and doing exit(1) silently.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
