### PR TITLE
LLVM 17-19 compatibility

### DIFF
--- a/lib/Core/ExecutorUtil.cpp
+++ b/lib/Core/ExecutorUtil.cpp
@@ -237,7 +237,10 @@ namespace klee {
       }
       return base;
     }
-      
+
+// NOTE: In more recent LLVM versions ConstantExpr is getting more limited:
+// https://discourse.llvm.org/t/rfc-remove-most-constant-expressions/63179
+#if LLVM_VERSION_MAJOR < 19
     case Instruction::ICmp: {
       switch(ce->getPredicate()) {
       default: assert(0 && "unhandled ICmp predicate");
@@ -253,6 +256,7 @@ namespace klee {
       case ICmpInst::ICMP_SLE: return op1->Sle(op2);
       }
     }
+#endif
 
     case Instruction::Select:
       return op1->isTrue() ? op2 : op3;

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -99,7 +99,7 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
           auto castedSrc =
               Builder.CreatePointerCast(src, i8pp, "vacopy.cast.src");
 #if LLVM_VERSION_CODE >= LLVM_VERSION(15, 0)
-          auto load = Builder.CreateLoad(Builder.getInt8PtrTy(), castedSrc,
+          auto load = Builder.CreateLoad(Builder.getPtrTy(), castedSrc,
                                          "vacopy.read");
 #else
           auto load =

--- a/lib/Module/KLEEIRMetaData.h
+++ b/lib/Module/KLEEIRMetaData.h
@@ -43,7 +43,7 @@ public:
     if (!sv)
       return false;
 
-    return sv->getString().equals(value);
+    return sv->getString() == value;
   }
 };
 }

--- a/lib/Module/OptNone.cpp
+++ b/lib/Module/OptNone.cpp
@@ -25,8 +25,16 @@ bool OptNonePass::runOnModule(llvm::Module &M) {
   // and mark all functions that contain such call or invoke as optnone
   llvm::SmallPtrSet<llvm::Function *,16> CallingFunctions;
   for (auto &F : M) {
-    if (!F.hasName() || !F.getName().startswith("klee_"))
+    if (!F.hasName())
       continue;
+#if LLVM_VERSION_CODE >= LLVM_VERSION(16, 0)
+    if (!F.getName().starts_with("klee_"))
+      continue;
+#else
+    if (!F.getName().startswith("klee_"))
+      continue;
+#endif
+
     for (auto *U : F.users()) {
       // skip non-calls and non-invokes
       if (!llvm::isa<llvm::CallInst>(U) && !llvm::isa<llvm::InvokeInst>(U))

--- a/lib/Module/Passes.h
+++ b/lib/Module/Passes.h
@@ -15,7 +15,11 @@
 #include "klee/Support/CompilerWarning.h"
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#if LLVM_VERSION_MAJOR >= 17
+#include "llvm/TargetParser/Triple.h"
+#else
 #include "llvm/ADT/Triple.h"
+#endif // LLVM_VERSION_MAJOR
 #include "llvm/CodeGen/IntrinsicLowering.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"

--- a/lib/Module/RaiseAsm.cpp
+++ b/lib/Module/RaiseAsm.cpp
@@ -21,7 +21,11 @@ DISABLE_WARNING_DEPRECATED_DECLARATIONS
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
+#if LLVM_VERSION_CODE >= LLVM_VERSION(16, 0)
+#include "llvm/TargetParser/Host.h"
+#else
 #include "llvm/Support/Host.h"
+#endif
 #if LLVM_VERSION_CODE >= LLVM_VERSION(14, 0)
 #include "llvm/MC/TargetRegistry.h"
 #else

--- a/lib/Support/ErrorHandling.cpp
+++ b/lib/Support/ErrorHandling.cpp
@@ -52,10 +52,11 @@ static bool shouldSetColor(const char *pfx, const char *msg,
   if (pfx && strcmp(pfx, prefixToSearchFor) == 0)
     return true;
 
-  if (llvm::StringRef(msg).startswith(prefixToSearchFor))
-    return true;
-
-  return false;
+#if LLVM_VERSION_CODE >= LLVM_VERSION(16, 0)
+  return llvm::StringRef(msg).starts_with(prefixToSearchFor);
+#else
+  return llvm::StringRef(msg).startswith(prefixToSearchFor);
+#endif
 }
 
 static void klee_vfmessage(FILE *fp, const char *pfx, const char *msg,

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -38,7 +38,11 @@ DISABLE_WARNING_DEPRECATED_DECLARATIONS
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Errno.h"
 #include "llvm/Support/FileSystem.h"
+#if LLVM_VERSION_CODE >= LLVM_VERSION(16, 0)
+#include "llvm/TargetParser/Host.h"
+#else
 #include "llvm/Support/Host.h"
+#endif
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -402,7 +406,7 @@ KleeHandler::KleeHandler(int argc, char **argv)
       if (errno != EEXIST)
         klee_error("cannot create \"%s\": %s", m_outputDirectory.c_str(), strerror(errno));
     }
-    if (i == INT_MAX && m_outputDirectory.str().equals(""))
+    if (i == INT_MAX && m_outputDirectory.str() == "")
         klee_error("cannot create output directory: index out of range");
   }
 
@@ -661,9 +665,14 @@ std::string KleeHandler::getRunTimeLibraryPath(const char *argv0) {
 
   SmallString<128> libDir;
 
-  if (strlen( KLEE_INSTALL_BIN_DIR ) != 0 &&
-      strlen( KLEE_INSTALL_RUNTIME_DIR ) != 0 &&
-      toolRoot.str().endswith( KLEE_INSTALL_BIN_DIR ))
+  if (strlen(KLEE_INSTALL_BIN_DIR) != 0 &&
+      strlen(KLEE_INSTALL_RUNTIME_DIR) != 0 &&
+#if LLVM_VERSION_CODE >= LLVM_VERSION(16, 0)
+      toolRoot.str().ends_with(KLEE_INSTALL_BIN_DIR)
+#else
+      toolRoot.str().endswith(KLEE_INSTALL_BIN_DIR)
+#endif
+  )
   {
     KLEE_DEBUG_WITH_TYPE("klee_runtime", llvm::dbgs() <<
                          "Using installed KLEE library runtime: ");


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 

See #1739 for previous discussion. I was asked to open a separate PR for the LLVM 17 compatibility patches, this now also includes LLVM 19 (at least, it compiles).

They deprecated `startswith` in LLVM 18 and removed it in LLVM 19. To stay compatible with LLVM 13 I changed it to `.find()` instead of `#if` and duplicating the code.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
