### PR TITLE
Fix dangling pointer in utimes() for symbolic files when the second argument is NULL

### DIFF
--- a/runtime/POSIX/fd.c
+++ b/runtime/POSIX/fd.c
@@ -252,9 +252,9 @@ int utimes(const char *path, const struct timeval times[2]) {
   exe_disk_file_t *dfile = __get_sym_file(path);
 
   if (dfile) {
+    struct timeval newTimes[2];
 
     if (!times) {
-      struct timeval newTimes[2];
       gettimeofday(&(newTimes[0]), NULL);
       newTimes[1] = newTimes[0];
       times = newTimes;

--- a/test/Runtime/POSIX/FileTime.c
+++ b/test/Runtime/POSIX/FileTime.c
@@ -1,7 +1,7 @@
 // Tests the functionality of setting and getting file access and modification times
 // RUN: %clang %s -emit-llvm %O0opt -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --libc=uclibc --posix-runtime %t1.bc --sym-files 1 1
+// RUN: %klee --output-dir=%t.klee-out --libc=uclibc --posix-runtime %t1.bc --sym-files 1 1 2>&1 | FileCheck %s
 
 #include <stdio.h>
 #include <assert.h>
@@ -15,6 +15,7 @@ int main(int argc, char** argv) {
   // Create the file
   FILE* const f = fopen(filePath, "w");
   assert(f);
+  // CHECK: KLEE: ERROR: {{.*}} ASSERTION FAIL: f
   const int r = fclose(f);
   assert(r == 0);
 
@@ -41,7 +42,9 @@ int main(int argc, char** argv) {
   stat(filePath, &sb);
 
   assert(sb.st_atim.tv_sec >= now.tv_sec && sb.st_atim.tv_sec <= someTimeAfter.tv_sec);
+  // CHECK-NOT: KLEE: ERROR: {{.*}} ASSERTION FAIL: sb.st_atim.tv_sec >= now.tv_sec && sb.st_atim.tv_sec <= someTimeAfter.tv_sec
   assert(sb.st_mtim.tv_sec >= now.tv_sec && sb.st_mtim.tv_sec <= someTimeAfter.tv_sec);
+  // CHECK-NOT: KLEE: ERROR: {{.*}} ASSERTION FAIL: sb.st_mtim.tv_sec >= now.tv_sec && sb.st_mtim.tv_sec <= someTimeAfter.tv_sec
   
   return 0;
 }


### PR DESCRIPTION
## Summary: 

In the runtime implementation of utimes(), there is a dangling pointer bug when file is symbolic and the second argument is NULL. This PR fixes it and modifies the testcase to check the correct behavior.

For the optimized Release runtime, the dangling pointer results in the copy `newTimes[1] = newTimes[0]` to be optimized out, therefore leaving `mtime` uninitialized. The fix moves the `newTimes` variable definition to the parent block.

## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
