### PR TITLE
fix: Dockerfile warning FromAsCasing inconsistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ghcr.io/klee/stp:2.3.3_ubuntu_jammy-20230126 AS stp_base
 FROM ghcr.io/klee/z3:4.8.15_ubuntu_jammy-20230126 AS z3_base
 FROM ghcr.io/klee/libcxx:130_ubuntu_jammy-20230126 AS libcxx_base
 FROM ghcr.io/klee/sqlite:3400100_ubuntu_jammy-20230126 AS sqlite3_base
-FROM llvm_base as intermediate
+FROM llvm_base AS intermediate
 COPY --from=gtest_base /tmp /tmp/
 COPY --from=uclibc_base /tmp /tmp/
 COPY --from=tcmalloc_base /tmp /tmp/


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 
Docker now warns on building the dockerfile:
```
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 9)
```
This PR simply fixes the casing of the `AS` to much the `FROM` (and other instances of `AS`).

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
