### PR TITLE
POSIX/fd.c: Properly initialize the read_request variable

### DIFF
--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -111,7 +111,7 @@ mode_t umask(mode_t mask) {
    s->st_uid / geteuid() and s->st_gid / getegid(). */
 static int has_permission(int flags, struct stat64 *s) {
   mode_t mode = s->st_mode;
-  int read_request = ((flags & O_RDONLY) | (flags & O_RDWR)) ? 1 : 0;
+  int read_request = (flags & O_WRONLY) ? 0 : 1;
   int write_request = ((flags & O_WRONLY) | (flags & O_RDWR)) ? 1 : 0;
 
   /* It is important to do this check using only bitwise operators so that we 

--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -153,7 +153,7 @@ int __fd_open(const char *pathname, int flags, mode_t mode) {
       return -1;
     }
     
-    if ((flags & O_TRUNC) && (flags & O_RDONLY)) {
+    if ((flags & O_TRUNC) && (flags & O_ACCMODE) == O_RDONLY) {
       /* The result of using O_TRUNC with O_RDONLY is undefined, so we
 	 return error */
       klee_warning("Undefined call to open(): O_TRUNC | O_RDONLY\n");


### PR DESCRIPTION
Since the O_RDONLY define evaluates to 0 the checking code in form of (flags & O_RDONLY) is invalid. Instead, set read_request to 0 only if O_WRONLY is specified.

Closes #1815

This probably might benefit from a test case.

## Summary: 


## Checklist:
- [X] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [X] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [X] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [X] Each commit has a meaningful message documenting what it does.
- [X] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [X] The code is commented OR not applicable/necessary.
- [ ] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [ ] There are test cases for the code you added or modified OR no such test cases are required.
