### PR TITLE
Recent versions of LLVM compile abs to llvm.abs.  Changed external ca…

### DIFF
--- a/test/Feature/ExtCall.c
+++ b/test/Feature/ExtCall.c
@@ -2,22 +2,23 @@
 // RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
 
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --external-calls=all --exit-on-error %t.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --external-calls=all --exit-on-error %t.bc abc def 2>&1 | FileCheck %s
 
 #include "klee/klee.h"
 
 #include <assert.h>
 #include <stdio.h>
-#include <stdlib.h>
+#include <string.h>
 
-int main() {
+int main(int argc, char **argv) {
   int x;
   klee_make_symbolic(&x, sizeof(x), "x");
-  klee_assume(x >= 0);
+  // x is 0 or 1; argv[1] is "abc"; argv[2] is "def"
+  klee_assume(x >= 1 & x <= 2);
 
-  int y = abs(x);
-  printf("y = %d\n", y);
-  // CHECK: calling external: abs((ReadLSB w32 0 x))
+  int len = strlen(argv[x]);
+  printf("len = %d\n", len);
+  // CHECK: calling external: strlen
 
-  assert(x == y);
+  assert(len == 3);
 }

--- a/test/Feature/ExtCallWarnings.c
+++ b/test/Feature/ExtCallWarnings.c
@@ -1,20 +1,20 @@
 // RUN: %clang %s -emit-llvm %O0opt -g -c -o %t.bc
 
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --external-call-warnings=none %t.bc 2>&1 | FileCheck --check-prefix=CHECK-NONE %s
+// RUN: %klee --output-dir=%t.klee-out --external-call-warnings=none %t.bc abc defg 2>&1 | FileCheck --check-prefix=CHECK-NONE %s
 
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --external-call-warnings=once-per-function %t.bc 2>&1 | FileCheck --check-prefix=CHECK-ONCE %s
+// RUN: %klee --output-dir=%t.klee-out --external-call-warnings=once-per-function %t.bc abc defg 2>&1 | FileCheck --check-prefix=CHECK-ONCE %s
 
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --external-call-warnings=all %t.bc 2>&1 | FileCheck --check-prefix=CHECK-ALL %s
+// RUN: %klee --output-dir=%t.klee-out --external-call-warnings=all %t.bc abc defg 2>&1 | FileCheck --check-prefix=CHECK-ALL %s
 
 #include "klee/klee.h"
 #include <stdio.h>
-#include <stdlib.h>
+#include <string.h>
 
-int main() {
-  return abs(-5) + abs(6);
+int main(int argc, char** argv) {
+  return strlen(argv[1]) + strlen(argv[2]);
   // CHECK-NONE-NOT: calling external
 
   // CHECK-ONCE: calling external

--- a/test/Feature/NoExternalCallsAllowed.c
+++ b/test/Feature/NoExternalCallsAllowed.c
@@ -1,13 +1,12 @@
 // RUN: %clang %s -emit-llvm %O0opt -c -g -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --external-calls=none %t1.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --external-calls=none %t1.bc abc def 2>&1 | FileCheck %s
 // RUN: test %t.klee-out/test000001.user.err
 #include <stdio.h>
-#include <stdlib.h>
+#include <string.h>
 
 int main(int argc, char** argv) {
-  // CHECK: Disallowed call to external function: abs
-  int x = abs(argc);
-  printf("%d\n", argc);
-  return 0;
+  // CHECK: Disallowed call to external function: strlen
+  int len = strlen(argv[0]);
+  printf("%d\n", len);
 }

--- a/test/Feature/SeedConcretizeExternalCall.c
+++ b/test/Feature/SeedConcretizeExternalCall.c
@@ -1,3 +1,6 @@
+// The test checks that when an external call is made with a symbolic
+// argument, the concretized value is chosen to be the seed value
+
 // RUN: %clang -emit-llvm -c -g %s -o %t.bc
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --entry-point=TestGen %t.bc
@@ -14,15 +17,20 @@
 #include <stdlib.h>
 
 void TestGen() {
-  int x;
-  klee_make_symbolic(&x, sizeof(x), "x");
-  klee_assume(x == 12345678);
+  int a, b;
+  klee_make_symbolic(&a, sizeof(a), "a");
+  klee_make_symbolic(&b, sizeof(b), "b");
+  klee_assume(a == 12345678);
+  klee_assume(b == 123456);
 }
 
 int main() {
-  int x;
-  klee_make_symbolic(&x, sizeof(x), "x");
-  assert(abs(x) == 12345678);
+  int a, b;
+  klee_make_symbolic(&a, sizeof(a), "a");
+  klee_make_symbolic(&b, sizeof(b), "b");
+  div_t r = div(a, b);
+  assert(r.quot == 100);
+  assert(r.rem == 78);
 
-  // CHECK-STATS: 1
+  // CHECK-STATS: 2
 }


### PR DESCRIPTION
…ll tests to use other external functions, in particular strlen() and div()

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 
Recent versions of LLVM compile abs to llvm.abs.  Changed external call tests to use other external functions, in particular strlen() and div()

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
