### PR TITLE
Fix macOS CI (namely the step "brew install python-tabulate")

### DIFF
--- a/scripts/build/p-klee-osx.inc
+++ b/scripts/build/p-klee-osx.inc
@@ -11,7 +11,7 @@ install_build_dependencies_klee() {
   brew install python-tabulate lit
 
   # brew does not seem to update this properly for 0.9.0_1
-  export PYTHONPATH=/opt/homebrew/Cellar/python-tabulate/0.9.0_1/libexec/lib/python3.12/site-packages
+  export PYTHONPATH=/usr/local/opt/python-tabulate/libexec/lib/python3.12/site-packages
 
   # Get path of package location
   base_path=$(python -m site --user-base)

--- a/scripts/build/p-klee-osx.inc
+++ b/scripts/build/p-klee-osx.inc
@@ -2,6 +2,7 @@
 install_build_dependencies_klee() {
   brew upgrade python               # upgrade to Python 3
   brew link --overwrite python
+  export PATH="$(brew --prefix python)/libexec/bin:$PATH"
 
   if [[ $(to_bool "${ENABLE_DOXYGEN}") -eq 1 ]]; then
     brew install doxygen graphviz

--- a/scripts/build/p-klee-osx.inc
+++ b/scripts/build/p-klee-osx.inc
@@ -9,6 +9,9 @@ install_build_dependencies_klee() {
 
   brew install python-tabulate lit
 
+  # brew does not seem to update this properly for 0.9.0_1
+  export PYTHONPATH=/opt/homebrew/Cellar/python-tabulate/0.9.0_1/libexec/lib/python3.12/site-packages
+
   # Get path of package location
   base_path=$(python3 -m site --user-base)
   export PATH="${base_path}/bin:$PATH"

--- a/scripts/build/p-klee-osx.inc
+++ b/scripts/build/p-klee-osx.inc
@@ -14,6 +14,6 @@ install_build_dependencies_klee() {
   export PYTHONPATH=/opt/homebrew/Cellar/python-tabulate/0.9.0_1/libexec/lib/python3.12/site-packages
 
   # Get path of package location
-  base_path=$(python3 -m site --user-base)
+  base_path=$(python -m site --user-base)
   export PATH="${base_path}/bin:$PATH"
 }

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 
 # ===-- klee-stats --------------------------------------------------------===##


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 
Fix macOS CI: set PYTHONPATH explicitly to point to tabulate, as brew does not seem to do this properly anymore for python-tabulate v0.9.0_1

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
