### PR TITLE
UBSan: model LLVM 17 function sanitizer prefixes

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -64,6 +64,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
@@ -684,6 +685,92 @@ void Executor::initializeGlobals(ExecutionState &state) {
   initializeGlobalObjects(state);
 }
 
+MemoryObject *
+Executor::allocateFunctionMemoryObject(ExecutionState &state,
+                                       Function &function,
+                                       std::uint64_t prefixBytes) {
+  // KLEE has historically represented each function with an aligned 8-byte
+  // synthetic object. Reserve any requested prefix bytes before that object so
+  // callers can expose an adjusted function address.
+  constexpr std::uint64_t LegacyFunctionObjectBytes = 8;
+  constexpr std::uint64_t FunctionObjectBytes = LegacyFunctionObjectBytes;
+  constexpr std::uint64_t FunctionObjectAlignment = LegacyFunctionObjectBytes;
+
+  return memory->allocate(prefixBytes + FunctionObjectBytes,
+                          /*isLocal=*/false, /*isGlobal=*/true, &state,
+                          /*allocSite=*/&function, FunctionObjectAlignment);
+}
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(17, 0)
+/// For instrumented functions, the allocation and returned address look like:
+///   mo->address             mo->address + 4      returned function address
+///   v                       v                    v
+///   +----------------------+--------------------+--------------------------+
+///   | prologue signature   | function type hash | synthetic function object |
+///   +----------------------+--------------------+--------------------------+
+///
+/// The returned address is stored in `globalAddresses` and `legalFunctions`.
+/// LLVM's indirect-call check loads the prologue signature from that address
+/// minus 8 and the type hash from that address minus 4.
+///
+/// Relevant LLVM implementation references:
+/// - https://github.com/llvm/llvm-project/blob/release/17.x/clang/lib/CodeGen/CodeGenFunction.cpp#L964-L971
+///   sets `MD_func_sanitize`.
+/// - https://github.com/llvm/llvm-project/blob/release/17.x/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp#L980-L989
+///   emits the prefix words.
+/// - https://github.com/llvm/llvm-project/blob/release/17.x/clang/lib/CodeGen/CGExpr.cpp#L5332-L5390
+///   emits the indirect-call prefix reads.
+/// - https://github.com/llvm/llvm-project/blob/release/17.x/compiler-rt/lib/ubsan/ubsan_handlers.h#L234-L243
+///   defines the handler ABI.
+std::uint64_t
+Executor::allocateFunctionObjectWithUBSan(ExecutionState &state,
+                                          Function &function,
+                                          MDNode &metadata) {
+  // LLVM emits the function sanitizer prefix as 32-bit integer constants: the
+  // sanitizer prologue signature followed by the instrumented function's type
+  // hash. Keep the synthetic object layout tied to that ABI word type.
+  using PrefixWord = std::uint32_t;
+  constexpr unsigned PrefixWords = 2;
+  constexpr std::uint64_t WordBytes = sizeof(PrefixWord);
+  constexpr std::uint64_t PrefixBytes = PrefixWords * WordBytes;
+
+  // Clang's function sanitizer emits two 32-bit words immediately before each
+  // instrumented function and checks them via function_pointer minus the
+  // prefix size before calling __ubsan_handle_function_type_mismatch.
+  PrefixWord prefix[PrefixWords] = {0, 0};
+  assert(metadata.getNumOperands() == PrefixWords &&
+         "unexpected function sanitizer metadata shape");
+  for (unsigned i = 0; i < PrefixWords; ++i) {
+    auto *CI = mdconst::extract<ConstantInt>(metadata.getOperand(i));
+    assert(CI->getBitWidth() == Expr::Int32 &&
+           "unexpected function sanitizer metadata word width");
+    prefix[i] = CI->getZExtValue();
+  }
+
+  auto *mo = allocateFunctionMemoryObject(state, function, PrefixBytes);
+  ObjectState *os = bindObjectInState(state, mo, false);
+  for (unsigned i = 0; i < PrefixWords; ++i)
+    os->write32(i * WordBytes, prefix[i]);
+  os->setReadOnly(true);
+
+  return mo->address + PrefixBytes;
+}
+#endif
+
+std::uint64_t
+Executor::allocateFunctionObject(ExecutionState &state, Function &function) {
+  constexpr std::uint64_t NoPrefixBytes = 0;
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(17, 0)
+  auto *MD = function.getMetadata(LLVMContext::MD_func_sanitize);
+  if (MD != nullptr)
+    return allocateFunctionObjectWithUBSan(state, function, *MD);
+#endif
+
+  auto *mo = allocateFunctionMemoryObject(state, function, NoPrefixBytes);
+  return mo->address;
+}
+
 void Executor::allocateGlobalObjects(ExecutionState &state) {
   Module *m = kmodule->module.get();
 
@@ -706,9 +793,9 @@ void Executor::allocateGlobalObjects(ExecutionState &state) {
       // We allocate an object to represent each function,
       // its address can be used for function pointers.
       // TODO: Check whether the object is accessed?
-      auto mo = memory->allocate(8, false, true, &state, &f, 8);
-      addr = Expr::createPointer(mo->address);
-      legalFunctions.emplace(mo->address, &f);
+      auto functionAddress = allocateFunctionObject(state, f);
+      addr = Expr::createPointer(functionAddress);
+      legalFunctions.emplace(functionAddress, &f);
     }
 
     globalAddresses.emplace(&f, addr);

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -32,6 +32,7 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>
@@ -52,6 +53,7 @@ namespace llvm {
   class GlobalValue;
   class Instruction;
   class LLVMContext;
+  class MDNode;
   class DataLayout;
   class Twine;
   class Value;
@@ -228,6 +230,23 @@ private:
 			      unsigned offset);
   void initializeGlobals(ExecutionState &state);
   void allocateGlobalObjects(ExecutionState &state);
+
+  MemoryObject *allocateFunctionMemoryObject(ExecutionState &state,
+                                             llvm::Function &function,
+                                             std::uint64_t prefixBytes);
+
+  /// Allocate KLEE's synthetic object for a function and return the concrete
+  /// address that should be used as the function pointer value.
+  std::uint64_t allocateFunctionObject(ExecutionState &state,
+                                       llvm::Function &function);
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(17, 0)
+  /// Allocate a synthetic function object containing LLVM's UBSan function
+  /// sanitizer prefix and return the address after that prefix.
+  std::uint64_t allocateFunctionObjectWithUBSan(ExecutionState &state,
+                                                llvm::Function &function,
+                                                llvm::MDNode &metadata);
+#endif
   void initializeGlobalAliases();
   void initializeGlobalObjects(ExecutionState &state);
 

--- a/test/UBSan/ubsan_function.cpp
+++ b/test/UBSan/ubsan_function.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: geq-llvm-17.0
-// XFAIL: *
 // RUN: %clangxx %s -fsanitize=function -emit-llvm -g %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
 // RUN: %klee --output-dir=%t.klee-out --emit-all-errors --ubsan-runtime %t.bc 2>&1 | FileCheck %s


### PR DESCRIPTION
**NOTE: this is a follow-up change after introducing the "function" UBSan support in  #1813, and later adding full LLVM17 support in #1814**

LLVM 17 function sanitizer checks read a two-word prefix immediately before the indirect-call target. KLEE previously exposed the synthetic function object address directly, so those prefix loads addressed bytes before the object instead of the sanitizer metadata.

Allocate a prefixed synthetic function object for functions carrying func_sanitize metadata, expose the address after the prefix as the function pointer, and keep that exposed address as the legal indirect-call target. Older LLVM builds and functions without the metadata keep the existing synthetic function object layout.

Tested with minimal required runtime:

- Built the LLVM 17 UBSan runtime and KLEE binary

- Ran the focused LLVM 17 UBSan function lit test: `lit -sv build-llvm17-test/test --filter=ubsan_function`

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
