### PR TITLE
Fix MemoryManager reuse across runFunctionAsMain calls

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3589,14 +3589,24 @@ bool Executor::checkMemoryUsage() {
 }
 
 void Executor::doDumpStates() {
-  if (!DumpStatesOnHalt || states.empty()) {
-    interpreterHandler->incPathsExplored(states.size());
+  if (states.empty())
     return;
+
+  std::vector<ExecutionState *> remainingStates(states.begin(), states.end());
+
+  if (DumpStatesOnHalt) {
+    klee_message("halting execution, dumping remaining states");
+
+    for (ExecutionState *state : remainingStates) {
+      terminateStateEarly(*state, "Execution halting.",
+                          StateTerminationType::Interrupted);
+    }
+  } else {
+    for (ExecutionState *state : remainingStates) {
+      terminateState(*state, StateTerminationType::Interrupted);
+    }
   }
 
-  klee_message("halting execution, dumping remaining states");
-  for (const auto &state : states)
-    terminateStateEarly(*state, "Execution halting.", StateTerminationType::Interrupted);
   updateStates(nullptr);
 }
 
@@ -4774,7 +4784,7 @@ void Executor::runFunctionAsMain(Function *f,
   executionTree = nullptr;
 
   // hack to clear memory objects
-  memory = nullptr;
+  memory = std::make_unique<MemoryManager>(&arrayCache);
 
   globalObjects.clear();
   globalAddresses.clear();

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3592,20 +3592,15 @@ void Executor::doDumpStates() {
   if (states.empty())
     return;
 
-  std::vector<ExecutionState *> remainingStates(states.begin(), states.end());
-
-  if (DumpStatesOnHalt) {
+  if (DumpStatesOnHalt)
     klee_message("halting execution, dumping remaining states");
 
-    for (ExecutionState *state : remainingStates) {
+  for (ExecutionState *state : states)
+    if (DumpStatesOnHalt)
       terminateStateEarly(*state, "Execution halting.",
                           StateTerminationType::Interrupted);
-    }
-  } else {
-    for (ExecutionState *state : remainingStates) {
+    else
       terminateState(*state, StateTerminationType::Interrupted);
-    }
-  }
 
   updateStates(nullptr);
 }

--- a/test/Replay/klee-replay/ReplayKTestDirAfterError.c
+++ b/test/Replay/klee-replay/ReplayKTestDirAfterError.c
@@ -1,0 +1,30 @@
+// RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out %t.replay-out %t.replay
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors %t.bc
+// RUN: mkdir -p %t.replay
+// RUN: cp %t.klee-out/test*.ktest %t.replay/
+// RUN: %klee --output-dir=%t.replay-out --replay-ktest-dir=%t.replay %t.bc 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+#include <assert.h>
+
+int main(void) {
+  int x;
+  klee_make_symbolic(&x, sizeof(x), "x");
+
+  if (x == 0) {
+    klee_assert(0 && "first replay error");
+  }
+
+  if (x == 1) {
+    klee_assert(0 && "second replay error");
+  }
+
+  return 0;
+}
+
+// CHECK: KLEE: replaying:
+// CHECK: KLEE: ERROR:
+// CHECK: KLEE: replaying:
+// CHECK: KLEE: ERROR:
+// CHECK: KLEE: done:


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary 

This PR fixes a crash when `Executor::runFunctionAsMain()` is invoked multiple
times, for example when replaying multiple `.ktest` files.

Previously, `runFunctionAsMain()` cleared the executor memory manager by setting
`memory = nullptr` at the end of a run. If the same `Executor` instance was then
used for another run, later allocations could dereference an unset memory
manager.

This PR changes the cleanup path to install a fresh `MemoryManager` after the
per-run state has been cleared.

It also updates `doDumpStates()` so that active states are removed even when
`DumpStatesOnHalt` is false. This avoids leaving live `ExecutionState`s whose
address spaces may still reference `MemoryObject`s from the old memory manager.

Observed failure:

- replaying multiple `.ktest` inputs
- the first replay terminates with a KLEE error, for example a pointer error
- the next replay crashes in `MemoryManager::allocate()` because `memory` was
  null

Relevant stack trace excerpt:

```text
KLEE: replaying: 0x556279fc9590 (69 bytes) (1/2)
KLEE: ERROR: (location information missing) memory error: out of bound pointer
KLEE: replaying: 0x556279fc95f0 (29 bytes) (2/2)
#4  klee::ref<klee::kdalloc::Allocator::Control>::isNull() const
#5  klee::kdalloc::Allocator::operator bool() const
#6  klee::kdalloc::Allocator::allocate(unsigned long)
#7  klee::MemoryManager::allocate(unsigned long, bool, bool,
                                  klee::ExecutionState*,
                                  llvm::Value const*, unsigned long)
#8  klee::Executor::runFunctionAsMain(llvm::Function*, int, char**, char**)
#9  main
KLEE: WARNING: KLEE: watchdog exiting (no child)
```

The replayed `.ktest` files came from a generated test driver for this function:

```c
long sum_array(const int *arr, int count) {
  long sum = 0;

  for (int i = 0; i < count; i++) {
    sum += arr[i];
  }

  return sum;
}
```

The relevant symbolic inputs were the array/null selector, `count`:

The failing replay sequence included cases where `arr` was null and `count` was
large, which first produced the expected KLEE pointer error. The following replay
then crashed in `Executor::runFunctionAsMain()` because the previous run had
cleared the executor memory manager.


## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
