### PR TITLE
Avoid leaking solver shared memory segments

### DIFF
--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -178,7 +178,7 @@ STPSolverImpl::STPSolverImpl(bool useForkedSTP, bool optimizeDivides)
   if (useForkedSTP) {
     assert(shared_memory_id == 0 && "shared memory id already allocated");
     shared_memory_id =
-        shmget(IPC_PRIVATE, shared_memory_size, IPC_CREAT | 0700);
+        shmget(IPC_PRIVATE, shared_memory_size, IPC_CREAT | 0600);
     if (shared_memory_id < 0)
       llvm::report_fatal_error(
           llvm::Twine("unable to allocate shared memory region: ") +

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -26,6 +26,7 @@
 #include <array>
 #include <csignal>
 #include <memory>
+#include <string>
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <sys/wait.h>
@@ -179,11 +180,16 @@ STPSolverImpl::STPSolverImpl(bool useForkedSTP, bool optimizeDivides)
     shared_memory_id =
         shmget(IPC_PRIVATE, shared_memory_size, IPC_CREAT | 0700);
     if (shared_memory_id < 0)
-      llvm::report_fatal_error("unable to allocate shared memory region");
+      llvm::report_fatal_error(
+          llvm::Twine("unable to allocate shared memory region: ") +
+          llvm::sys::StrError(errno));
     shared_memory_ptr = (unsigned char *)shmat(shared_memory_id, nullptr, 0);
-    if (shared_memory_ptr == (void *)-1)
-      llvm::report_fatal_error("unable to attach shared memory region");
+    int shmatErrno = errno;
     shmctl(shared_memory_id, IPC_RMID, nullptr);
+    if (shared_memory_ptr == (void *)-1)
+      llvm::report_fatal_error(
+          llvm::Twine("unable to attach shared memory region: ") +
+          llvm::sys::StrError(shmatErrno));
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 
Avoid leaking solver shared memory segments.
Run into this issue many times on macOS.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
