### PR TITLE
Use StringRef equality

### DIFF
--- a/lib/Module/Optimize.cpp
+++ b/lib/Module/Optimize.cpp
@@ -168,7 +168,7 @@ void klee::optimizeModule(llvm::Module *M,
       StringRef GVName = GV.getName();
 
       for (const char *fun : preservedFunctions)
-        if (GVName.equals(fun))
+        if (GVName == fun)
           return true;
 
       return false;


### PR DESCRIPTION
StringRef::equals() was removed in LLVM 19. Use operator==, which is available in older supported LLVM versions too.

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee-se.org/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
