### PR TITLE
Make test FunctionPointer.c less fragile by changing CHECK to CHECK-DAG, as both orders are allowed

### DIFF
--- a/test/Feature/FunctionPointer.c
+++ b/test/Feature/FunctionPointer.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
   xx("called via xx");
 
   klee_make_symbolic(&fp, sizeof fp, "fp");
-  if(fp == baz) {
+  if (fp == baz) {
     // CHECK: baz: calling via simple symbolic!
     printf("fp = %p, baz = %p\n", fp, baz);
     fp("calling via simple symbolic!");
@@ -41,9 +41,9 @@ int main(int argc, char **argv) {
 
   void (*fp2)(const char *);
   klee_make_symbolic(&fp2, sizeof fp2, "fp2");
-  if(fp2 == baz || fp2 == foo) {
-    // CHECK: baz: calling via symbolic!
-    // CHECK: foo: calling via symbolic!
+  if (fp2 == baz || fp2 == foo) {
+    // CHECK-DAG: baz: calling via symbolic!
+    // CHECK-DAG: foo: calling via symbolic!
     fp2("calling via symbolic!");
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 
Make test FunctionPointer.c less fragile by changing CHECK to CHECK-DAG, as both orders are allowed

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
