### PR TITLE
test/Concrete/ConstantExpr.ll: Replace select instruction no longer supported in newer LLVM versions

### DIFF
--- a/test/Concrete/ConstantExpr.ll
+++ b/test/Concrete/ConstantExpr.ll
@@ -1,4 +1,3 @@
-; REQUIRES: geq-llvm-15.0
 ; RUN: %S/ConcreteTest.py --klee='%klee' --lli=%lli %s
 
 ; Most of the test below use the *address* of gInt as part of their computation,
@@ -69,7 +68,9 @@ define void @"test_logical_ops"() {
 
 define void @"test_misc"() {
   ; probability that @gInt == 100 is very very low 
-  %t1 = add i32 select(i1 icmp eq (i32* @gInt, i32* inttoptr(i32 100 to i32*)), i32 10, i32 0), 0
+  %t1.cmp = icmp eq i32* @gInt, inttoptr(i32 100 to i32*)
+  %t1.select = select i1 %t1.cmp, i32 10, i32 0
+  %t1 = add i32 %t1.select, 0
   call void @print_i32(i32 %t1)
 
   %t2 = load i32, i32* getelementptr(%test.struct.type, %test.struct.type* @test_struct, i32 0, i32 1)


### PR DESCRIPTION


<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 

test/Concrete/ConstantExpr.ll: Replace select instruction no longer supported in newer LLVM versions
This change also allows us to remove the requirement for LLVM >= 15

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
