### PR TITLE
UBSan: support LLVM 17 function handler ABI

### DIFF
--- a/include/klee/Core/TerminationTypes.h
+++ b/include/klee/Core/TerminationTypes.h
@@ -60,7 +60,8 @@ enum class StateTerminationClass : std::uint8_t {
   TTYPE(MissingReturn, 43U, "missing_return.err")                              \
   TTYPE(InvalidLoad, 44U, "invalid_load.err")                                  \
   TTYPE(NullableAttribute, 45U, "nullable_attribute.err")                      \
-  TTMARK(PROGERR, 45U)                                                         \
+  TTYPE(FunctionTypeMismatch, 46U, "function_type_mismatch.err")               \
+  TTMARK(PROGERR, 46U)                                                         \
   TTYPE(User, 50U, "user.err")                                                 \
   TTMARK(USERERR, 50U)                                                         \
   TTYPE(Execution, 60U, "exec.err")                                            \

--- a/runtime/Sanitizer/README.md
+++ b/runtime/Sanitizer/README.md
@@ -17,17 +17,25 @@ For compiling/linking with **all** available checks to catch **both** undefined 
 add one of the following options:
 
 * Short exclusive form
-    * `-fsanitize=undefined,float-divide-by-zero,unsigned-integer-overflow,implicit-conversion,nullability -fno-sanitize=local-bounds,function,vptr`
+    * LLVM 16 and lower
+        * `-fsanitize=undefined,float-divide-by-zero,unsigned-integer-overflow,implicit-conversion,nullability -fno-sanitize=local-bounds,function,vptr`
+    * LLVM 17 and higher
+        * `-fsanitize=undefined,float-divide-by-zero,unsigned-integer-overflow,implicit-conversion,nullability -fno-sanitize=local-bounds,vptr`
 * Verbose inclusive form
     * LLVM 11 and lower
         * `-fsanitize=alignment,bool,builtin,array-bounds,enum,float-cast-overflow,float-divide-by-zero,implicit-unsigned-integer-truncation,implicit-signed-integer-truncation,implicit-integer-sign-change,integer-divide-by-zero,nonnull-attribute,null,nullability-arg,nullability-assign,nullability-return,object-size,pointer-overflow,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,unsigned-integer-overflow,vla-bound`
-    * LLVM 12 and higher
+    * LLVM 12 through 16
         * `-fsanitize=alignment,bool,builtin,array-bounds,enum,float-cast-overflow,float-divide-by-zero,implicit-unsigned-integer-truncation,implicit-signed-integer-truncation,implicit-integer-sign-change,integer-divide-by-zero,nonnull-attribute,null,nullability-arg,nullability-assign,nullability-return,object-size,pointer-overflow,return,returns-nonnull-attribute,shift,unsigned-shift-base,signed-integer-overflow,unreachable,unsigned-integer-overflow,vla-bound`
+    * LLVM 17 and higher
+        * `-fsanitize=alignment,bool,builtin,array-bounds,enum,float-cast-overflow,float-divide-by-zero,function,implicit-unsigned-integer-truncation,implicit-signed-integer-truncation,implicit-integer-sign-change,integer-divide-by-zero,nonnull-attribute,null,nullability-arg,nullability-assign,nullability-return,object-size,pointer-overflow,return,returns-nonnull-attribute,shift,unsigned-shift-base,signed-integer-overflow,unreachable,unsigned-integer-overflow,vla-bound`
 
 For compiling/linking with **all** available checks to catch **only** undefined behaviour, just add
 the following option:
 
-* `-fsanitize=undefined -fno-sanitize=local-bounds,function,vptr`
+* LLVM 16 and lower
+    * `-fsanitize=undefined -fno-sanitize=local-bounds,function,vptr`
+* LLVM 17 and higher
+    * `-fsanitize=undefined -fno-sanitize=local-bounds,vptr`
 
 ## Available checks
 
@@ -40,6 +48,7 @@ Available checks for KLEE as are:
 * `-fsanitize=enum`
 * `-fsanitize=float-cast-overflow`
 * `-fsanitize=float-divide-by-zero`
+* `-fsanitize=function` (LLVM 17 and higher)
 * `-fsanitize=implicit-unsigned-integer-truncation`
 * `-fsanitize=implicit-signed-integer-truncation`
 * `-fsanitize=implicit-integer-sign-change`
@@ -65,7 +74,7 @@ Available checks for KLEE as are:
 Also, note some unavailable checks as are:
 
 * `-fsanitize=local-bounds`
-* `-fsanitize=function`
+* `-fsanitize=function` (LLVM 16 and lower)
 * `-fsanitize=objc-cast`
 * `-fsanitize=vptr`
 

--- a/runtime/Sanitizer/ubsan/ubsan_handlers.cpp
+++ b/runtime/Sanitizer/ubsan/ubsan_handlers.cpp
@@ -92,8 +92,12 @@ static const char *get_suffix(ErrorType ET) {
   case ErrorType::InvalidEnumLoad:
     return "invalid_load.err";
   case ErrorType::FunctionTypeMismatch:
+#if LLVM_VERSION_MAJOR >= 17
+    return "function_type_mismatch.err";
+#else
     // This check is unsupported
     return "exec.err";
+#endif
   case ErrorType::InvalidNullReturn:
   case ErrorType::InvalidNullReturnWithNullability:
   case ErrorType::InvalidNullArgument:
@@ -500,5 +504,25 @@ extern "C" void __ubsan_handle_pointer_overflow_abort(PointerOverflowData *Data,
 
   handlePointerOverflowImpl(Data, Base, Result);
 }
+
+#if LLVM_VERSION_MAJOR >= 17
+static void handleFunctionTypeMismatch(FunctionTypeMismatchData * /*Data*/,
+                                       ValueHandle /*Function*/) {
+  ErrorType ET = ErrorType::FunctionTypeMismatch;
+  report_error_type(ET);
+}
+
+extern "C" void
+__ubsan_handle_function_type_mismatch(FunctionTypeMismatchData *Data,
+                                      ValueHandle Function) {
+  handleFunctionTypeMismatch(Data, Function);
+}
+
+extern "C" void
+__ubsan_handle_function_type_mismatch_abort(FunctionTypeMismatchData *Data,
+                                            ValueHandle Function) {
+  handleFunctionTypeMismatch(Data, Function);
+}
+#endif
 
 } // namespace __ubsan

--- a/runtime/Sanitizer/ubsan/ubsan_handlers.h
+++ b/runtime/Sanitizer/ubsan/ubsan_handlers.h
@@ -102,4 +102,11 @@ struct PointerOverflowData {
   SourceLocation Loc;
 };
 
+#if LLVM_VERSION_MAJOR >= 17
+struct FunctionTypeMismatchData {
+  SourceLocation Loc;
+  const TypeDescriptor &Type;
+};
+#endif
+
 #endif // UBSAN_HANDLERS_H

--- a/test/UBSan/ubsan_function.cpp
+++ b/test/UBSan/ubsan_function.cpp
@@ -1,0 +1,18 @@
+// REQUIRES: geq-llvm-17.0
+// RUN: %clangxx %s -fsanitize=function -emit-llvm -g %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s
+// RUN: ls %t.klee-out/ | grep .ktest | wc -l | grep 1
+// RUN: ls %t.klee-out/ | grep .function_type_mismatch.err | wc -l | grep 1
+
+int target(int x) {
+  return x;
+}
+
+int main() {
+  typedef int (*MismatchedFunction)(double);
+  MismatchedFunction fp = reinterpret_cast<MismatchedFunction>(&target);
+
+  // CHECK: KLEE: ERROR: {{.*}}runtime/Sanitizer/ubsan/ubsan_handlers.cpp:{{[0-9]+}}: function-type-mismatch
+  return fp(1.0);
+}


### PR DESCRIPTION
Add support for the LLVM 17 function type mismatch handler ABI and expose it as a dedicated KLEE termination type.

The function sanitizer existed before LLVM 17, but Clang lowered it to the older C++ UBSan runtime ABI. That implementation compares RTTI type information in the runtime and may either report or continue execution, so it is not just another unconditional KLEE error handler. LLVM 17 introduced the simpler `__ubsan_handle_function_type_mismatch(Data, Function)` ABI used here, where the runtime handler always reports the function type mismatch.

LLVM 16 and older therefore remain unsupported for this sanitizer until KLEE models the older C++ runtime semantics.

Tested with minimal required runtime:

Built the LLVM 17 UBSan runtime and KLEE binary with build-llvm17-test. The focused UBSan lit test is active under LLVM 17, but execution is blocked before handler dispatch by the existing LLVM >= 17 Instrument.cpp stub.

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [ ] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [ ] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [ ] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [ ] Each commit has a meaningful message documenting what it does.
- [ ] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [ ] The code is commented OR not applicable/necessary.
- [ ] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [ ] There are test cases for the code you added or modified OR no such test cases are required.
