### PR TITLE
Improve support for llvm.load.relative by converting relative tables to absolute ones. 

### DIFF
--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -35,6 +35,54 @@ DISABLE_WARNING_POP
 using namespace llvm;
 
 namespace klee {
+namespace {
+
+// Extract the target pointer from a relative-table entry of the form
+// trunc(ptrtoint(target) - ptrtoint(table)).
+Constant *getRelativeTarget(Constant *entry, const GlobalVariable *table) {
+  auto *trunc = dyn_cast<ConstantExpr>(entry);
+  if (!trunc || trunc->getOpcode() != Instruction::Trunc)
+    return nullptr;
+  auto *sub = dyn_cast<ConstantExpr>(trunc->getOperand(0));
+  if (!sub || sub->getOpcode() != Instruction::Sub)
+    return nullptr;
+  auto *targetAsInt = dyn_cast<ConstantExpr>(sub->getOperand(0));
+  auto *baseAsInt = dyn_cast<ConstantExpr>(sub->getOperand(1));
+  if (!targetAsInt || targetAsInt->getOpcode() != Instruction::PtrToInt ||
+      !baseAsInt || baseAsInt->getOpcode() != Instruction::PtrToInt ||
+      baseAsInt->getOperand(0)->stripPointerCasts() != table)
+    return nullptr;
+  return cast<Constant>(targetAsInt->getOperand(0));
+}
+
+// Convert a constant i32 relative-offset table into an equivalent absolute
+// pointer table
+GlobalVariable *getAbsoluteRelativeTable(Module &M, GlobalVariable *table,
+                                         Type *pointerType) {
+  auto *initializer = dyn_cast_or_null<ConstantArray>(table->getInitializer());
+  if (!initializer ||
+      !initializer->getType()->getElementType()->isIntegerTy(32))
+    return nullptr;
+  std::string name = (table->getName() + ".klee_absolute").str();
+  if (auto *absoluteTable = M.getNamedGlobal(name))
+    return absoluteTable;
+  std::vector<Constant *> targets;
+  targets.reserve(initializer->getNumOperands());
+  for (Value *operand : initializer->operand_values()) {
+    Constant *target = getRelativeTarget(cast<Constant>(operand), table);
+    if (!target)
+      return nullptr;
+    targets.push_back(ConstantExpr::getPointerCast(target, pointerType));
+  }
+  auto *arrayType = ArrayType::get(pointerType, targets.size());
+  auto *absoluteTable = new GlobalVariable(
+      M, arrayType, true, GlobalValue::PrivateLinkage,
+      ConstantArray::get(arrayType, targets), name);
+  absoluteTable->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+  return absoluteTable;
+}
+
+} // namespace
 
 char IntrinsicCleanerPass::ID;
 
@@ -334,7 +382,7 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
 
         i = ii->eraseFromParent();
 
-        // check if the instruction after the one we just replaced is not the
+        // Check if the instruction after the one we just replaced is not the
         // end of the basic block and if it is not (i.e. it is a valid
         // instruction), delete it and all remaining because the cleaner just
         // introduced a terminating instruction (unreachable) otherwise llvm will
@@ -353,6 +401,28 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
         Value *base = ii->getArgOperand(0);
         Value *offset = ii->getArgOperand(1);
         unsigned addressSpace = base->getType()->getPointerAddressSpace();
+
+        // Relative tables encode signed 32-bit link-time relocations. KLEE's
+        // deterministic allocator (KDAlloc) may place the table and its targets
+        // more than 2 GiB apart, so preserve the relocation by converting a
+        // static relative table to an absolute pointer table before execution.
+        if (auto *table = dyn_cast<GlobalVariable>(base->stripPointerCasts())) {
+          if (auto *absoluteTable =
+                  getAbsoluteRelativeTable(M, table, ii->getType())) {
+            Value *index = Builder.CreateUDiv(
+                offset, ConstantInt::get(offset->getType(), 4),
+                "load.relative.index");
+            Value *entry = Builder.CreateInBoundsGEP(
+                absoluteTable->getValueType(), absoluteTable,
+                {Builder.getInt32(0), index}, "load.relative.entry");
+            Value *result =
+                Builder.CreateLoad(ii->getType(), entry, "load.relative.result");
+            ii->replaceAllUsesWith(result);
+            ii->eraseFromParent();
+            dirty = true;
+            break;
+          }
+        }
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(15, 0)
         Value *baseAsI8 = base;

--- a/test/Intrinsics/load-relative.ll
+++ b/test/Intrinsics/load-relative.ll
@@ -1,14 +1,14 @@
 ; RUN: %llvmas %s -o=%t.bc
 ; RUN: rm -rf %t.klee-out
-; RUN: %klee -exit-on-error --output-dir=%t.klee-out --optimize=false %t.bc
+; RUN: %klee -exit-on-error --output-dir=%t.klee-out %t.bc
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-@target = internal global i8 7, align 1
-@table = internal global [2 x i32] [
-  i32 trunc (i64 sub (i64 ptrtoint (i8* @target to i64), i64 ptrtoint ([2 x i32]* @table to i64)) to i32),
-  i32 0
+@target = internal constant [17 x i8] c"load-relative-ok\00", align 1
+@table = internal constant [2 x i32] [
+  i32 trunc (i64 sub (i64 ptrtoint ([17 x i8]* @target to i64), i64 ptrtoint ([2 x i32]* @table to i64)) to i32),
+  i32 trunc (i64 sub (i64 ptrtoint ([17 x i8]* @target to i64), i64 ptrtoint ([2 x i32]* @table to i64)) to i32)
 ], align 4
 
 declare i8* @llvm.load.relative.i64(i8*, i64)
@@ -17,9 +17,9 @@ declare void @klee_abort(i8*)
 define i32 @main() {
 entry:
   %base = bitcast [2 x i32]* @table to i8*
-  %ptr = call i8* @llvm.load.relative.i64(i8* %base, i64 0)
+  %ptr = call i8* @llvm.load.relative.i64(i8* %base, i64 4)
   %value = load i8, i8* %ptr, align 1
-  %ok = icmp eq i8 %value, 7
+  %ok = icmp eq i8 %value, 108
   br i1 %ok, label %done, label %abort
 
 abort:


### PR DESCRIPTION
<!--Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 
Improve support for llvm.load.relative by converting relative tables to absolute ones. 
This becomes a problem when LLVM 16 (and likely later versions) and --kdalloc are used. 
LLVM 16 generates such relative table accesses, but KDAlloc may place the table and its targets more than 2 GiB apart.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
