### PR TITLE
fix ASan support for GCC 14 (and modernize it)

### DIFF
--- a/lib/Support/MemoryUsage.cpp
+++ b/lib/Support/MemoryUsage.cpp
@@ -30,65 +30,37 @@
 // will use ASan's public interface to query how much memory has been
 // allocated.
 //
-// Unfortunately the interface is dependent on the compiler version. It is also
-// unfortunate that the way to detect compilation with ASan differs between
-// compilers. The preprocessor code below tries to determine if ASan is enabled
-// and if so which interface should be used.
-//
-// If ASan is enabled the `KLEE_ASAN_BUILD` macro will be defined other it will
-// be undefined. If `KLEE_ASAN_BUILD` is defined then the
-// `ASAN_GET_ALLOCATED_MEM_FUNCTION` macro will defined to the name of the ASan
-// function that can be called to get memory allocation
+// If and only if ASan is enabled the `KLEE_ASAN_BUILD` macro will be defined.
 
 // Make sure we start with the macro being undefined.
 #undef KLEE_ASAN_BUILD
 
-// Clang and ASan
 #if defined(__has_feature)
-#  if __has_feature(address_sanitizer)
-#     if __has_include("sanitizer/allocator_interface.h")
-#       include <sanitizer/allocator_interface.h>
-        // Modern interface
-#       define ASAN_GET_ALLOCATED_MEM_FUNCTION __sanitizer_get_current_allocated_bytes
-#     else
-#       include <sanitizer/asan_interface.h>
-        // Deprecated interface.
-#       define ASAN_GET_ALLOCATED_MEM_FUNCTION __asan_get_current_allocated_bytes
-#     endif /* has_include("sanitizer/allocator_interface.h") */
-#    define KLEE_ASAN_BUILD
-#  endif /* __has_feature(address_sanitizer) */
+#if __has_feature(address_sanitizer)
+#define KLEE_ASAN_BUILD
+#endif                              /* __has_feature(address_sanitizer) */
+#elif defined(__SANITIZE_ADDRESS__) // no __has_feature support before GCC 14
+#define KLEE_ASAN_BUILD
 #endif /* defined(__has_feature) */
 
-// For GCC and ASan
-#ifndef KLEE_ASAN_BUILD
-#  if defined(__SANITIZE_ADDRESS__)
-     // HACK: GCC doesn't ship `allocator_interface.h`  or `asan_interface.h` so
-     // just provide the proto-types here.
-     extern "C" {
-       size_t __sanitizer_get_current_allocated_bytes();
-       size_t __asan_get_current_allocated_bytes(); // Deprecated.
-     }
-     // HACK: Guess which function to use based on GCC version
-#    if __GNUC__ > 4
-       // Tested with gcc 5.2, 5.4, and 6.2.1
-       // Modern interface
-#      define ASAN_GET_ALLOCATED_MEM_FUNCTION __sanitizer_get_current_allocated_bytes
-#    else
-       // Tested with gcc 4.8 and 4.9
-       // Deprecated interface
-#      define ASAN_GET_ALLOCATED_MEM_FUNCTION __asan_get_current_allocated_bytes
-#    endif
-#    define KLEE_ASAN_BUILD
-#  endif /* defined(__SANITIZE_ADDRESS__) */
-#endif /* ndef KLEE_ASAN_BUILD */
+#ifdef KLEE_ASAN_BUILD
+#if __has_include(<sanitizer/allocator_interface.h>)
+#include <sanitizer/allocator_interface.h>
+#else
+// GCC doesn't ship `allocator_interface.h` so just provide the prototype here.
+extern "C" {
+size_t __sanitizer_get_current_allocated_bytes();
+}
+#endif /* has_include(<sanitizer/allocator_interface.h>) */
+#endif /* KLEE_ASAN_BUILD */
 
 using namespace klee;
 
 size_t util::GetTotalMallocUsage() {
 #ifdef KLEE_ASAN_BUILD
-  // When building with ASan on Linux `mallinfo()` just returns 0 so use ASan runtime
-  // function instead to get used memory.
-  return ASAN_GET_ALLOCATED_MEM_FUNCTION();
+  // When building with ASan on Linux `mallinfo()` just returns 0 so use ASan
+  // runtime function instead to get used memory.
+  return __sanitizer_get_current_allocated_bytes();
 #endif
 
 #ifdef HAVE_GPERFTOOLS_MALLOC_EXTENSION_H


### PR DESCRIPTION

## Summary: 
[GCC 14 supports `__has_feature()`](https://gcc.gnu.org/gcc-14/changes.html) to be compatible with Clang.
However, GCC still does not ship the header file `<sanitizer/allocator_interface.h>`.

The current handling code thus leads to the following error when comping KLEE with ASan support and GCC 14.2:
```
klee/lib/Support/MemoryUsage.cpp: In function ‘size_t klee::util::GetTotalMallocUsage()’:
klee/lib/Support/MemoryUsage.cpp:56:48: error: ‘__asan_get_current_allocated_bytes’ was not declared in this scope; did you mean ‘__asan_get_current_fake_stack’?
   56 | #       define ASAN_GET_ALLOCATED_MEM_FUNCTION __asan_get_current_allocated_bytes
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
klee/lib/Support/MemoryUsage.cpp:91:10: note: in expansion of macro ‘ASAN_GET_ALLOCATED_MEM_FUNCTION’
   91 |   return ASAN_GET_ALLOCATED_MEM_FUNCTION();
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I fixed the above issue and modernized the code a bit.
The interface `__asan_get_current_allocated_bytes()` was already deprecated when the code was last changed in 2017.
In addition, as we require C++17 for a while now, I think we can safely drop support for GCC versions 4.8 and 4.9.

As the changes should still allow for all (relevant) previous cases, I have not tested the new code with different / older compiler versions.

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [X] There are test cases for the code you added or modified OR no such test cases are required.
