### PR TITLE
Execute unsupported intrinsics via external calls

### DIFF
--- a/include/klee/Module/KCallable.h
+++ b/include/klee/Module/KCallable.h
@@ -25,7 +25,7 @@ namespace klee {
 /// Wrapper for callable objects passed in callExternalFunction
 class KCallable {
 public:
-  enum CallableKind { CK_Function, CK_InlineAsm };
+  enum CallableKind { CK_Function, CK_InlineAsm, CK_Intrinsic };
 
 private:
   const CallableKind Kind;
@@ -37,7 +37,7 @@ public:
 
   virtual llvm::StringRef getName() const = 0;
   virtual llvm::FunctionType *getFunctionType() const = 0;
-  virtual llvm::Value *getValue() = 0;
+  virtual llvm::Value *getValue() const = 0;
 
   virtual ~KCallable() = default;
 };
@@ -63,13 +63,37 @@ public:
     return value->getFunctionType();
   }
 
-  llvm::Value *getValue() override { return value; }
+  llvm::Value *getValue() const override { return value; }
 
   static bool classof(const KCallable *callable) {
     return callable->getKind() == CK_InlineAsm;
   }
 
   llvm::InlineAsm *getInlineAsm() { return value; }
+};
+
+/// Wrapper for unsupported LLVM intrinsics that can be handled through the
+/// external-call path when the selected external-call policy allows it.
+class KIntrinsic : public KCallable {
+  llvm::Function *value;
+
+public:
+  explicit KIntrinsic(llvm::Function *value)
+      : KCallable(CK_Intrinsic), value(value) {}
+
+  llvm::StringRef getName() const override { return value->getName(); }
+
+  llvm::FunctionType *getFunctionType() const override {
+    return value->getFunctionType();
+  }
+
+  llvm::Value *getValue() const override { return value; }
+
+  static bool classof(const KCallable *callable) {
+    return callable->getKind() == CK_Intrinsic;
+  }
+
+  llvm::Function *getFunction() const { return value; }
 };
 
 } // namespace klee

--- a/include/klee/Module/KModule.h
+++ b/include/klee/Module/KModule.h
@@ -68,7 +68,7 @@ namespace klee {
       return function->getFunctionType();
     }
 
