### PR TITLE
Core: recompute GEP indices instead of accumulating them across runs

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3440,6 +3440,11 @@ void Executor::computeOffsetsSeqTy(KGEPInstruction *kgepi,
 
 template <typename TypeIt>
 void Executor::computeOffsets(KGEPInstruction *kgepi, TypeIt ib, TypeIt ie) {
+  // Recomputing the offsets of an instruction must overwrite the previous
+  // result, not add to it. bindModuleConstants() runs once per
+  // runFunctionAsMain() call, so each call would otherwise append another
+  // copy of every variable GEP index (e.g. when replaying several ktests).
+  kgepi->indices.clear();
   ref<ConstantExpr> constantOffset =
     ConstantExpr::alloc(0, Context::get().getPointerWidth());
   uint64_t index = 1;

--- a/test/Replay/klee-replay/ReplayKTestDirGEPIndices.c
+++ b/test/Replay/klee-replay/ReplayKTestDirGEPIndices.c
@@ -1,0 +1,32 @@
+// Variable GEP indices must be recomputed, not accumulated, when
+// bindModuleConstants() runs for each runFunctionAsMain() call. Without the
+// clear, the second replay in this test has two copies of every variable
+// index, and a[i] silently reads a[2*i].
+
+// RUN: %clang %s -emit-llvm -g %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out %t.replay-out %t.replay
+// RUN: %klee --output-dir=%t.klee-out %t.bc
+// RUN: mkdir -p %t.replay
+// RUN: cp %t.klee-out/test000001.ktest %t.replay/test1.ktest
+// RUN: cp %t.klee-out/test000001.ktest %t.replay/test2.ktest
+// RUN: %klee --output-dir=%t.replay-out --replay-ktest-dir=%t.replay %t.bc 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+
+int main(void) {
+  int i;
+  klee_make_symbolic(&i, sizeof i, "i");
+  klee_assume(i == 1); // single path: exactly one ktest is generated
+
+  volatile int a[4] = {10, 11, 12, 13};
+  int v = a[i]; // must read a[1] == 11 in every replay
+
+  if (v != 11)
+    klee_report_error(__FILE__, __LINE__, "variable GEP index applied twice",
+                      "gep.err");
+  return 0;
+}
+
+// Replaying the same input twice must take the same path both times.
+// CHECK-NOT: variable GEP index applied twice
+// CHECK: KLEE: done: completed paths = 2


### PR DESCRIPTION
## Summary

`Executor::computeOffsets()` assigns the constant part of a GEP to
`kgepi->offset` but *appends* every variable index to `kgepi->indices`
without clearing it first. `bindModuleConstants()`, and through it
`computeOffsets()`, runs once per `Executor::run()`, i.e. once per
`runFunctionAsMain()` call. After *k* calls, each variable index is therefore
present *k* times, so its address contribution is multiplied by *k* (for
example, the second execution addresses `a[2*i]` instead of `a[i]`).

In practice this is hit by the ktest replay loop in `tools/klee/main.cpp`
(`--replay-ktest-dir`, or `--replay-ktest-file` given more than once): the
first replayed input is correct, while replay *k* uses *k* copies of each
variable GEP index. The result is either silently wrong values and a different
path, or a spurious `memory error: out of bound pointer` reported against the
program under test.

The fix makes offset computation idempotent by clearing `kgepi->indices` at
the start of `computeOffsets()`.

```diff
 void Executor::computeOffsets(KGEPInstruction *kgepi, TypeIt ib, TypeIt ie) {
+  kgepi->indices.clear();
   ref<ConstantExpr> constantOffset =
     ConstantExpr::alloc(0, Context::get().getPointerWidth());
```

## Notes for the reviewer

- The alternative, making `bindModuleConstants()` run only once, was
  considered and not chosen: `evalConstant()` resolves global addresses,
  which legitimately change between runs, so the constant table does need to
  be rebuilt per run. Only the *index accumulation* is wrong, so clearing is
  the minimal correct change and keeps `computeOffsets()` idempotent by
  construction, which is the property the caller already assumes.
- No behaviour change for a single `runFunctionAsMain()` call: on the first
  run `indices` is empty, so `clear()` is a no-op.
- This is a distinct bug from #1788, which fixed the null-`memory` crash on
  reuse; that crash previously stopped a second `runFunctionAsMain()` call
  before it reached any GEP, masking this defect. #1788's regression test
  (`ReplayKTestDirAfterError.c`) passes on an otherwise-unpatched tree and so
  does not cover this.

## Testing

New regression test
`test/Replay/klee-replay/ReplayKTestDirGEPIndices.c` replays one and the same
ktest twice and requires both replays to complete the same path.
It fails on unpatched `master` (`completed paths = 1`) and passes with the
patch (`completed paths = 2`).

Full `lit` suite (LLVM 16.0.4, Z3, uClibc disabled in this build):

| tree | passed | failed | unsupported | xfail |
|---|---|---|---|---|
| `master` + new test, unpatched | 353 | **1** (the new test) | 77 | 2 |
| `master` + new test, patched | **354** | **0** | 77 | 2 |

No other test changes behaviour. Reproduces and is fixed identically under
`--kdalloc=true` and `--kdalloc=false`.

## Disclaimer
This bug was found during large-scale decompiler evaluations using KLEE with different configurations.
Two complementary approaches should have witnessed the same bug for a decompiler, and upon investigations why one lane failed to spot the divergence, I assumed there was something wrong with KLEE.
Fable 5+GPT 5.6 Sol was used to investigate the bug.

## Checklist

- [x] The PR addresses a single issue.
- [x] A single commit is sufficient for this change.
- [x] There are no unnecessary commits.
- [x] The commit message documents the change.
- [x] Added messages, comments, and the commit message are spellchecked.
- [x] The code is commented where useful.
- [x] The patch follows the existing LLVM/KLEE formatting.
- [x] The change includes a regression test.
