### PR TITLE
POSIX runtime: enforce fd access mode checks for sym-file read/write operations

### DIFF
--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -376,6 +376,12 @@ ssize_t read(int fd, void *buf, size_t count) {
     return r;
   }
   else {
+
+    if (!(f->flags & eReadable)) {
+      errno = EBADF;
+      return -1;
+    }
+
     assert(f->off >= 0);
     if (((off64_t)f->dfile->size) < f->off)
       return 0;
@@ -435,6 +441,12 @@ ssize_t write(int fd, const void *buf, size_t count) {
     return r;
   }
   else {
+
+    if (!(f->flags & eWriteable)) {
+      errno = EBADF;
+      return -1;
+    }
+
     /* symbolic file */    
     size_t actual_count = 0;
     if (f->off + count <= f->dfile->size)

--- a/test/Runtime/POSIX/FileAccessMode.c
+++ b/test/Runtime/POSIX/FileAccessMode.c
@@ -1,0 +1,27 @@
+// RUN: %clang %s -emit-llvm %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --exit-on-error --libc=uclibc --posix-runtime %t.bc --sym-files 1 10
+
+#include "klee/klee.h"
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+  char buf[1];
+
+  int rfd = open("A", O_RDONLY);
+  if (rfd < 0)
+    klee_silent_exit(0); // open will be denied on some symbolic paths so it doesn't count as a test failure
+  assert(write(rfd, "x", 1) == -1 && errno == EBADF);
+  close(rfd);
+
+  int wfd = open("A", O_WRONLY);
+  if (wfd < 0)
+    klee_silent_exit(0); // file not writable on this path so we skip so it doesn't count as a test failure
+  assert(read(wfd, buf, 1) == -1 && errno == EBADF);
+  close(wfd);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary: 
POSIX runtime: enforce fd access mode checks for sym-file read/write operations. Previously, sym-files could be read from descriptors opened with O_WRONLY and written to descriptors opened with O_RDONLY because read() and write() summaries did not validate the corresponding eReadable and eWriteable flags. Added access mode checks to ensure reads require eReadable and writes require eWriteable, matching POSIX semantics.

## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so. 

The issue is permission checking although if necessary can be split into read/write permission checking.

- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [X] There are test cases for the code you added or modified OR no such test cases are required.

Not sure what to write here since I have been doing my own tests: https://github.com/dino-fan777/klee-tests/tree/main/individual_Tests.

- [X] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).

Note: I'm relatively new to contributing to open-source projects and still learning the ropes of symbolic execution. I did my best to follow the project's conventions, but I may have missed something. I'm happy to make any changes needed, feedback is very welcome!