-    llvm::Value *getValue() override { return function; }
+    llvm::Value *getValue() const override { return function; }
 
     static bool classof(const KCallable *callable) {
       return callable->getKind() == CK_Function;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1915,9 +1915,15 @@ void Executor::executeCall(ExecutionState &state, KInstruction *ki, Function *f,
       // FIXME: It would be nice to check for errors in the usage of this as
       // well.
     default:
-      klee_warning("unimplemented intrinsic: %s", f->getName().data());
-      terminateStateOnExecError(state, "unimplemented intrinsic");
-      return;
+      if (ExternalCalls != ExternalCallPolicy::None) {
+        KIntrinsic callable(f);
+        callExternalFunction(state, ki, &callable, arguments);
+        break;
+      } else {
+        klee_warning("unimplemented intrinsic: %s", f->getName().data());
+        terminateStateOnExecError(state, "unimplemented intrinsic");
+        return;
+      }
     }
 
     if (InvokeInst *ii = dyn_cast<InvokeInst>(i)) {

--- a/lib/Core/ExternalDispatcher.cpp
+++ b/lib/Core/ExternalDispatcher.cpp
@@ -324,6 +324,17 @@ Function *ExternalDispatcherImpl::createDispatcher(KCallable *target,
   } else if (auto* asmValue = dyn_cast<KInlineAsm>(target)) {
     result = Builder.CreateCall(asmValue->getInlineAsm(),
                                 llvm::ArrayRef<Value *>(args, args + i));
+  } else if (auto* intrinsicValue = dyn_cast<KIntrinsic>(target)) {
+    auto *intrinsic = intrinsicValue->getFunction();
+    // Re-declare the intrinsic in the dispatch module. Calling the original
+    // function from the user's module would create invalid cross-module IR.
+    auto dispatchTarget =
+        module->getOrInsertFunction(intrinsic->getName(),
+                                    intrinsic->getFunctionType(),
+                                    intrinsic->getAttributes());
+    result = Builder.CreateCall(dispatchTarget,
+                                llvm::ArrayRef<Value *>(args, args + i));
+    result->setCallingConv(intrinsic->getCallingConv());
   } else {
     assert(0 && "Unhandled KCallable derived class");
   }

--- a/test/Intrinsics/ExternalCallConcreteArgs.ll
+++ b/test/Intrinsics/ExternalCallConcreteArgs.ll
@@ -1,6 +1,8 @@
 ; RUN: %llvmas %s -o=%t.bc
-; RUN: rm -rf %t.klee-out
-; RUN: %klee --output-dir=%t.klee-out --optimize=false %t.bc 2>&1 | FileCheck %s
+; RUN: rm -rf %t.none.klee-out
+; RUN: rm -rf %t.concrete.klee-out
+; RUN: %klee --external-calls=none --output-dir=%t.none.klee-out --optimize=false %t.bc 2>&1 | FileCheck %s
+; RUN: %klee --external-calls=concrete -exit-on-error --output-dir=%t.concrete.klee-out --optimize=false %t.bc 2>&1 | FileCheck %s -check-prefix=CHECK-EXTERNAL-CONCRETE
 
 ; Check that IntrinsicCleaner notices missing intrinsic
 ; CHECK: KLEE: WARNING ONCE: unsupported intrinsic llvm.minnum.f32
@@ -16,8 +18,21 @@
 ; CHECK: KLEE: done: generated tests = 2
 
 
+; Check that Executor calls missing intrinsic as external
+; when only external function calls with concrete arguments are allowed
+; CHECK-EXTERNAL-CONCRETE: KLEE: WARNING ONCE: unsupported intrinsic llvm.minnum.f32
+; CHECK-EXTERNAL-CONCRETE-NOT: KLEE: WARNING: unimplemented intrinsic: llvm.minnum.f32
+; CHECK-EXTERNAL-CONCRETE-NOT: KLEE: ERROR: (location information missing) unimplemented intrinsic
+; CHECK-EXTERNAL-CONCRETE: KLEE: WARNING ONCE: calling external: llvm.minnum.f32
 
-; This test checks that KLEE will ignore intrinsics that are not executed
+; Check that Executor explores all paths
+; CHECK-EXTERNAL-CONCRETE: KLEE: done: completed paths = 3
+; CHECK-EXTERNAL-CONCRETE: KLEE: done: partially completed paths = 0
+; CHECK-EXTERNAL-CONCRETE: KLEE: done: generated tests = 3
+
+
+; This test checks that KLEE will call intrinsics that are not implemented
+; when policy allows to do that
 ; It consists of a dead function that is called on one path but not on
 ; another path.
 ;

--- a/test/Intrinsics/ExternalCallSymbolicArgs.ll
+++ b/test/Intrinsics/ExternalCallSymbolicArgs.ll
@@ -1,0 +1,95 @@
+; RUN: %llvmas %s -o=%t1.bc
+; RUN: %llvmas %s -o=%t2.bc
+; RUN: %llvmas %s -o=%t3.bc
+; RUN: rm -rf %t1.klee-out
+; RUN: rm -rf %t2.klee-out
+; RUN: rm -rf %t3.klee-out
+; RUN: %klee --external-calls=concrete --output-dir=%t1.klee-out --optimize=false %t1.bc 2>&1 | FileCheck %s -check-prefix=CHECK-EXTERNAL-CONCRETE --check-prefix=CHECK
+; RUN: %klee --external-calls=all -exit-on-error --output-dir=%t2.klee-out --optimize=false %t2.bc 2>&1 | FileCheck %s -check-prefix=CHECK-EXTERNAL-ALL --check-prefix=CHECK
+; RUN: %klee --external-calls=over-approx -exit-on-error --output-dir=%t3.klee-out --optimize=false %t3.bc 2>&1 | FileCheck %s -check-prefix=CHECK-EXTERNAL-OVERAPPROX --check-prefix=CHECK
+
+; Check that IntrinsicCleaner notices missing intrinsic
+; CHECK: KLEE: WARNING ONCE: unsupported intrinsic llvm.minnum.f32
+
+; Check that Executor does not report the intrinsic as unimplemented
+; CHECK-NOT: KLEE: WARNING: unimplemented intrinsic: llvm.minnum.f32
+; CHECK-NOT: KLEE: ERROR: (location information missing) unimplemented intrinsic
+
+; Check that Executor does not call missing intrinsic as external
+; when only external function calls with concrete arguments are allowed
+; CHECK-EXTERNAL-CONCRETE: KLEE: ERROR: (location information missing) external call with symbolic argument: llvm.minnum.f32
+
+; Check that Executor explores all paths
+; CHECK-EXTERNAL-CONCRETE: KLEE: done: completed paths = 1
+; CHECK-EXTERNAL-CONCRETE: KLEE: done: partially completed paths = 2
+; CHECK-EXTERNAL-CONCRETE: KLEE: done: generated tests = 2
+
+
+; Check that Executor calls missing intrinsic as external
+; when all external function calls are allowed
+; CHECK-EXTERNAL-ALL-NOT: KLEE: WARNING: unimplemented intrinsic: llvm.minnum.f32
+; CHECK-EXTERNAL-ALL-NOT: KLEE: ERROR: (location information missing) unimplemented intrinsic
+; CHECK-EXTERNAL-ALL: KLEE: WARNING ONCE: calling external: llvm.minnum.f32
+; CHECK-EXTERNAL-OVERAPPROX-NOT: KLEE: WARNING: unimplemented intrinsic: llvm.minnum.f32
+; CHECK-EXTERNAL-OVERAPPROX-NOT: KLEE: ERROR: (location information missing) unimplemented intrinsic
+; CHECK-EXTERNAL-OVERAPPROX: KLEE: WARNING ONCE: calling external: llvm.minnum.f32
+
+; Check that Executor explores all paths
+; CHECK-EXTERNAL-ALL: KLEE: done: completed paths = 3
+; CHECK-EXTERNAL-ALL: KLEE: done: partially completed paths = 0
+; CHECK-EXTERNAL-ALL: KLEE: done: generated tests = 3
+; CHECK-EXTERNAL-OVERAPPROX: KLEE: done: completed paths = 3
+; CHECK-EXTERNAL-OVERAPPROX: KLEE: done: partially completed paths = 0
+; CHECK-EXTERNAL-OVERAPPROX: KLEE: done: generated tests = 3
+
+
+
+; This test checks that KLEE will call intrinsics that are not implemented
+; when policy allows to do that
+; It consists of a dead function that is called on one path but not on
+; another path.
+;
+; The choice of which unimplemented intrinsic to use in this test is arbitrary
+; and will need to be updated if the intrinsic is implemented.
+;
+; The dead function is called twice so that we can distinguish between
+; KLEE executing both paths successfully and KLEE aborting on
+; the last path it explores.
+
+declare float @llvm.minnum.f32(float, float)
+
+define void @dead() {
+  %sym_addr = alloca float, align 4
+  %cast_addr = bitcast float* %sym_addr to i8*
+  call void @klee_make_symbolic(i8* %cast_addr, i64 4, i8* null)
+  %sym_value = load float, float* %sym_addr, align 4
+  %x = call float @llvm.minnum.f32(float 1.0, float %sym_value)
+  ret void
+}
+
+declare void @klee_make_symbolic(i8*, i64, i8*)
+
+define i32 @main() {
+  %x1_addr = alloca i8, i8 1
+  call void @klee_make_symbolic(i8* %x1_addr, i64 1, i8* null)
+  %x1 = load i8, i8* %x1_addr
+
+  %x2_addr = alloca i8, i8 1
+  call void @klee_make_symbolic(i8* %x2_addr, i64 1, i8* null)
+  %x2 = load i8, i8* %x2_addr
+
+  %c1 = icmp eq i8 %x1, 0
+  br i1 %c1, label %useDeadIntrinsic1, label %skip1
+useDeadIntrinsic1:
+  call void @dead()
+  ret i32 1
+skip1:
+
+  %c2 = icmp eq i8 %x2, 0
+  br i1 %c2, label %skip2, label %useDeadIntrinsic2
+skip2:
+  ret i32 0
+useDeadIntrinsic2:
+  call void @dead()
+  ret i32 2
+}


### PR DESCRIPTION
Route unsupported LLVM intrinsics through the existing external-call policy instead of always terminating execution.

Add KIntrinsic as a KCallable wrapper so Executor can distinguish intrinsics from normal functions and inline asm while still using the ExternalDispatcher path. Re-declare intrinsics in the temporary dispatch module to avoid invalid cross-module IR.

This is a best-effort fallback for intrinsics that LLVM can lower through the JIT, not a replacement for direct symbolic support or lowering in IntrinsicCleaner.

Rename the missing-intrinsic regression to cover concrete arguments, and add a symbolic-argument case covering external-calls=none, concrete, all, and over-approx.

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [ x ] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [ x ] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [ x ] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [ x ] Each commit has a meaningful message documenting what it does.
- [ x ] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [ x ] The code is commented OR not applicable/necessary.
- [ x ] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [ x ] There are test cases for the code you added or modified OR no such test cases are required.
