### PR TITLE
Fixed compiler warning about variable length arrays in C++

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1974,7 +1974,8 @@ void Executor::executeCall(ExecutionState &state, KInstruction *ki, Function *f,
       uint64_t size = 0; // total size of variadic arguments
       bool requires16ByteAlignment = false;
 
-      uint64_t offsets[callingArgs]; // offsets of variadic arguments
+      // Offsets of variadic arguments.
+      std::vector<uint64_t> offsets(callingArgs);
       uint64_t argWidth;             // width of current variadic argument
 
       const CallBase &cb = cast<CallBase>(*i);

--- a/tools/ktest-gen/ktest-gen.cpp
+++ b/tools/ktest-gen/ktest-gen.cpp
@@ -16,6 +16,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <vector>
+
 #include "klee/ADT/KTest.h"
 
 #if defined(__FreeBSD__) || defined(__minix) || defined(__APPLE__)
@@ -131,9 +133,9 @@ int main(int argc, char *argv[]) {
     char filename[7] = "A_data";
     char statname[12] = "A_data_stat";
     char sym_file_name = 'A';
-    FILE *fp[file_counter];
-    unsigned char *file_content[file_counter];
-    struct stat64 file_stat[file_counter];
+    std::vector<FILE *> fp(file_counter);
+    std::vector<unsigned char *> file_content(file_counter);
+    std::vector<struct stat64> file_stat(file_counter);
     long max_file_size = 0;
 
     for (unsigned current_file = 0; current_file < file_counter;
@@ -146,7 +148,7 @@ int main(int argc, char *argv[]) {
 #endif
 #endif
       if ((fp[current_file] = fopen(content_filename, "r")) == NULL ||
-          stat64(content_filename, file_stat + current_file) < 0) {
+          stat64(content_filename, &file_stat[current_file]) < 0) {
         perror("Failed to open");
         fprintf(stderr, "Failure opening %s %p\n", content_filename,
                 fp[current_file]);


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 
Fixed compiler warning about variable length arrays in C++

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
