### PR TITLE
Fix assertion error in `PPrinter::hasOrderedReads`.

### DIFF
--- a/lib/Expr/ExprPPrinter.cpp
+++ b/lib/Expr/ExprPPrinter.cpp
@@ -251,7 +251,9 @@ private:
     
     // Get stride expr in proper index width.
     Expr::Width idxWidth = base->index->getWidth();
-    ref<Expr> strideExpr = ConstantExpr::alloc(stride, idxWidth);
+    ref<ConstantExpr> strideExpr = ConstantExpr::alloc(1, idxWidth);
+    if (stride == -1)
+      strideExpr = strideExpr->Neg();
     ref<Expr> offset = ConstantExpr::create(0, idxWidth);
     
     e = e->getKid(1);


### PR DESCRIPTION
Right now when stride is `-1` but `idxWidth < 64`, we're calling `ConstantExpr::alloc(uint64_t, Width)`. Before the call, `-1` is converted to `UINT64_MAX`, which does fit in `idxWith`, resulting in an assert in `APInt`:

```
assert.h assertion failed at llvm/include/llvm/ADT/APInt.h:128 in llvm::APInt::APInt(unsigned int, uint64_t, bool, bool): llvm::isUIntN(BitWidth, val) && "Value is not an N-bit unsigned value"
*** Check failure stack trace: ***
    @     0x558dcd432cb4  __assert_fail
    @     0x558dc98716fa  klee::ConstantExpr::alloc()
    @     0x558dc98f2e5e  PPrinter::hasOrderedReads()
    @     0x558dc98efb95  PPrinter::print()
    @     0x558dc98f3588  PPrinter::printExpr()
    @     0x558dc98eff2e  PPrinter::print()
    @     0x558dc98f3643  PPrinter::printExpr()
    @     0x558dc98eff2e  PPrinter::print()
    @     0x558dc98f102e  klee::ExprPPrinter::printQuery()
    @     0x558dc98f041c  klee::ExprPPrinter::printConstraints()
    @     0x558dc988c437  klee::Executor::getConstraintLog()
    @     0x558dc98564d2  KleeHandler::processTestCase()
    @     0x558dc9888891  klee::Executor::terminateStateOnError()
    @     0x558dc98bd387  klee::SpecialFunctionHandler::handleAssertFail()
    @     0x558dc98bc80b  klee::SpecialFunctionHandler::handle()
    @     0x558dc98764b3  klee::Executor::callExternalFunction()
    @     0x558dc9874d6c  klee::Executor::executeCall()
    @     0x558dc987f613  klee::Executor::executeInstruction()
    @     0x558dc9885ed4  klee::Executor::run()
    @     0x558dc988beef  klee::Executor::runFunctionAsMain()
```

## Summary: 


## Checklist:
- [x] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [x] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [x] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [x] Each commit has a meaningful message documenting what it does.
- [x] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [x] The code is commented OR not applicable/necessary.
- [x] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [x] There are test cases for the code you added or modified OR no such test cases are required.
